### PR TITLE
The inventory command should not have arguments.

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -186,6 +186,7 @@ class CmdInventory(MuxCommand):
     key = "inventory"
     aliases = ["inv", "i"]
     locks = "cmd:all()"
+    arg_regex = r"$"
 
     def func(self):
         "check inventory"


### PR DESCRIPTION
This makes it so that iguana does not match this command.