### PR TITLE
Allows inputting of empty lines.

### DIFF
--- a/src/server/serversession.py
+++ b/src/server/serversession.py
@@ -196,7 +196,9 @@ class ServerSession(Session):
         oob - this should hold a dictionary of oob command calls from
               the oob-supporting protocol.
         """
-        if text:
+        #explicitly check for None since text can be an empty string, which is
+        #also valid
+        if text is not None:
             # this is treated as a command input
             #text = to_unicode(escape_control_sequences(text), encoding=self.encoding)
             # handle the 'idle' command


### PR DESCRIPTION
Empty lines ("") are currently not being parsed by Evennia and the CMD_NOINPUT command handler won't run for them. Adding a space (" ") makes the command parseable by Evennia.

This pull request fixes this so that an empty string will also run the CMD_NOINPUT command.
This is an issue in for instnce the menu_login contrib: an empty lines is used to return back to the previous menu item, but that didn't work.
