### PR TITLE
Quiet searches should still perform the corect logic and return a single...

### DIFF
--- a/src/objects/models.py
+++ b/src/objects/models.py
@@ -445,6 +445,8 @@ class ObjectDB(TypedObject):
                                                  candidates=candidates,
                                                  exact=exact)
         if quiet:
+            if len(results) == 1:
+                return results[0]
             return results
         return  _AT_SEARCH_RESULT(self, searchdata, results, global_search)
 


### PR DESCRIPTION
... onbject instance when the result is one. (just how it does on non-quiet searches)
