### PR TITLE
TYPOS IN CODE COMMENTS

### DIFF
--- a/evennia/server/amp.py
+++ b/evennia/server/amp.py
@@ -38,7 +38,7 @@ SDISCONN = chr(5)     # server session disconnect
 SDISCONNALL = chr(6)  # server session disconnect all
 SSHUTD = chr(7)       # server shutdown
 SSYNC = chr(8)        # server session sync
-SCONN = chr(9)        # server creating new connectiong (for irc/imc2 bots etc)
+SCONN = chr(9)        # server creating new connection (for irc/imc2 bots etc)
 PCONNSYNC = chr(10)   # portal post-syncing a session
 
 MAXLEN = 65535  # max allowed data length in AMP protocol

--- a/evennia/server/models.py
+++ b/evennia/server/models.py
@@ -40,7 +40,7 @@ class ServerConfig(WeakSharedMemoryModel):
     #
     #
     # These database fields are all set using their corresponding properties,
-    # named same as the field, but withtout the db_* prefix.
+    # named same as the field, but without the db_* prefix.
 
     # main name of the database entry
     db_key = models.CharField(max_length=64, unique=True)

--- a/evennia/server/oob_cmds.py
+++ b/evennia/server/oob_cmds.py
@@ -221,7 +221,7 @@ def oob_report(session, *args, **kwargs):
     """
     Called with the `REPORT PROPNAME` MSDP command.
     Monitors the changes of given property name. Assumes reporting
-    happens on an objcet controlled by the session.
+    happens on an object controlled by the session.
 
     Args:
         session (Session): The Session doing the monitoring. The

--- a/evennia/server/oob_cmds.py
+++ b/evennia/server/oob_cmds.py
@@ -45,7 +45,7 @@ Data is usually returned to the user via a return OOB call:
 Oobcmdnames (like "MSDP.LISTEN" / "LISTEN" above) are case-sensitive.
 Note that args, kwargs must be iterable. Non-iterables will be
 interpreted as a new command name (you can send multiple oob commands
-with one msg() call))
+with one msg() call)
 
 Evennia introduces two internal extensions to MSDP, and that is the
 MSDP_ARRAY and MSDP_TABLE commands. These are never sent across the

--- a/evennia/server/webserver.py
+++ b/evennia/server/webserver.py
@@ -87,8 +87,8 @@ class EvenniaReverseProxyResource(ReverseProxyResource):
 class DjangoWebRoot(resource.Resource):
     """
     This creates a web root (/) that Django
-    understands by tweaking the way the
-    child instancee are recognized.
+    understands by tweaking the way
+    child instancee ars recognized.
     """
     def __init__(self, pool):
         """

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -1113,7 +1113,7 @@ def format_table(table, extra_space=1):
 
 def get_evennia_pids():
     """
-    Get the currently valids PIDs (Process IDs) of the Portal and Server
+    Get the currently valid PIDs (Process IDs) of the Portal and Server
     by trying to access an PID file. This can be used to determine if we
     are in a subprocess by something like
 

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -1006,7 +1006,7 @@ def string_similarity(string1, string2):
 
 def string_suggestions(string, vocabulary, cutoff=0.6, maxnum=3):
     """
-    Given a string and a vocabulary, return a match or a list of suggestsion
+    Given a string and a vocabulary, return a match or a list of suggestions
     based on string similarity.
 
     Args:


### PR DESCRIPTION
While reading through code comments I came across a few minor typos. Corrected them on the spot ... just in case I won't be reading them again...