### PR TITLE
TYPO IN COMMENTS: @batchprocess => @batchcommand

### DIFF
--- a/contrib/tutorial_world/build.ev
+++ b/contrib/tutorial_world/build.ev
@@ -16,7 +16,7 @@
 # To load this file, place yourself in Limbo (room #2) and load the
 # file as user #1 with
 #
-#     @batchprocess contrib.tutorial_world.build
+#     @batchcommand contrib.tutorial_world.build
 #
 # If you give the /interactive switch you can step through the
 # build process command for command.


### PR DESCRIPTION
Hi Griatch, this was the typo I mentioned the other day about the tutorial's comments. Only I gave you the wrong reference (the README file) but it was in the "build.ev" file! When I first used I got confused because when I tried the command it didn't exist!