### PR TITLE
Implemented .split() and .rsplit() for ANSIString.

### DIFF
--- a/src/utils/ansi.py
+++ b/src/utils/ansi.py
@@ -772,7 +772,7 @@ class ANSIString(unicode):
             if next < 0:
                 break
             # Get character codes after the index as well.
-            res.append(self[start:next])
+            res.append(self[start:next] + self._get_interleving(next))
             start = next + bylen
             maxsplit -= 1   # NB. if it's already < 0, it stays < 0
 
@@ -798,7 +798,7 @@ class ANSIString(unicode):
             if next < 0:
                 break
             # Get character codes after the index as well.
-            res.append(self[next+bylen:end])
+            res.append(self[next+bylen:end] + self._get_interleving(end))
             end = next
             maxsplit -= 1   # NB. if it's already < 0, it stays < 0
 


### PR DESCRIPTION
Found a pure Python implementation for .split() and .rsplit() in PyPy. Just took that and tweaked it for ANSIString. Come to think of it, probably would have gotten some of this coded sooner if I'd looked there first :)
