### PR TITLE
Added capability to delete character from players._playable_characters upon object deletion

### DIFF
--- a/src/objects/models.py
+++ b/src/objects/models.py
@@ -21,7 +21,6 @@ from django.conf import settings
 from src.typeclasses.models import (TypedObject, TagHandler, NickHandler,
                                     AliasHandler, AttributeHandler)
 from src.objects.manager import ObjectManager
-from ev import managers
 from src.players.models import PlayerDB
 from src.commands.cmdsethandler import CmdSetHandler
 from src.commands import cmdhandler
@@ -724,7 +723,8 @@ class ObjectDB(TypedObject):
                 pid = int(pid[:pid.find(")")])
             except ValueError:
                 return False
-            player = managers.players.get_id(pid)
+            players = PlayerDB.objects
+            player = players.get_id(pid)
             player.db._playable_characters.remove(self)
 
         # See if we need to kick the player off.


### PR DESCRIPTION
When deleting a character object using the @del command, it will result in a error if the look command is called ooc. This can occur even in the default multisession mode if an immortal deletes a character, but not an account. 

I have incorporated a quick check in the src/object/models.py delete method to identify the player the character belongs to and delete the character from the player's playable characters list. The only way I was able to determine which player a character belonged to without looping through all the players was to check the character's puppet locks for the player id. 

My methodology seems very clumsy to me and I assume there is a better way to accomplish this. If there isn't something better already built in, it might be prudent to a PID field to character during creation to more easily identify the associated player when the character is not being puppetted.

As always, feel free to modify this or give me some pointers for a better way to accomplish this.

Thanks
