### PR TITLE
TYPO IN COMMENTS of CMD @copy

### DIFF
--- a/src/commands/default/building.py
+++ b/src/commands/default/building.py
@@ -189,7 +189,7 @@ class CmdCopy(ObjManipCommand):
               since it was first created.
 
     Create one or more copies of an object. If you don't supply any targets,
-    one exact copt of the original object will be created with the name *_copy.
+    one exact copy of the original object will be created with the name *_copy.
     """
 
     key = "@copy"


### PR DESCRIPTION
TYPO IN COMMENTS: file "/src/commands/default/building.py"

one exact copt of the original
    ....copT = copY...
copy of the ....