### PR TITLE
Multisession fixes

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -100,7 +100,7 @@ def _msg_err(receiver, string):
         string (str): string with a {traceback} format marker inside it.
 
     """
-    receiver.msg(string.format(traceback=format_exc()))
+    receiver.msg(string.format(traceback=format_exc(), _nomulti=True))
 
 
 # custom Exceptions
@@ -411,15 +411,18 @@ def cmdhandler(called_by, raw_string, _testing=False, callertype="session", sess
     elif callertype == "player":
         player = called_by
         if sessid:
+            session = player.get_session(sessid)
             obj = yield player.get_puppet(sessid)
     elif callertype == "object":
         obj = called_by
     else:
         raise RuntimeError("cmdhandler: callertype %s is not valid." % callertype)
-
     # the caller will be the one to receive messages and excert its permissions.
     # we assign the caller with preference 'bottom up'
     caller = obj or player or session
+    # The error_to is the default recipient for errors. Tries to make sure a player
+    # does not get spammed for errors while preserving character mirroring.
+    error_to = obj or session or player
 
     try:  # catch bugs in cmdhandler itself
         try:  # catch special-type commands
@@ -470,7 +473,7 @@ def cmdhandler(called_by, raw_string, _testing=False, callertype="session", sess
                 # No commands match our entered command
                 syscmd = yield cmdset.get(CMD_NOMATCH)
                 if syscmd:
-                    # use custom CMD_NOMATH command
+                    # use custom CMD_NOMATCH command
                     sysarg = raw_string
                 else:
                     # fallback to default error text
@@ -516,19 +519,19 @@ def cmdhandler(called_by, raw_string, _testing=False, callertype="session", sess
                 returnValue(ret)
             elif sysarg:
                 # return system arg
-                caller.msg(exc.sysarg)
+                error_to.msg(exc.sysarg, _nomulti=True)
 
         except NoCmdSets:
             # Critical error.
             logger.log_errmsg("No cmdsets found: %s" % caller)
-            caller.msg(_ERROR_NOCMDSETS)
+            error_to.msg(_ERROR_NOCMDSETS, _nomulti=True)
 
         except Exception:
             # We should not end up here. If we do, it's a programming bug.
             logger.log_trace()
-            _msg_err(caller, _ERROR_UNTRAPPED)
+            _msg_err(error_to, _ERROR_UNTRAPPED)
 
     except Exception:
         # This catches exceptions in cmdhandler exceptions themselves
         logger.log_trace()
-        _msg_err(caller, _ERROR_CMDHANDLER)
+        _msg_err(error_to, _ERROR_CMDHANDLER)

--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -513,6 +513,7 @@ class CmdQuit(MuxPlayerCommand):
     game. Use the /all switch to disconnect from all sessions.
     """
     key = "@quit"
+    aliases = "quit"
     locks = "cmd:all()"
 
     def func(self):

--- a/evennia/commands/default/syscommands.py
+++ b/evennia/commands/default/syscommands.py
@@ -61,7 +61,7 @@ class SystemNoMatch(MuxCommand):
         """
         This is given the failed raw string as input.
         """
-        self.caller.msg("Huh?")
+        self.msg("Huh?")
 
 
 #
