### PR TITLE
Fixed admin creation of objects. Removed 'code zombies'.

### DIFF
--- a/src/objects/admin.py
+++ b/src/objects/admin.py
@@ -6,6 +6,7 @@
 from django import forms
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin.utils import flatten_fieldsets
 from src.typeclasses.admin import AttributeInline, TagInline
 from src.objects.models import ObjectDB
 
@@ -62,7 +63,6 @@ class ObjectDBAdmin(admin.ModelAdmin):
     save_on_top = True
     list_select_related = True
     list_filter = ('db_typeclass_path',)
-    #list_filter = ('db_permissions', 'db_typeclass_path')
 
     # editing fields setup
 
@@ -73,16 +73,7 @@ class ObjectDBAdmin(admin.ModelAdmin):
                            ('db_location', 'db_home'), 'db_destination','db_cmdset_storage'
                            )}),
         )
-    #fieldsets = (
-    #    (None, {
-    #            'fields': (('db_key','db_typeclass_path'), ('db_permissions', 'db_lock_storage'),
-    #                       ('db_location', 'db_home'), 'db_destination','db_cmdset_storage'
-    #                       )}),
-    #    )
 
-    #deactivated temporarily, they cause empty objects to be created in admin
-
-    # Custom modification to give two different forms wether adding or not.
     add_form = ObjectCreateForm
     add_fieldsets = (
         (None, {
@@ -91,12 +82,6 @@ class ObjectDBAdmin(admin.ModelAdmin):
                            )}),
         )
 
-    #add_fieldsets = (
-    #    (None, {
-    #            'fields': (('db_key','db_typeclass_path'), 'db_permissions',
-    #                       ('db_location', 'db_home'), 'db_destination', 'db_cmdset_storage'
-    #                       )}),
-    #    )
     def get_fieldsets(self, request, obj=None):
         if not obj:
             return self.add_fieldsets
@@ -109,9 +94,9 @@ class ObjectDBAdmin(admin.ModelAdmin):
         defaults = {}
         if obj is None:
             defaults.update({
-                    'form': self.add_form,
-                    'fields': admin.util.flatten_fieldsets(self.add_fieldsets),
-                    })
+                'form': self.add_form,
+                'fields': flatten_fieldsets(self.add_fieldsets),
+            })
             defaults.update(kwargs)
         return super(ObjectDBAdmin, self).get_form(request, obj, **defaults)
 


### PR DESCRIPTION
Admin module's `util` module renamed `utils`. Fixed this, and removed a bunch of old comments that don't appear to apply anymore.

Resolves #668 