### PR TITLE
Added m_len and made ANSIString ignore MXP.

### DIFF
--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -618,7 +618,7 @@ class ANSIString(unicode):
         code_indexes.extend(
             cls._shifter(second._code_indexes, len(first._raw_string)))
         char_indexes.extend(
-            cls._shifter(second._code_indexes, len(first._raw_string)))
+            cls._shifter(second._char_indexes, len(first._raw_string)))
         return ANSIString(raw_string, code_indexes=code_indexes,
                           char_indexes=char_indexes,
                           clean_string=clean_string)
@@ -660,7 +660,7 @@ class ANSIString(unicode):
         a start and end with [x:y], but many forget that they can also specify
         an interval with [x:y:z]. As a result, not only do we have to track
         the ANSI Escapes that have played before the start of the slice, we
-        must also replay any in these intervals, should the exist.
+        must also replay any in these intervals, should they exist.
 
         Thankfully, slicing the _char_indexes table gives us the actual
         indexes that need slicing in the raw string. We can check between

--- a/evennia/utils/tests.py
+++ b/evennia/utils/tests.py
@@ -135,6 +135,21 @@ class ANSIStringTestCase(TestCase):
         self.assertEqual(mxp1, ANSIString(mxp1))
         self.assertEqual(mxp2, unicode(ANSIString(mxp2)))
 
+    def test_add(self):
+        """
+        Verify concatination works correctly.
+        """
+        a = ANSIString("{gTest")
+        b = ANSIString("{cString{n")
+        c = a + b
+        result = u'\x1b[1m\x1b[32mTest\x1b[1m\x1b[36mString\x1b[0m'
+        self.checker(c, result, u'TestString')
+        char_table = [9, 10, 11, 12, 22, 23, 24, 25, 26, 27]
+        code_table = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 13, 14, 15, 16, 17, 18, 19, 20, 21, 28, 29, 30, 31
+        ]
+        self.table_check(c, char_table, code_table)
+
 
 class TestIsIter(TestCase):
     def test_is_iter(self):

--- a/evennia/utils/tests.py
+++ b/evennia/utils/tests.py
@@ -5,8 +5,8 @@ try:
 except ImportError:
     from django.test import TestCase
 
-from ansi import ANSIString
-import utils
+from .ansi import ANSIString
+from evennia import utils
 
 
 class ANSIStringTestCase(TestCase):
@@ -121,6 +121,20 @@ class ANSIStringTestCase(TestCase):
         result = u'\x1b[1m\x1b[32mTest\x1b[0m'
         self.checker(target.capitalize(), result, u'Test')
 
+    def test_mxp_agnostic(self):
+        """
+        Make sure MXP tags are not treated like ANSI codes, but normal text.
+        """
+        mxp1 = "{lclook{ltat{le"
+        mxp2 = "Start to {lclook here{ltclick somewhere here{le first"
+        self.assertEqual(15, len(ANSIString(mxp1)))
+        self.assertEqual(53, len(ANSIString(mxp2)))
+        # These would indicate an issue with the tables.
+        self.assertEqual(len(ANSIString(mxp1)), len(ANSIString(mxp1).split("\n")[0]))
+        self.assertEqual(len(ANSIString(mxp2)), len(ANSIString(mxp2).split("\n")[0]))
+        self.assertEqual(mxp1, ANSIString(mxp1))
+        self.assertEqual(mxp2, unicode(ANSIString(mxp2)))
+
 
 class TestIsIter(TestCase):
     def test_is_iter(self):
@@ -177,3 +191,26 @@ class TestListToString(TestCase):
         self.assertEqual('1, 2 and 3', utils.list_to_string([1,2,3]))
         self.assertEqual('"1", "2" and "3"', utils.list_to_string([1,2,3], endsep="and", addquote=True))
 
+
+class TestMLen(TestCase):
+    """
+    Verifies that m_len behaves like len in all situations except those
+    where MXP may be involved.
+    """
+    def test_non_mxp_string(self):
+        self.assertEqual(utils.m_len('Test_string'), 11)
+
+    def test_mxp_string(self):
+        self.assertEqual(utils.m_len('{lclook{ltat{le'), 2)
+
+    def test_mxp_ansi_string(self):
+        self.assertEqual(utils.m_len(ANSIString('{lcl{gook{ltat{le{n')), 2)
+
+    def test_non_mxp_ansi_string(self):
+        self.assertEqual(utils.m_len(ANSIString('{gHello{n')), 5)
+
+    def test_list(self):
+        self.assertEqual(utils.m_len([None, None]), 2)
+
+    def test_dict(self):
+        self.assertEqual(utils.m_len({'hello': True, 'Goodbye': False}), 2)

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -1245,3 +1245,13 @@ def calledby(callerdepth=1):
     return "[called by '%s': %s:%s %s]" % (frame[3], path, frame[2], frame[4])
 
 
+def m_len(target):
+    """
+    Provides length checking for strings with MXP patterns, and falls
+    back to normal len for other objects.
+    """
+    # Would create circular import if in module root.
+    from evennia.utils.ansi import ANSI_PARSER
+    if inherits_from(target, basestring):
+        return len(ANSI_PARSER.strip_mxp(target))
+    return len(target)


### PR DESCRIPTION
As discussed earlier, this change makes ANSIString essentially ignore MXP, and creates the m_len function.

It also tweaks parse_ansi slightly to not add state changes to the parser object during the function, since the object has a lot of shared references via ANSIString.