@@ -124,7 +124,7 @@ class SystemMultimatch(MuxCommand):
         all the clashing matches.
         """
         string = self.format_multimatches(self.caller, self.matches)
-        self.caller.msg(string)
+        self.msg(string)
 
 
 # Command called when the command given at the command line

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -171,9 +171,10 @@ class TestPlayer(CommandTest):
             self.call(player.CmdOOCLook(), "", "Account TestPlayer (you are OutofCharacter)", caller=self.player)
 
     def test_ooc(self):
-        self.call(player.CmdOOC(), "", "You are already", caller=self.player)
+        self.call(player.CmdOOC(), "", "You go OOC.", caller=self.player)
 
     def test_ic(self):
+        self.player.unpuppet_object(self.session.sessid)
         self.call(player.CmdIC(), "Char", "You become Char.", caller=self.player, receiver=self.char1)
 
     def test_password(self):
@@ -198,7 +199,6 @@ class TestPlayer(CommandTest):
         self.call(player.CmdCharCreate(), "Test1=Test char", "Created new character Test1. Use @ic Test1 to enter the game", caller=self.player)
 
     def test_quell(self):
-        self.call(player.CmdIC(), "Char", "You become Char.", caller=self.player, receiver=self.char1)
         self.call(player.CmdQuell(), "", "Quelling to current puppet's permissions (immortals).", caller=self.player)
 
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -528,6 +528,7 @@ class DefaultObject(ObjectDB):
             log_trace()
 
         # session relay
+        kwargs['_nomulti'] = kwargs.get('_nomulti', True)
 
         if self.player:
             # for there to be a session there must be a Player.
@@ -537,13 +538,11 @@ class DefaultObject(ObjectDB):
                 if sessions:
                     # this is a special instruction to ignore MULTISESSION_MODE
                     # and only relay to this given session.
-                    kwargs["_nomulti"] = True
                     for session in make_iter(sessions):
                         session.msg(text=text, **kwargs)
                     return
-            # we only send to the first of any connected sessions - the sessionhandler
-            # will disperse this to the other sessions based on MULTISESSION_MODE.
-            sessions = self.player.get_all_sessions()
+            # Send to all sessions connected to this object
+            sessions = [self.player.get_session(sessid) for sessid in self.sessid.get()]
             if sessions:
                 sessions[0].msg(text=text, **kwargs)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -533,18 +533,12 @@ class DefaultObject(ObjectDB):
         if self.player:
             # for there to be a session there must be a Player.
             if sessid:
-                # this could still be an iterable if sessid is.
-                sessions = self.player.get_session(sessid)
-                if sessions:
-                    # this is a special instruction to ignore MULTISESSION_MODE
-                    # and only relay to this given session.
-                    for session in make_iter(sessions):
-                        session.msg(text=text, **kwargs)
-                    return
-            # Send to all sessions connected to this object
-            sessions = [self.player.get_session(sessid) for sessid in self.sessid.get()]
+                sessions = make_iter(self.player.get_session(sessid))
+            else:
+                # Send to all sessions connected to this object
+                sessions = [self.player.get_session(sessid) for sessid in self.sessid.get()]
             if sessions:
-                sessions[0].msg(text=text, **kwargs)
+                sessions[0].msg(text=text, session=sessions, **kwargs)
 
     def msg_contents(self, message, exclude=None, from_obj=None, **kwargs):
         """

--- a/evennia/players/players.py
+++ b/evennia/players/players.py
@@ -231,22 +231,21 @@ class DefaultPlayer(PlayerDB):
         # re-cache locks to make sure superuser bypass is updated
         obj.locks.cache_lock_bypass(obj)
 
-    def unpuppet_object(self, sessid):
+    def unpuppet_object(self, sessid, ignore_empty=False):
         """
         Disengage control over an object
 
         Args:
             sessid(int): the session id to disengage
+            ignore_empty(bool): ignores sessions without puppets
 
         Raises:
             RuntimeError with message about error.
         """
         if _MULTISESSION_MODE == 1:
             sessions = self.get_all_sessions()
-            ignore_empty = True
         else:
             sessions = self.get_session(sessid)
-            ignore_empty = False
         if not sessions:
             raise RuntimeError("No session was found.")
         for session in make_iter(sessions):
@@ -270,7 +269,7 @@ class DefaultPlayer(PlayerDB):
         before a reset/shutdown.
         """
         for session in self.get_all_sessions():
-            self.unpuppet_object(session.sessid)
+            self.unpuppet_object(session.sessid, ignore_empty=True)
 
     def get_puppet(self, sessid, return_dbobj=False):
         """

