### PR TITLE
Adds support for clickable links

### DIFF
--- a/contrib/menusystem.py
+++ b/contrib/menusystem.py
@@ -313,9 +313,9 @@ class MenuNode(object):
             choice = ""
             if self.keywords[ilink]:
                 if self.keywords[ilink] not in (CMD_NOMATCH, CMD_NOINPUT):
-                    choice += "{g%s{n" % self.keywords[ilink]
+                    choice += "{g{lc%s{lt%s{le{n" % (self.keywords[ilink], self.keywords[ilink])
             else:
-                choice += "{g %i{n" % (ilink + 1)
+                choice += "{g {lc%i{lt%i{le{n" % ((ilink + 1), (ilink + 1))
             if self.linktexts[ilink]:
                 choice += " - %s" % self.linktexts[ilink]
             choices.append(choice)

--- a/src/server/portal/mxp.py
+++ b/src/server/portal/mxp.py
@@ -1,0 +1,57 @@
+"""
+MXP - Mud eXtension Protocol.
+
+Partial implementation of the MXP protocol.
+The MXP protocol allows more advanced formatting options for telnet clients
+that supports it (mudlet, zmud, mushclient are a few)
+
+This only implements the SEND tag.
+
+More information can be found on the following links:
+http://www.zuggsoft.com/zmud/mxp.htm
+http://www.mushclient.com/mushclient/mxp.htm
+http://www.gammon.com.au/mushclient/addingservermxp.htm
+"""
+import re
+
+LINKS_SUB =  re.compile(r'\{lc(.*?)\{lt(.*?)\{le', re.DOTALL)
+
+MXP = "\x5B"
+MXP_TEMPSECURE = "\x1B[4z"
+MXP_SEND = MXP_TEMPSECURE + \
+           "<SEND HREF='\\1'>" + \
+           "\\2" + \
+           MXP_TEMPSECURE + \
+           "</SEND>"
+
+def mxp_parse(text):
+    """
+    Replaces links to the correct format for MXP.
+    """
+    text = LINKS_SUB.sub(MXP_SEND, text)
+    return text
+
+class Mxp(object):
+    """
+    Implements the MXP protocol.
+    """
+
+    def __init__(self, protocol):
+        """Initializes the protocol by checking if the client supports it."""
+        self.protocol = protocol
+        self.protocol.protocol_flags["MXP"] = False
+        self.protocol.will(MXP).addCallbacks(self.do_mxp, self.no_mxp)
+
+    def no_mxp(self, option):
+        """
+        Client does not support MXP.
+        """
+        self.protocol.protocol_flags["MXP"] = False
+
+    def do_mxp(self, option):
+        """
+        Client does support MXP.
+        """
+        self.protocol.protocol_flags["MXP"] = True
+        self.protocol.handshake_done()
+        self.protocol.requestNegotiation(MXP, '')


### PR DESCRIPTION
Those changes adds in support for links that can be clicked to send a command back to the server.
The links are sent like this:

```
msg("Exits: {lcgo south{ltsouth{le")
```

(lc starts for link command, lt for link text and le for link end)
This makes the links somewhat consistent with the existing Evennia formating codes. But feel free to change those to whatever :)

On the protocol side: this is implemented using MXP for telnet clients that support it and just plain html/javascript for the webclient. Other protocols will just see the link text without being able to click on them.

A working implementation of this has been added in the menu system so a menu can be used by just clicking on menu items.
