### PR TITLE
Resolution to issue #484 Web Client Removes Excess Whitespace

### DIFF
--- a/src/utils/text2html.py
+++ b/src/utils/text2html.py
@@ -76,7 +76,7 @@ class TextToHTMLparser(object):
     re_normal = re.compile(normal.replace("[", r"\["))
     re_hilite = re.compile("(?:%s)(.*)(?=%s)" % (hilite.replace("[", r"\["), fgstop))
     re_uline = re.compile("(?:%s)(.*?)(?=%s)" % (ANSI_UNDERLINE.replace("[", r"\["), fgstop))
-    re_string = re.compile(r'(?P<htmlchars>[<&>])|(?P<space>^[ \t]+)|(?P<lineend>\r\n|\r|\n)', re.S|re.M|re.I)
+    re_string = re.compile(r'(?P<htmlchars>[<&>])|(?P<space> [ \t]+)|(?P<lineend>\r\n|\r|\n)', re.S|re.M|re.I)
 
     def re_color(self, text):
         """


### PR DESCRIPTION
The regex pattern for the text2html parser had a <space>^ which indicates that it will only match the first instance of whitespace or /t in a string and ignore all remaining occurrences. There still seems to be an issue where /t will not be replaced with &nbsp; if it doesn't have a space next to it.