--- a/evennia/players/players.py
+++ b/evennia/players/players.py
@@ -231,7 +231,6 @@ class DefaultPlayer(PlayerDB):
         # re-cache locks to make sure superuser bypass is updated
         obj.locks.cache_lock_bypass(obj)
 
-
     def unpuppet_object(self, sessid):
         """
         Disengage control over an object

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -10,7 +10,6 @@ are stored on the Portal side)
 import time
 from datetime import datetime
 from django.conf import settings
-#from evennia.scripts.models import ScriptDB
 from evennia.comms.models import ChannelDB
 from evennia.utils import logger
 from evennia.utils.inlinefunc import parse_inlinefunc

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -110,7 +110,7 @@ class ServerSession(Session):
         if self.logged_in:
             sessid = self.sessid
             player = self.player
-            player.unpuppet_object(sessid)
+            player.unpuppet_object(sessid, ignore_empty=True)
             uaccount = player
             uaccount.last_login = datetime.now()
             uaccount.save()

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -222,7 +222,9 @@ class ServerSession(Session):
         text = text if text else ""
         if INLINEFUNC_ENABLED and not "raw" in kwargs:
             text = parse_inlinefunc(text, strip="strip_inlinefunc" in kwargs, session=self)
-        self.sessionhandler.data_out(self, text=text, **kwargs)
+        session = kwargs.pop('session', None)
+        session = session or self
+        self.sessionhandler.data_out(session, text=text, **kwargs)
     # alias
     msg = data_out
 

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -456,7 +456,8 @@ class ServerSessionHandler(SessionHandler):
 
         """
         sessions = make_iter(session)
-        text = text and to_str(to_unicode(text), encoding=sessions[0].encoding)
+        session = sessions[0]
+        text = text and to_str(to_unicode(text), encoding=session.encoding)
         multi = not kwargs.pop("_nomulti", None)
         forced_nomulti = kwargs.pop("_forced_nomulti", None)
         # Mode 1 mirrors to all.

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -16,7 +16,8 @@ import time
 from django.conf import settings
 from evennia.commands.cmdhandler import CMD_LOGINSTART
 from evennia.utils.utils import variable_from_module, is_iter, \
-                            to_str, to_unicode, strip_control_sequences
+                            to_str, to_unicode, strip_control_sequences, make_iter
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -454,10 +455,10 @@ class ServerSessionHandler(SessionHandler):
                 Useful for connection handling messages.
 
         """
-        text = text and to_str(to_unicode(text), encoding=session.encoding)
+        sessions = make_iter(session)
+        text = text and to_str(to_unicode(text), encoding=sessions[0].encoding)
         multi = not kwargs.pop("_nomulti", None)
         forced_nomulti = kwargs.pop("_forced_nomulti", None)
-        sessions = [session]
         # Mode 1 mirrors to all.
         if _MULTISESSION_MODE == 1:
             multi = True

--- a/evennia/utils/test_resources.py
+++ b/evennia/utils/test_resources.py
@@ -40,7 +40,9 @@ class EvenniaTest(TestCase):
         self.char1.permissions.add("Immortals")
         self.char2 = create.create_object(self.character_typeclass, key="Char2", location=self.room1, home=self.room1)
         self.char1.player = self.player
+        self.player.db._last_puppet = self.char1
         self.char2.player = self.player2
+        self.player2.db._last_puppet = self.char2
         self.script = create.create_script(self.script_typeclass, key="Script")
         self.player.permissions.add("Immortals")
 


### PR DESCRIPTION
Fixes multisession modes to work as advertised.

@Griatch , please take note of a few behavioral changes this introduces. The primary one is that, by default, characters get their messages mirrored between sessions, but players do not, unless a message is intended to go to all sessions a player has. I'm not sure if that was the default before, because it's been eons since I used the multisession modes. But, for instance, one doesn't get 'command not found' error messages in every session if an OOC session makes an error.

Additionally, this adds an alias to `@quit`, `quit`, so that the same command works when unlogged in or logged in.

Resolves #673