### PR TITLE
Allows sending lines without newlines (to be used with prompts)

### DIFF
--- a/src/objects/models.py
+++ b/src/objects/models.py
@@ -556,6 +556,21 @@ class ObjectDB(TypedObject):
         for session in sessions:
             session.msg(text=text, **kwargs)
 
+    def prompt(self, text=None, sessid=0):
+        """
+        Sends a prompt text to the object.
+        """
+
+        global _SESSIONS
+        if not _SESSIONS:
+            from src.server.sessionhandler import SESSIONS as _SESSIONS
+
+        text = to_str(text, force_string=True) if text else ""
+
+        sessions = _SESSIONS.session_from_sessid([sessid] if sessid else make_iter(_GA(self, "sessid").get()))
+        for session in sessions:
+            session.prompt(text=text)
+
     def msg_contents(self, message, exclude=None, from_obj=None, **kwargs):
         """
         Emits something to all objects inside an object.

--- a/src/objects/objects.py
+++ b/src/objects/objects.py
@@ -338,6 +338,16 @@ class Object(TypeClass):
 
         self.dbobj.msg(text=text, **kwargs)
 
+    def prompt(self, text=None, sessid=0):
+        """
+        Sends a prompt text to the object.
+
+        text (str): The prompt text to send
+        sessid: optional session target. If sessid=0, the session will
+                default to self.sessid or from_obj.sessid.
+        """
+        self.dbobj.prompt(text=text, sessid=sessid)
+
     def msg_contents(self, text=None, exclude=None, from_obj=None, **kwargs):
         """
         Emits something to all objects inside an object.

--- a/src/server/serversession.py
+++ b/src/server/serversession.py
@@ -260,6 +260,9 @@ class ServerSession(Session):
         "alias for at_data_out"
         self.data_out(text=text, **kwargs)
 
+    def prompt(self, text=''):
+        self.data_out(text=text, prompt=True)
+
     # Dummy API hooks for use during non-loggedin operation
 
     def at_cmdset_get(self):


### PR DESCRIPTION
By default Evennia adds a newline to every text sent through msg with no way of removing this (at least I couldn't find it...)
This adds a new function on objects:

```
def prompt(self, text=None, sessid=0) 
```

Which sends text to the player without any newline. An IAC + GA is sent instead of the newline, to tell the mud client that it can show/process the line (tintin++ uses this for instance and Mudlet too afaik)
