### PR TITLE
(WIP) Collab

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -198,11 +198,21 @@ class CmdCopy(ObjManipCommand):
     locks = "cmd:perm(copy) or perm(Builders)"
     help_category = "Building"
 
+    def check_target_location(self, target_location):
+        """
+        Check from object to make sure that it is alright to copy.
+
+        Used for overriding in subclassed commands, and is responsible for displaying
+        its own error messages.
+        """
+        return True
+
     def func(self):
         "Uses ObjManipCommand.parse()"
 
         caller = self.caller
         args = self.args
+        self.copied_obj = None
         if not args:
             caller.msg("Usage: @copy <obj> [=new_name[;alias;alias..]][:new_location] [, new_name2...]")
             return
@@ -215,9 +225,9 @@ class CmdCopy(ObjManipCommand):
                 return
             to_obj_name = "%s_copy" % from_obj_name
             to_obj_aliases = ["%s_copy" % alias for alias in from_obj.aliases.all()]
-            copiedobj = ObjectDB.objects.copy_object(from_obj, new_key=to_obj_name,
-                                                     new_aliases=to_obj_aliases)
-            if copiedobj:
+            self.copied_obj = ObjectDB.objects.copy_object(from_obj, new_key=to_obj_name,
+                                                           new_aliases=to_obj_aliases)
+            if self.copied_obj:
                 string = "Identical copy of %s, named '%s' was created." % (from_obj_name, to_obj_name)
             else:
                 string = "There was an error copying %s."
@@ -235,14 +245,14 @@ class CmdCopy(ObjManipCommand):
                 if to_obj_location:
                     to_obj_location = caller.search(to_obj_location,
                                                     global_search=True)
-                    if not to_obj_location:
+                    if not to_obj_location or not self.check_target_location(to_obj_location):
                         return
 
-                copiedobj = ObjectDB.objects.copy_object(from_obj,
-                                                        new_key=to_obj_name,
-                                                        new_location=to_obj_location,
-                                                        new_aliases=to_obj_aliases)
-                if copiedobj:
+                self.copied_obj = ObjectDB.objects.copy_object(from_obj,
+                                                               new_key=to_obj_name,
+                                                               new_location=to_obj_location,
+                                                               new_aliases=to_obj_aliases)
+                if self.copied_obj:
                     string = "Copied %s to '%s' (aliases: %s)." % (from_obj_name, to_obj_name,
                                                                    to_obj_aliases)
                 else:

--- a/evennia/contrib/collab/collab_settings.py
+++ b/evennia/contrib/collab/collab_settings.py
@@ -1,0 +1,83 @@
+# To enable collaborative building in your game, add this line to your settings.py file:
+#
+# from evennia.contrib.collab.collab_settings import *
+#
+# ...After the line:
+#
+# from evennia.settings_default import *
+#
+
+# First, we need to overwrite some base typeclasses so objects become collab-aware.
+# If you have any custom typeclasses already made, you should change their parent classes
+# to line up with these.
+BASE_PLAYER_TYPECLASS = 'evennia.contrib.collab.typeclasses.CollabPlayer'
+BASE_OBJECT_TYPECLASS = 'evennia.contrib.collab.typeclasses.CollabObject'
+BASE_CHARACTER_TYPECLASS = 'evennia.contrib.collab.typeclasses.CollabCharacter'
+BASE_ROOM_TYPECLASS = 'evennia.contrib.collab.typeclasses.CollabRoom'
+BASE_EXIT_TYPECLASS = 'evennia.contrib.collab.typeclasses.CollabExit'
+
+# The default permission given to all new players
+PERMISSION_PLAYER_DEFAULT = "Builders"
+
+# The types of objects that can be created with the @create command.
+# @create/room would create a room with the specified typeclass.
+# This dictionary also holds important configuration points like what
+# Types are available for creation and what limits are set on their creation.
+COLLAB_TYPES = {
+    'object': {'typeclass': 'evennia.contrib.collab.typeclasses.CollabObject',
+               'quota': 30, 'create_lock': '_:perm(builders)'},
+    'room': {'typeclass': 'evennia.contrib.collab.typeclasses.CollabRoom',
+             'quota': 30, 'create_lock': '_:perm(builders)'},
+    'exit': {'typeclass': 'evennia.contrib.collab.typeclasses.CollabExit',
+             'quota': 100, 'create_lock': '_:perm(builders)'}}
+
+# If overriding the above in your own settings file, rerun this in there.
+# It does a reverse map to look up object types by typeclass path.
+COLLAB_REVERSE_TYPES = {
+    value['typeclass']: key for key, value in COLLAB_TYPES.items()
+}
+
+# Used by @dig to pick from CREATE_TYPES
+COLLAB_ROOM_TYPE = 'room'
+# Used by @open to pick from CREATE_TYPES
+COLLAB_EXIT_TYPE = 'exit'
+# What to create if no type is specified.
+COLLAB_DEFAULT_TYPE = 'object'
+# If set false, users will be able to build as much as they please.
+COLLAB_QUOTAS_ENABLED = True
+# Set this to the permission level at which quotas are ignored.
+COLLAB_QUOTA_BYPASS_LOCK = '_:pperm(Wizards)'
+
+# Spec out which scripts are available to who.
+COLLAB_SCRIPT_TYPES = {
+    # 'example': {'typeclass': 'path.to.typeclass.ClassName',
+    #             'create_lock': '_:perm(builders)'},
+}
+
+# Used for global permissions masking on properties that match certain
+# patterns. Useful for making certain attributes invisible or uneditable.
+# Patterns are specified via regex.
+COLLAB_PROPTYPE_PERMS = {
+    # Server admin only info. User emails, IP addresses.
+    'imh': 'write:perm(Immortals);read:perm(Immortals)',
+    # Wizard info. Special settings that affect the environment but
+    # should not be shared with the player.
+    'wizh': 'write:perm(Wizards);read:perm(Wizards)',
+    # Wizard editable info reviewable by users. Also used by commands
+    # which need to ensure their data is not accidentally overwritten.
+    'wiz': 'write:perm(Wizards);read:controls()',
+    # Stuff that anyone's script can fiddle with. Not to
+    # be trusted.
+    'pub': 'write:all();read:all()',
+    # Stuff the user sets, but is public to read. Default for @set.
+    'usr': 'write:controls();read:all()',
+    # Stuff the user sets, but is not public to read.
+    'usrh': 'write:controls();read:controls()',
+    # Default attributes, like stuff on .db. Used for compatibility
+    # with non-collab aware code.
+    '': 'write:perm(Wizards);read:perm(Wizards)'
+}
+
+# This lock, if passed, allows a user to act as if they have control over an
+# object when they otherwise wouldn't.
+COLLAB_OVERRIDE_PERM_LOCK = '_:pperm(wizards)'

--- a/evennia/contrib/collab/commands.py
+++ b/evennia/contrib/collab/commands.py
@@ -1,0 +1,894 @@
+import evennia
+
+from django.conf import settings
+from evennia.contrib.collab.perms import (
+    quota_check, collab_check, PermissionsError, 
+    is_owner, set_owner, attr_check, get_owner, prefix_check, get_handler)
+from evennia.commands.cmdhandler import get_and_merge_cmdsets
+from evennia.commands.default.muxcommand import MuxCommand
+from evennia.commands.default.building import (
+    CmdSetObjAlias, CmdListCmdSets, CmdName, CmdLock, CmdSetAttribute, CmdCpAttr, CmdMvAttr, CmdCopy
+)
+from evennia.utils import utils, lazy_property
+from evennia.utils.ansi import ANSIString as A
+from evennia.utils.eveditor import EvEditor
+from evennia.utils.utils import inherits_from
+
+
+# Reminder of some of the things in the default Build commands. Removing ones
+# that don't matter or we've already implemented as we go.
+# __all__ = (
+#           "CmdTunnel",
+#           "CmdTypeclass", "CmdWipe",
+#           "CmdExamine", "CmdFind", "CmdTeleport",
+#           "CmdScript", "CmdTag", "CmdSpawn")
+
+def pre_collab(command, syntax_err, perm_err, locks=None, call_super=True, extra_check=None):
+    """
+    Used for commands that affect an object. Can optionally call the super if
+    this is the only difference that needs to be handled.
+
+    If extra_check is provided, will run that as a final check on the object before
+    the super is called (if it is to be called)
+    """
+    if not command.lhs:
+        command.msg("{r%s{n" % syntax_err)
+        return False
+    obj = command.caller.search(command.lhs)
+    if not obj:
+        return False
+    if not collab_check(command.caller, obj, locks=locks):
+        command.msg("{r%s{n" % perm_err)
+        return False
+    if extra_check:
+        if not extra_check(obj):
+            return False
+    if call_super:
+        super(command.__class__, command).func()
+    return True
+
+
+class BaseCreationCommand(MuxCommand):
+    """
+    Creates objects of different typeclasses as specified in the settings.
+    """
+    locks = "cmd:perm(create) or perm(builders)"
+    help_category = "Building"
+    not_permitted = []
+
+    def pre_load(self):
+        """
+        Used for typeclass-frontloaded commands like @dig.
+        """
+
+    def get_location(self):
+        """
+        Used to determine what object will be placed in the object's
+        destination field upon creation.
+        """
+        if not self.caller.location:
+            if hasattr(self.caller, 'player'):
+                return self.caller
+            else:
+                raise ValueError(
+                    "{rYou aren't anywhere. Where would you put it?{n")
+        return self.caller.location
+
+    def get_home(self):
+        """
+        Return the home for the new object.
+        """
+        return self.get_location()
+
+    def get_destination(self):
+        """
+        Return the destination for the new object.
+        """
+        if not self.rhs:
+            return None
+        destination = self.caller.search(self.rhs)
+        if not destination:
+            raise ValueError
+        return destination
+
+    def get_key_and_aliases(self):
+        """
+        Return both the name for the object and any aliases it should have.
+        """
+        if not self.lhs:
+            raise ValueError("{rYou must specify a name.{n")
+        aliases = [A(name.strip()).clean() for name in self.lhs.split(';')]
+        key = aliases.pop(0)
+        return key, aliases
+
+    def func(self):
+        self.pre_load()
+        try:
+            self.create_type = self.switches[0]
+        except IndexError:
+            self.create_type = settings.COLLAB_DEFAULT_TYPE
+
+        # This should only matter if pre_load is not used.
+        if self.create_type in self.not_permitted:
+            self.msg("{rType '%s' cannot be created with this"
+                            " command.{n" % self.create_type)
+            return
+        lock = self.caller.locks.check_lockstring(
+            self.caller,
+            settings.COLLAB_TYPES[self.create_type]['create_lock'])
+        if not lock:
+            self.msg("{rYou don't have permission to create "
+                            "objects of type '%s'.{n" % self.create_type)
+            return
+        if self.create_type not in settings.COLLAB_TYPES:
+            self.msg("{rType '%s' is not recognized.{n"
+                            % self.create_type)
+            return
+        self.player = getattr(self.caller, 'player', self.caller)
+        if not quota_check(self.player, self.create_type):
+            self.msg("{rYou have already met your quota for type '%s'.{n"
+                     % self.create_type)
+            return
+        thing = self.create_object()
+        if thing is None:
+            return
+        self.caller.db.last_created = thing
+        self.post_creation(thing)
+        self.success_message(thing)
+
+    def success_message(self, thing):
+        """
+        This is liable to change depending on what we're actually creating to
+        be more semantically useful.
+        """
+        self.msg("{gObject '%s' of type '%s' created with DBref #%s.{n" % (
+            thing.name, self.create_type, thing.id))
+
+    def post_creation(self, thing):
+        """
+        Perform any post-creation actions that should be done, like setting the
+        owner.
+        """
+        set_owner(self.caller, thing)
+
+    def perm_check(self, key, destination, location):
+        """
+        Verify that the user has permission to create an object with these
+        parameters. Raise an exception if not.
+        """
+        if destination:
+            if not collab_check(self.caller, destination, locks=['link_to']):
+                raise PermissionsError(
+                    "{rYou don't have permission to link to '%s'.{n"
+                    % destination)
+        if location:
+            if not collab_check(self.caller, location, locks=['create_in']):
+                raise PermissionsError(
+                    "{rYou can't create something in '%s'.{n" % location.name)
+
+    def create_object(self):
+        """
+        Perform the actual creation of the object, after some validation.
+        """
+        typeclass = settings.COLLAB_TYPES[self.create_type]['typeclass']
+        try:
+            key, aliases = self.get_key_and_aliases()
+        except ValueError as err:
+            self.msg(str(err))
+            return
+        try:
+            destination = self.get_destination()
+        except ValueError as err:
+            self.msg(str(err))
+            return
+        try:
+            location = self.get_location()
+        except ValueError as err:
+            self.msg(str(err))
+            return
+        try:
+            self.perm_check(key, destination, location)
+        except PermissionsError as err:
+            self.msg(str(err))
+
+        return evennia.create_object(key=key, aliases=aliases, location=location,
+                                     destination=destination, typeclass=typeclass)
+
+
+class CmdCreate(BaseCreationCommand):
+    """
+    Create an object.
+
+    Usage:
+        @create object name;object alias 1;alias2
+    """
+    key = '@create'
+
+    @lazy_property
+    def not_permitted(self):
+        return [settings.COLLAB_EXIT_TYPE, settings.COLLAB_ROOM_TYPE]
+
+    def get_location(self):
+        if hasattr(self.caller, 'player'):
+            return self.caller
+        return super(CmdCreate, self).get_location()
+
+
+class CmdDig(BaseCreationCommand):
+    """
+    Create a new room.
+
+    Usage:
+        @dig room name;room alias 1;room alias 2
+    """
+    key = '@dig'
+    help_category = "Building"
+
+    def get_location(self):
+        return None
+
+    def pre_load(self):
+        self.switches.insert(0, settings.COLLAB_ROOM_TYPE)
+
+    def success_message(self, thing):
+        self.msg("{gRoom '%s' created with DBREF #%s. "
+                 "Type @tel me=#%s to visit it."
+                 % (thing.name, thing.id, thing.id))
+
+
+class CmdOpen(BaseCreationCommand):
+    """
+    Create a new exit between the current room and a destination.
+
+    Usage:
+        @open Exit name;exit alias 1;exit=room
+    """
+    key = '@open'
+
+    def get_location(self):
+        return self.caller.location
+
+    def pre_load(self):
+        self.switches.insert(0, settings.COLLAB_EXIT_TYPE)
+
+
+class CmdBuildNick(MuxCommand):
+    """
+    Sets a nick for the last object you created. Useful for when pasting
+    several commands at once and the DBREF may change.
+
+    Usage:
+        @bn tmproom
+
+    This will allow you to refer to the last object created as 'tmproom'. This
+    might be appropriate if you used @dig.
+    """
+    key = '@buildnick'
+    aliases = ['@bnick', '@bn']
+
+    def func(self):
+        if not self.caller.db.last_created:
+            self.msg("{rCouldn't locate your last created object, or you have already assigned a nick to it.{n")
+            return
+        if not self.args:
+            self.msg("{rUsage: @bn name{n")
+        self.caller.nicks.add(self.args, "#%s" % self.caller.db.last_created.id,
+                              category='object')
+        self.msg("{gNick '{y%s{g' set for %s{n" % (self.args, self.caller.db.last_created))
+        # Delete reference to object once a nick is established. Too likely otherwise that someone will
+        # accidentally assign nicks to unintended objects.
+        del self.caller.db.last_created
+
+
+class CmdDestroy(MuxCommand):
+    """
+    Deletes an object from the game.
+
+    Usage:
+        @destroy thing
+    """
+    key = '@destroy'
+    aliases = ['@rec', '@delete', '@recycle']
+    locks = "cmd:perm(create) or perm(builders)"
+
+    def func(self):
+        target = self.caller.search(self.args)
+        if not target:
+            return
+        if not collab_check(self.caller, target, locks=['delete']):
+            self.msg("{rYou don't have permission to destroy that.{n")
+            return
+        if self.caller == target:
+            self.msg("{rSuicide is not the answer.{n")
+            return
+        owner = get_owner(target, player_check=True) == getattr(self.caller, 'player', self.caller)
+        if not owner and 'force' not in self.switches:
+            self.msg("{rYou don't own %s. If you really want to delete it, use the /force switch." % target)
+            return
+        name = target.name
+        target_id = target.id
+        target.delete()
+        self.msg("{y%s(#%s) destroyed.{n" % (name, target_id))
+
+
+class CmdChown(MuxCommand):
+    """
+    Take ownership of an object.
+
+    Usage:
+        @chown object
+
+    Wizards may also chown objects to specific persons.
+
+    Usage:
+        @chown object=new owner
+    """
+    key = '@chown'
+
+    def func(self):
+        target = self.caller.search(self.lhs)
+        if self.rhs:
+            new_owner = self.caller.search(self.rhs)
+            allowed_class = (
+                inherits_from(new_owner,
+                              settings.BASE_CHARACTER_TYPECLASS)
+                or
+                inherits_from(new_owner,
+                              settings.BASE_PLAYER_TYPECLASS))
+            if not allowed_class:
+                self.msg("{rYou can't set '%s' as an owner.{n"
+                         % new_owner.name)
+                return
+            if not collab_check(self.caller, new_owner, locks=['chown_to']):
+                self.msg("{rYou don't have permission to give that person "
+                         "possessions.{n")
+                return
+        if not target:
+            return
+
+        if is_owner(self.caller, target, check_character=True):
+            self.msg("{rYou already own that.{n")
+            return
+
+        if not collab_check(self.caller, target, locks=['chown']):
+            self.msg("{rYou don't have permission to change that object's "
+                     "owner.{n")
+            return
+
+        set_owner(self.caller, target)
+        self.msg("{gOwner for %s(#%s) set to %s(#%s).{n"
+                 % (target.name, target.id, self.caller, self.caller.id))
+
+
+class CmdLink(MuxCommand):
+    """
+    Set the destination of an object. Most useful for changing the place where
+    exits will lead.
+
+    Usage:
+        @link exit=destination
+    """
+    key = '@link'
+
+    def func(self):
+        if not self.lhs:
+            self.msg("{rUsage: @link thing=destination{n")
+        source = self.caller.search(self.lhs)
+        if not source:
+            return
+        if self.rhs:
+            destination = self.caller.search(self.rhs)
+            if not destination:
+                return
+        else:
+            destination = None
+        if not collab_check(self.caller, source, locks=['link']):
+            self.msg("{rYou don't have permission to link to '%s'.{n" % source)
+            return
+        if destination and not collab_check(self.caller, destination,
+                                            locks=['link_to']):
+            self.msg("{rYou don't have permission to link to '%s'."
+                     % destination.name)
+            return
+        source.destination = destination
+        if destination is None:
+            self.msg("{g'%s' unlinked." % source.name)
+        else:
+            self.msg("{g'%s' linked to '%s'."
+                     % (source.name, destination.name))
+
+
+class CmdSetHome(MuxCommand):
+    """
+    Set the home of an object.
+
+    Usage:
+        @home object=home
+    """
+    key = '@home'
+
+    def func(self):
+        if not self.rhs:
+            self.msg("{rUsage: @home thing=home{n")
+        obj = self.caller.search(self.lhs)
+        if not obj:
+            return
+        if self.rhs:
+            home = self.caller.search(self.rhs)
+            if not home:
+                return
+        else:
+            home = None
+        if not collab_check(self.caller, obj, locks=['home']):
+            self.msg("{rYou don't have permission to set the home for '%s'.{n"
+                     % obj)
+            return
+        if home and not collab_check(self.caller, home, locks=['home_to']):
+            self.msg("{rYou don't have permission to set home to '%s'."
+                     % home.name)
+            return
+        obj.home = home
+        if home is None:
+            self.msg("{g'%s' home cleared. {yWarning, this object may get "
+                     "lost if its container is destroyed.{n" % obj.name)
+        else:
+            self.msg("{g'%s' home set to '%s'."
+                     % (obj.name, home.name))
+
+
+class CmdDesc(MuxCommand):
+    """
+    Describe an object. To give an object a one-line description, use:
+
+    @desc object=description
+
+    To enter a line editor for a longer description, use:
+
+    @desc/long object
+    """
+    key = '@desc'
+    aliases = ['@describe']
+
+    def func(self):
+        if not ((self.lhs or self.rhs) or 'long' in self.switches):
+            self.msg("{rUsage: @desc thing=Description{n")
+        obj = self.caller.search(self.lhs)
+        if not obj:
+            return
+        if not collab_check(self.caller, obj, locks=['desc']):
+            self.msg("rYou don't have permission to describe this object.")
+            return
+        if self.rhs and 'long' in self.switches:
+            self.msg("{rYou may specify a description, or use the long flag, "
+                     "but not both.{n")
+            return
+        if self.rhs:
+            obj.db.desc = self.rhs
+            self.msg("{gDescription set.")
+            return
+        # Time to call in the line editor.
+
+        # hook save/load functions
+        def load():
+            return obj.db.desc or ""
+
+        def save():
+            """
+            Save line buffer to given attribute name. This should
+            return True if successful and also report its status.
+            """
+            obj.db.desc = self.editor.buffer
+            self.caller.msg("Saved.")
+            return True
+
+        self.editor = EvEditor(
+            self.caller,
+            loadfunc=load,
+            savefunc=save,
+            key="desc"
+        )
+
+
+class CmdCollabCpAttr(CmdCpAttr):
+    __doc__ = CmdCpAttr.__doc__
+
+    def check_from_attr(self, obj, attr, clear=False):
+        attr_name, handler = prefix_check(obj, attr)
+        if clear:
+            access = 'write'
+        else:
+            access = 'read'
+        if not attr_check(self.caller, obj, access, handler):
+            if clear:
+                action = 'clear'
+            else:
+                action = 'read from'
+            self.msg("{rYou are not allowed to %s '%s' on '%s'.{n"
+                     % (action, attr, obj))
+            return False
+        return True
+
+    def check_to_attr(self, obj, attr):
+        attr_name, handler = prefix_check(obj, attr)
+        if not attr_check(self.caller, obj, 'write', handler):
+            self.msg("{rYou are not allowed to write to '%s' on '%s'."
+                     % (obj, attr))
+            return False
+        return True
+
+    def check_has_attr(self, obj, attr):
+        attr_name, handler = prefix_check(obj, attr)
+        if not handler.has(attr_name):
+            self.caller.msg(
+                "%s doesn't have an attribute %s."
+                % (obj.name, attr))
+            return False
+        return True
+
+    def get_attr(self, obj, attr):
+        """
+        Hook for overriding on subclassed commands. Do any preprocessing
+        required and get the attribute from the object.
+        """
+        attr_name, handler = prefix_check(obj, attr)
+        return handler.get(attr_name)
+
+
+class CmdExamine(MuxCommand):
+    """
+    Examine the technical details of an object. To learn the basics of an
+    object's settings, use:
+
+    examine obj
+
+    To browse the attributes of an object, use:
+
+    examine/db obj
+
+    To see an object's non-persistant attributes (things that go away when
+    the game restarts):
+
+    examine/ndb obj
+
+    To see detailed information about commands available to an object, run:
+
+    examine/cmd obj
+    """
+    key = "@examine"
+    aliases = ["@ex","ex", "exam", "examine"]
+    locks = "cmd:perm(examine) or perm(Builders)"
+    help_category = "Building"
+
+    player_mode = False
+
+    def func(self):
+        if not self.lhs:
+            self.msg("{rUsage: ex obj[=attribute_dir]{n")
+        obj = self.caller.search(self.lhs)
+        if not obj:
+            return
+        if not self.rhs and not self.switches:
+            self.overview(obj)
+            return
+
+        if 'cmd' in self.switches:
+            self.obj = obj
+            if hasattr(obj, "sessid") and obj.sessid.count():
+                mergemode = "session"
+            elif self.player_mode:
+                mergemode = "player"
+            else:
+                mergemode = "object"
+            get_and_merge_cmdsets(
+                obj, self.session, self.player, obj, mergemode).addCallback(
+                    self.cmd_info)
+            return
+
+        if 'db' in self.switches:
+            self.db_listing(obj)
+            return
+
+    def db_listing(self, obj):
+        self.msg('-' * 79)
+        self.msg('Attributes for %s:' % obj.name)
+        for key in settings.COLLAB_PROPTYPE_PERMS.keys():
+            try:
+                 handler = get_handler(obj, key)
+            except AttributeError:
+                continue
+            if not attr_check(self.caller, obj, 'read', handler):
+                continue
+            prefix = key + '_'
+            attributes = []
+            for attribute in handler.all():
+                if attribute.strvalue:
+                    attributes.append(
+                        "%s%s [strvalue]: %s{n"
+                        % (prefix, attribute.db_key, attribute.db_strvalue))
+                else:
+                    attributes.append(
+                        "%s%s: %s{n"
+                        % (prefix, attribute.db_key, attribute.value))
+            attributes.sort()
+            self.msg('\n'.join(attributes))
+        self.msg('-' * 79)
+
+    def namer(self, obj):
+        if obj is None:
+            return '{rNone{n'
+        if collab_check(self.caller, obj):
+            return "%s(#%s)" % (obj.name, obj.dbref)
+        else:
+            return obj.name
+
+    def cmd_info(self, avail_cmdset):
+        obj = self.obj
+        if (len(obj.cmdset.all()) == 1 and obj.cmdset.current.key == "_EMPTY_CMDSET"):
+            self.msg("There are no command sets on %s." % obj.name)
+            return
+        stored_cmdsets = obj.cmdset.all()
+        stored_cmdsets.sort(key=lambda x: x.priority, reverse=True)
+        stored_line = "{wStored Cmdset(s){n:\n %s" % (
+            "\n ".join(
+                ("%s [%s] (%s, prio %s)" % (cmdset.path, cmdset.key,
+                                            cmdset.mergetype, cmdset.priority)
+            for cmdset in stored_cmdsets if cmdset.key != "_EMPTY_CMDSET")))
+
+        # this gets all components of the currently merged set
+        all_cmdsets = [(cmdset.key, cmdset) for cmdset in avail_cmdset.merged_from]
+        # we always at least try to add player- and session sets since these are ignored
+        # if we merge on the object level.
+        if hasattr(obj, "player") and obj.player:
+            all_cmdsets.extend([(cmdset.key, cmdset) for cmdset in  obj.player.cmdset.all()])
+            if obj.sessid.count():
+                # if there are more sessions than one on objects it's because of multisession mode 3.
+                # we only show the first session's cmdset here (it is -in principle- possible that
+                # different sessions have different cmdsets but for admins who want such madness
+                # it is better that they overload with their own CmdExamine to handle it).
+                all_cmdsets.extend([(cmdset.key, cmdset) for cmdset in obj.player.get_session(obj.sessid.get()[0]).cmdset.all()])
+        else:
+            try:
+                # we have to protect this since many objects don't have sessions.
+                all_cmdsets.extend([(cmdset.key, cmdset) for cmdset in obj.get_session(obj.sessid.get()).cmdset.all()])
+            except (TypeError, AttributeError):
+                pass
+        all_cmdsets = [cmdset for cmdset in dict(all_cmdsets).values()]
+        all_cmdsets.sort(key=lambda x: x.priority, reverse=True)
+        merged_line = "{wMerged Cmdset(s){n:\n %s" % (
+            ("\n ".join("%s [%s] (%s, prio %s)" % (cmdset.path, cmdset.key, cmdset.mergetype, cmdset.priority)
+             for cmdset in all_cmdsets)))
+
+        # list the commands available to this object
+        avail_cmdset = sorted([cmd.key for cmd in avail_cmdset
+                               if cmd.access(obj, "cmd")])
+
+        cmdsetstr = utils.fill(", ".join(avail_cmdset), indent=2)
+        commands_line = "{wCommands available to %s (result of Merged CmdSets){n:\n %s" % (obj.key, cmdsetstr)
+        separator = '-' * 78
+        self.msg('\n'.join([separator, stored_line, merged_line, commands_line,
+                            separator]))
+
+    def overview(self, obj):
+        display_owner = get_owner(obj)
+        if not collab_check(self.caller, obj, locks=['examine']):
+            self.msg("Owner: %s" % display_owner)
+            return
+        true_owner = get_owner(obj, player_check=True)
+        name = "{wName/Key: {c%s{n(#%s)" % (obj.name, obj.id)
+        owner_string = '{wOwner: {n'
+        if not (true_owner or display_owner):
+            owner_string += 'This object is {rORPHANED{n'
+        elif (true_owner == display_owner) or not display_owner:
+            owner_string += '{c%s{n(#%s)[%s]' % (
+                true_owner.name, true_owner.id,
+                true_owner.__class__.__name__)
+        elif display_owner and not true_owner:
+            owner_string += '{c%s{n(#%s)[%s]' % (
+                display_owner.name, display_owner.id,
+                display_owner.__class__.__name__)
+        else:
+            owner_string += '{c%s{n(#%s)[%s] via {c%s{n(#%s)[%s]' % (
+                true_owner.name, true_owner.id,
+                true_owner.__class__.__name__, display_owner,
+                display_owner.id, display_owner.__class__.__name__)
+        typeclass = "{wTypeclass: %s (%s)" % (obj.typename,
+                                              obj.typeclass_path)
+        permissions = '{wPermissions:{n %s' % (
+                      ', '.join(obj.permissions.all()) or '{rNone{n')
+        lines = ["-" * 78, name, owner_string, typeclass, permissions]
+        if getattr(obj, 'player', None):
+            player_line = "{wPlayer:{n {c%s{n(#%s)" % (obj.player.name, obj.player.id)
+            ppermissions = "{wPlayer Permisions:{n %s" % (
+                ', '.join(obj.player.permissions.all() or '{rNone{n'))
+            if obj.player.is_superuser:
+                ppermissions += ' {g[Superuser]{n'
+            if obj.player.db._quelled:
+                ppermissions += ' {y(quelled){n'
+            lines.extend([player_line, ppermissions])
+        sessions_line = "{wSessions: {n"
+        if hasattr(obj, "sessions") and obj.sessions:
+            sessions_line += (
+                ", ".join(str(sess.sessid) for sess in obj.sessions))
+        else:
+            sessions_line += 'No sessions attached.'
+        location = "{wLocation: {n%s" % self.namer(obj.location)
+        destination = "{wDestination: {n%s" % self.namer(obj.destination)
+        home = "{wHome: {n%s" % self.namer(obj.home)
+        scripts = "{wScripts{n: "
+        if str(obj.scripts):
+            scripts += '\n%s' % obj.scripts
+        else:
+            scripts += '{rNone{n'
+        excluded = ['owner', 'display_owner']
+        tags = "{wTags{n: %s" % (
+            utils.fill(", ".join(
+                key for key, category in obj.tags.all(return_key_and_category=True)
+                if category not in excluded), indent=5)
+            or '{rNone{n')
+
+        lines.extend([sessions_line, location, destination, home,
+                      scripts, tags])
+
+        # add the contents
+        exits = []
+        pobjs = []
+        things = []
+        if hasattr(obj, "contents"):
+            for content in obj.contents:
+                if content.destination:
+                    exits.append(content)
+                elif content.player:
+                    pobjs.append(content)
+                else:
+                    things.append(content)
+            object_lists = [('Exits', exits), ('Characters', pobjs),
+                            ('Contents', things)]
+            for name, obj_list in object_lists:
+                item_list = [self.namer(item) for item in obj_list]
+                lines.append("{w%s: {n%s" % (
+                    name, ', '.join(item_list) or '{rNone{n'))
+        lines.append("-" * 78)
+        self.msg('\n'.join(lines))
+
+
+class CmdCollabSetAttribute(CmdSetAttribute):
+    __doc__ = CmdSetAttribute.__doc__
+
+    def check_obj(self, obj):
+        if not collab_check(self.caller, obj, ['setattribute']):
+            self.msg("{rYou do not have permission to set attributes on this "
+                     "object.")
+            return False
+        return True
+
+    def check_attr(self, obj, attr_name):
+        attr_name, handler = prefix_check(obj, attr_name)
+        if not attr_check(self.caller, obj, 'write', handler):
+            self.msg("{rYou do not have permission to set '%s' "
+                     "on this object.{n" % attr_name)
+            return False
+        return True
+
+    def view_attr(self, obj, attr):
+        """
+        Look up the value of an attribute and return a string displaying it.
+        """
+        attr_name, handler = prefix_check(obj, attr)
+        if handler.has(attr):
+            return "\nAttribute %s/%s = %s" % (obj.name, attr,
+                                               handler.get(attr_name))
+        else:
+            return "\n%s has no attribute '%s'." % (obj.name, attr)
+
+    def rm_attr(self, obj, attr):
+        """
+        Remove an attribute from the object, and report back.
+        """
+        attr_name, handler = prefix_check(obj, attr)
+        if handler.has(attr):
+            val = handler.has(attr)
+            handler.remove(attr)
+            return "\nDeleted attribute '%s' (= %s) from %s." % (attr, val, obj.name)
+        else:
+            return "\n%s has no attribute '%s'." % (obj.name, attr)
+
+    def set_attr(self, obj, attr, value):
+        attr_name, handler = prefix_check(obj, attr)
+        try:
+            handler.add(attr_name, value)
+            return "\nCreated attribute %s/%s = %s" % (obj.name, attr, value)
+        except SyntaxError:
+            # this means literal_eval tried to parse a faulty string
+            return ("\n{RCritical Python syntax error in your value. Only "
+                    "primitive Python structures are allowed.\nYou also "
+                    "need to use correct Python syntax. Remember especially "
+                    "to put quotes around all strings inside lists and "
+                    "dicts.{n")
+
+
+class CmdCollabSetObjAlias(CmdSetObjAlias):
+    __doc__ = CmdSetObjAlias.__doc__
+
+    def func(self):
+        pre_collab(
+            self, "Usage: @alias obj=alias",
+            "You do not have permission to set an alias for this "
+            "object", ['alias']
+        )
+
+
+class CmdCollabListCmdSets(CmdListCmdSets):
+    __doc__ = CmdListCmdSets.__doc__
+
+    def func(self):
+        pre_collab(
+            self, "Usage: @alias obj=alias",
+            "You do not have permission to list that object's "
+            "cmdsets.", ['listcmdsets']
+        )
+
+
+class CmdCollabName(CmdName):
+    __doc__ = CmdName.__doc__
+
+    def func(self):
+        pre_collab(
+            self, "Usage: @name <obj> = <newname>[;alias;alias;...]",
+            "You do not have permission to name that.", ['name']
+        )
+
+
+class CmdCollabLock(CmdLock):
+    __doc__ = CmdLock.__doc__
+
+    def func(self):
+        pre_collab(
+            self, "@lock <object>[ = <lockstring>] or @lock[/switch] "
+            "object/<access_type>",
+            "You do not have permission to set locks on this object."
+        )
+
+
+class CmdCollabCopy(CmdCopy):
+    __doc__ = CmdCopy.__doc__
+
+    def check_target_location(self, target_location):
+        if self.caller in target_location.contents:
+            return True
+        if target_location == self.caller:
+            return True
+        return collab_check(self.caller, target_location, locks=['create_in'])
+
+    def quota_check(self, obj):
+        """
+        Make sure copying doesn't circumvent quota.
+        """
+        collab_type = settings.COLLAB_REVERSE_TYPES.get(obj.typeclass_path)
+        if not collab_type:
+            self.msg("{rThe type of this object is not registered, and thus cannot be copied.{n")
+            return False
+
+        if not quota_check(self.caller, collab_type):
+            self.msg("{rYou have reached your quota for this item type.{n")
+            return False
+        return True
+
+    def func(self):
+        pre_collab(
+            self,
+            "@copy[/reset] <original obj> [= new_name][;alias;alias..][:new_location] [,new_name2 ...]",
+            "You do not have permission to copy this object.",
+            extra_check=self.quota_check
+        )
+        if not getattr(self, 'copied_obj', None):
+            return
+        set_owner(self.caller, self.copied_obj)
+        self.caller.db.last_created = self.copied_obj
+
+
+build_commands = [
+    CmdCreate, CmdLink, CmdSetHome, CmdChown, CmdDesc, CmdDestroy, CmdDig,
+    CmdOpen, CmdBuildNick, CmdCollabSetObjAlias, CmdCollabListCmdSets,
+    CmdCollabName, CmdCollabLock, CmdCollabSetAttribute, CmdMvAttr,
+    CmdExamine, CmdCollabCopy,
+]

--- a/evennia/contrib/collab/locks.py
+++ b/evennia/contrib/collab/locks.py
@@ -1,0 +1,9 @@
+from evennia.contrib.collab.perms import collab_check
+
+
+def controls(accessing_obj, accessed_obj):
+    """
+    Checks to see if the accessing object owns or has escalated
+    privileges over an object.
+    """
+    return collab_check(accessing_obj, accessed_obj)

--- a/evennia/contrib/collab/perms.py
+++ b/evennia/contrib/collab/perms.py
@@ -1,0 +1,264 @@
+from django.core.serializers.json import json
+from dateutil.parser import parse
+from evennia.contrib.collab import collab_settings
+from evennia.objects import DefaultCharacter
+from evennia.objects.models import ObjectDB
+from evennia.players import DefaultPlayer
+from evennia.players.models import PlayerDB
+from evennia.utils.utils import inherits_from
+
+
+class PermissionsError(Exception):
+    """
+    Used for cases when collaborative permissions checks aren't met.
+    """
+    pass
+
+
+def owner_tag_key(owner):
+    """
+    Used for creating the string value lookup on object attributes to find out
+    who created them quickly.
+    """
+    if inherits_from(owner, DefaultCharacter):
+        cls = 'object'
+    elif inherits_from(owner, DefaultPlayer):
+        cls = 'player'
+    else:
+        raise AssertionError("Owner is not an Object or Player.")
+    return json.dumps({'id': owner.id,
+                       'date': str(owner.db_date_created),
+                       'cls': cls}).lower()
+
+
+def quota_queryset(player, typeclass):
+    """
+    We use the raw manager here with db_strval for quicker counting.
+    """
+    return ObjectDB.objects.get_by_tag(
+        key=owner_tag_key(player), category='owner', raw_queryset=True).filter(
+            db_typeclass_path=typeclass)
+
+
+def get_limit_for(player, collab_type):
+    """
+    Given a player and a key for CREATE_TYPES, determine if the player has
+    already hit their quota for this object type.
+    """
+    if not collab_settings.COLLAB_QUOTAS_ENABLED:
+        return float('inf')
+    if player.locks.check_lockstring(
+            player, collab_settings.COLLAB_QUOTA_BYPASS_LOCK):
+        return float('inf')
+    quota = getattr(player.wizdb, 'quota_' + collab_type)
+    if quota is not None:
+        return quota
+    return collab_settings.COLLAB_TYPES[collab_type]['quota']
+
+
+def quota_check(player, collab_type):
+    """
+    Check to see if a player has any quota slots free for this collaborative
+    type.
+    """
+    player = getattr(player, 'player', player)
+    limit = get_limit_for(player, collab_type)
+    if limit == float('inf'):
+        return limit
+    typeclass = collab_settings.COLLAB_TYPES[collab_type]['typeclass']
+    current_object_count = quota_queryset(player, typeclass).count()
+    if current_object_count >= limit:
+        return 0
+    return limit - current_object_count
+
+
+def set_owner(subject, target):
+    """
+    Sets the owner for an object. The owner of an object has default
+    permissions to perform several actions.
+
+    Also sets a 'display owner', in the case that something is created while a
+    character. This allows one to keep some obscurity between their character
+    and player if needed.
+    """
+    player = getattr(subject, 'player', subject)
+    target.tags.clear(category='owner')
+    target.tags.clear(category='display_owner')
+    target.tags.add(owner_tag_key(player), category='owner')
+    target.tags.add(owner_tag_key(subject), category='display_owner')
+
+
+def is_owner(subject, target, check_character=False):
+    """
+    Checks to see if the subject owns the target. If check_character is True,
+    checks the display_owner when the distinction matters.
+    """
+    # Allow objects to act under the permissions of their owners.
+    subject = get_owner(subject)
+    if not subject:
+        return False
+    player = getattr(subject, 'player', subject)
+    if subject == target:
+        return True
+    if player == getattr(target, 'player', None):
+        return True
+    if check_character:
+        return target.tags.get(owner_tag_key(subject),
+                               category='display_owner')
+    return target.tags.get(owner_tag_key(player), category='owner')
+
+
+def is_privileged(subject, target):
+    """
+    Check to see if the player has permissions that would override the normal
+    permissions constraints, such as a wizard working with a normal player's
+    object.
+    """
+    return target.locks.check_lockstring(
+        subject, collab_settings.COLLAB_OVERRIDE_PERM_LOCK)
+
+
+def collab_check(subject, target, locks=None):
+    """
+    Takes a subject, like a character or player, and sees if they should have
+    access to a target. If they are the owner, then they do. Otherwise, checks
+    all of the locks in a list of lock names, and if any of them or true,
+    grants access, denying it otherwise.
+    """
+    locks = locks or []
+    if is_owner(subject, target):
+        return True
+    if hasattr(target, 'check_protected'):
+        protected = target.check_protected()
+    else:
+        protected = False
+    if not protected and is_privileged(subject, target):
+        return True
+    for lock in locks:
+        if target.access(subject, lock):
+            return True
+    return False
+
+
+def parse_owner(owner_tag):
+    try:
+        owner_info = json.loads(owner_tag)
+    except ValueError:
+        # Tag is corrupt. Return None.
+        return None
+    if owner_info['cls'] == 'player':
+        cls = PlayerDB
+    elif owner_info['cls'] == 'object':
+        cls = ObjectDB
+    else:
+        # Nonsense.
+        return None
+    db_date_created = parse(owner_info['date'])
+
+    try:
+        return cls.objects.get(id=owner_info['id'], db_date_created=db_date_created)
+    except cls.DoesNotExist:
+        return None
+
+
+def get_owner(obj, player_check=False, display_only=False):
+    """
+    Grabs the owner tags of an object and displays either the display owner or
+    true owner as specified. If both player_check and display_only are false,
+    does whatever it can to find a responsible party. If display_only is True,
+    only attempts to find who is the display owner of an object.
+
+    If player_check is true, it skips checking for the display owner.
+
+    Players always own themselves. Character objects own themselves, but may
+    have a player authority which owns them directly.
+    """
+    owner = None
+    if inherits_from(obj, DefaultPlayer):
+        # Players own themselves.
+        return obj
+    if not player_check:
+        owner = obj.tags.all(category='display_owner')
+        if owner:
+            owner = parse_owner(owner[0])
+            return owner
+    if not owner and inherits_from(obj, DefaultCharacter) and not player_check:
+        # Object is a character with no player. It owns itself.
+        return obj
+    if not owner and not display_only:
+        owner = obj.tags.all(category='owner')
+        if owner:
+            owner = parse_owner(owner[0])
+    return owner
+
+
+def prefix_check(obj, attr_name, default_type='usr'):
+    """
+    Attempts to grab a handler from a prefixed attribute. For instance, if the
+    attr_name was:
+
+    'wizh_test'
+
+    The result would be:
+
+    'test', obj.whattributes
+
+    If the attribute name is something like:
+
+    'test'
+
+    And the object is not a collab typeclass, it would return:
+
+    attr_name, obj.attributes
+
+    ...But if it /is/ a collab typeclass, it will act as if the prefix is
+    default_type, and thus parse to:
+
+    'usr_test'
+
+    ...if 'usr' is the default, and result in:
+
+    'test', obj.usrattributes
+
+    To refer to the normal .db attributes, one would use something like:
+
+    '_test'
+
+    And would get back:
+
+    'test', obj.attributes
+    """
+    old_name = attr_name
+    namer = attr_name.split('_', 1)
+    if namer[0] in collab_settings.COLLAB_PROPTYPE_PERMS:
+        attr_type = namer[0]
+        attr_name = namer[1]
+    else:
+        attr_type = default_type
+    try:
+        handler = get_handler(obj, attr_type)
+    except (AttributeError, TypeError):
+        return old_name, obj.attributes
+    return attr_name, handler
+
+
+def get_handler(obj, key):
+    if not key:
+        return obj.attributes
+    return getattr(obj, key + 'attributes')
+
+
+def attr_check(player, target, access_type, attr_type=''):
+    """
+    Checks an attribute on a target, and sees if the player has access to
+    it.
+
+    attr_type can be either the name of the type or a handler.
+    """
+    if hasattr(attr_type, '_attrtype'):
+        attr_type = attr_type._attrtype
+    if not attr_type:
+        attr_type = ''
+    return target.locks.check_lockstring(
+        player, collab_settings.COLLAB_PROPTYPE_PERMS[attr_type],
+        access_type=access_type)

--- a/evennia/contrib/collab/test_base.py
+++ b/evennia/contrib/collab/test_base.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+from contrib.collab import collab_settings
+from contrib.collab.typeclasses import CollabCharacter, CollabObject, CollabPlayer
+from django.conf import settings
+from src.commands.default.tests import CommandTest
+from src.locks.lockhandler import _cache_lockfuncs
+
+
+class CollabTest(CommandTest):
+    character_typeclass = CollabCharacter
+    object_typeclass = CollabObject
+    player_typeclass = CollabPlayer
+
+    def setUp(self):
+        """
+        Some tests will involve manipulating quota number settings.
+        """
+        self.old_types = collab_settings.CREATE_TYPES
+        collab_settings.CREATE_TYPES = deepcopy(self.old_types)
+        self.types = collab_settings.CREATE_TYPES
+        settings.LOCK_FUNC_MODULES += ('contrib.collab.locks',)
+        _cache_lockfuncs()
+        super(CollabTest, self).setUp()
+
+    def tearDown(self):
+        collab_settings.CREATE_TYPES = self.old_types
+        settings.LOCK_FUNC_MODULES = settings.LOCK_FUNC_MODULES[:-1]
+        _cache_lockfuncs()
+        super(CollabTest, self).tearDown()

--- a/evennia/contrib/collab/test_base.py
+++ b/evennia/contrib/collab/test_base.py
@@ -1,29 +1,29 @@
-from copy import deepcopy
-from contrib.collab import collab_settings
-from contrib.collab.typeclasses import CollabCharacter, CollabObject, CollabPlayer
-from django.conf import settings
-from src.commands.default.tests import CommandTest
-from src.locks.lockhandler import _cache_lockfuncs
+from django.test import override_settings
+from evennia.contrib.collab import collab_settings
+from evennia.contrib.collab.typeclasses import CollabCharacter, CollabObject, CollabPlayer, CollabExit
+from evennia.commands.default.tests import CommandTest
+from evennia.locks.lockhandler import _cache_lockfuncs
+from evennia import settings_default
 
 
+collab_overrides = {key: value for key, value in collab_settings.__dict__.items() if key.isupper()}
+collab_overrides['LOCK_FUNC_MODULES'] = settings_default.LOCK_FUNC_MODULES + ('evennia.contrib.collab.locks',)
+
+
+@override_settings(**collab_overrides)
 class CollabTest(CommandTest):
     character_typeclass = CollabCharacter
     object_typeclass = CollabObject
     player_typeclass = CollabPlayer
+    exit_typeclass = CollabExit
 
     def setUp(self):
         """
-        Some tests will involve manipulating quota number settings.
+        The lock functions will be overwritten, so we'll need to recache them.
         """
-        self.old_types = collab_settings.CREATE_TYPES
-        collab_settings.CREATE_TYPES = deepcopy(self.old_types)
-        self.types = collab_settings.CREATE_TYPES
-        settings.LOCK_FUNC_MODULES += ('contrib.collab.locks',)
         _cache_lockfuncs()
         super(CollabTest, self).setUp()
 
     def tearDown(self):
-        collab_settings.CREATE_TYPES = self.old_types
-        settings.LOCK_FUNC_MODULES = settings.LOCK_FUNC_MODULES[:-1]
         _cache_lockfuncs()
         super(CollabTest, self).tearDown()

--- a/evennia/contrib/collab/test_commands.py
+++ b/evennia/contrib/collab/test_commands.py
@@ -1,0 +1,246 @@
+from uuid import uuid4
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from mock import patch
+from evennia.contrib.collab.commands import CmdCreate, CmdBuildNick, CmdDig, CmdOpen, CmdDestroy, CmdChown, CmdLink, \
+    CmdCollabCopy
+from evennia.contrib.collab.perms import quota_queryset, get_owner, set_owner, quota_check
+from evennia.contrib.collab.test_base import CollabTest
+
+
+class CollabCommandTestMixin(object):
+    """
+    Helpful mixin for
+    """
+    def retrieve(self, caller):
+        """
+        Retrieve the last object created by the caller.
+        """
+        build_nick = str(uuid4())
+        self.call(CmdBuildNick(), build_nick, caller=caller)
+        return caller.search(build_nick)
+
+
+class CollabCreateCommandTestMixin(CollabCommandTestMixin):
+    """
+    Test collaborative commands. Verify they have the expected effects.
+    """
+    command = CmdCreate
+    type_key = 'object'
+
+    def create(self, cmd_string='thing', caller=None):
+        caller = caller or self.char1
+        self.call(self.command(), cmd_string, caller=caller)
+        return self.retrieve(caller)
+
+    def get_typeclass(self):
+        return settings.COLLAB_TYPES[self.type_key]['typeclass']
+
+    def test_create_typeclass(self):
+        """
+        Test creating an object.
+        """
+        thing = self.create()
+        self.assertEqual(thing.typename, self.get_typeclass().split('.')[-1])
+
+    def test_set_destination(self):
+        """
+        Test that setting a destination for an object works.
+        """
+        thing = self.create('thing=here')
+        self.assertTrue(thing.destination)
+        self.assertEqual(thing.destination, self.char1.location)
+
+    def test_set_aliases(self):
+        """
+        Test that aliases can be set for created objects.
+        """
+        thing = self.create('thing;thingus;thingectomy')
+        self.assertEqual(set(thing.aliases.all()), {'thingus', 'thingectomy'})
+
+    def test_affects_quota(self):
+        """
+        Make sure creating objects of a specific type affects the quota for that type.
+        """
+        old_count = quota_queryset(self.player, self.get_typeclass()).count()
+        self.create()
+        new_count = quota_queryset(self.player, self.get_typeclass()).count()
+        self.assertEquals(new_count, old_count + 1)
+
+    def test_sets_display_owner(self):
+        """
+        Ensure the 'display owner' of an object is set upon creation.
+        """
+        thing = self.create()
+        owner = get_owner(thing)
+        self.assertEqual(owner, self.char1)
+
+    def test_sets_owner(self):
+        """
+        Ensure the 'true owner' of an object is set upon creation.
+        """
+        thing = self.create()
+        owner = get_owner(thing, player_check=True)
+        self.assertEqual(owner, self.player)
+
+    def test_perm_check(self):
+        """
+        Verify a character without build permissions can't create.
+        """
+        self.player2.permissions.clear()
+        self.player2.permissions.add("Player")
+        thing = self.create(caller=self.char2)
+        self.assertIs(thing, None)
+
+    def test_respect_quota(self):
+        """
+        Verify that an object is not created by the command if the user's quota is already hit.
+        """
+        with patch.dict(settings.COLLAB_TYPES[self.type_key], {'quota': 1}):
+            settings.COLLAB_TYPES[self.type_key]['quota'] = 1
+            thing = self.create(caller=self.char2)
+            self.assertTrue(thing)
+            thing2 = self.create('dingus', caller=self.char2)
+            self.assertFalse(thing2)
+            self.assertEqual(quota_queryset(self.player2, self.get_typeclass()).count(), 1)
+
+
+class CreateCmdTest(CollabCreateCommandTestMixin, CollabTest):
+    pass
+
+
+class CmdDigTest(CollabCreateCommandTestMixin, CollabTest):
+    command = CmdDig
+    type_key = 'room'
+
+
+class OpenCmdTest(CollabCreateCommandTestMixin, CollabTest):
+    command = CmdOpen
+    type_key = 'exit'
+
+
+class CmdDestroyTest(CollabTest):
+    """
+    Tests the destroy command.
+    """
+    def test_destroy_object(self):
+        """
+        Verify destroy's base functionality.
+        """
+        set_owner(self.player, self.obj1)
+        self.call(CmdDestroy(), self.obj1.name)
+        self.assertRaises(ObjectDoesNotExist, getattr, self.obj1, 'name')
+
+    def test_perms_failure(self):
+        """
+        Make sure destroy does not work on objects the user does not own.
+        """
+        set_owner(self.player, self.obj1)
+        self.call(CmdDestroy(), self.obj1.name, caller=self.player2)
+        # Should not raise an exception, because it still exists.
+        self.obj1.name
+        # Force should not help here.
+        self.call(CmdDestroy(), '/force %s' % self.obj1.name, caller=self.player)
+        self.obj1.name
+
+    def test_destroy_override(self):
+        """
+        Verify an object that a user does not own is not destroyed unless the user really means it.
+        """
+        set_owner(self.player2, self.obj1)
+        self.call(CmdDestroy(), self.obj1.name, caller=self.char1)
+        self.obj1.name
+        self.call(CmdDestroy(), '/force %s' % self.obj1.name, caller=self.char1)
+        self.assertRaises(ObjectDoesNotExist, getattr, self.obj1, 'name')
+
+
+class TestCmdChown(CollabTest):
+    """
+    Tests that CmdChown works.
+    """
+    def test_good_chown(self):
+        """
+        Verify that a user who should be able to chown an object can.
+        """
+        self.assertNotEqual(get_owner(self.obj2), self.char1)
+        self.assertNotEqual(get_owner(self.obj2, player_check=True), self.player)
+        # Player is an immortal, so should always be able to chown.
+        self.call(CmdChown(), self.obj2.name, caller=self.char1)
+        self.assertEqual(get_owner(self.obj2), self.char1)
+        self.assertEqual(get_owner(self.obj2, player_check=True), self.player)
+
+    def test_bad_chown(self):
+        """
+        Verify that a user who should not be able to chown cannot.
+        """
+        self.assertNotEqual(get_owner(self.obj1), self.char2)
+        self.assertNotEqual(get_owner(self.obj1, player_check=True), self.player2)
+        self.call(CmdChown(), self.obj1.name, caller=self.char2)
+        self.assertNotEqual(get_owner(self.obj1), self.char2)
+        self.assertNotEqual(get_owner(self.obj1, player_check=True), self.player2)
+
+
+class TestCmdLink(CollabTest, CollabCommandTestMixin):
+    """
+    Verify linking works sanely.
+    """
+
+    def test_can_link(self):
+        """
+        Make sure that a user can link an exit they own to a room they own.
+        """
+        set_owner(self.char2, self.room1)
+        set_owner(self.char2, self.room2)
+        set_owner(self.char2, self.exit)
+        self.exit.destination = None
+        self.call(CmdLink(), '%s=#%s' % (self.exit.name, self.room2.id), caller=self.char2)
+        self.assertEqual(self.exit.destination, self.room2)
+
+    def test_no_link_to_unowned(self):
+        """
+        Make sure that a user cannot link to a place they do not own.
+        """
+        set_owner(self.char2, self.room1)
+        set_owner(self.char2, self.exit)
+        self.exit.destination = None
+        self.call(CmdLink(), '%s=#%s' % (self.exit.name, self.room2.id), caller=self.char2)
+        self.assertFalse(self.exit.destination)
+
+    def test_no_link_unowned_exit(self):
+        """
+        Make sure that a user cannot link up an exit they do not own.
+        """
+        set_owner(self.char2, self.room1)
+        set_owner(self.char2, self.room2)
+        self.exit.destination = None
+        self.call(CmdLink(), '%s=#%s' % (self.exit.name, self.room2.id), caller=self.char2)
+        self.assertFalse(self.exit.destination)
+
+
+class TestCmdCopy(CollabTest, CollabCommandTestMixin):
+    """
+    Test the copy command with collab enhancements.
+    """
+
+    def test_copy(self):
+        """
+        Test basic copying works.
+        """
+        self.char2.player = self.player2
+        set_owner(self.char2, self.obj1)
+        original_quota = quota_check(self.char2, settings.COLLAB_DEFAULT_TYPE)
+        self.call(CmdCollabCopy(), self.obj1.name, caller=self.char2, msg='Identical')
+        copied = self.retrieve(self.char2)
+        self.assertEqual(self.obj1.name + '_copy', copied.name)
+        self.assertEqual(self.obj1.typeclass_path, copied.typeclass_path)
+        self.assertLess(quota_check(self.char2, settings.COLLAB_DEFAULT_TYPE), original_quota)
+
+    def test_no_quota_circumvention(self):
+        """
+        Make sure a user can't skirt quotas by copying.
+        """
+        self.player2.wizdb.quota_object = 2
+        set_owner(self.player2, self.obj1)
+        set_owner(self.player2, self.obj2)
+        self.call(CmdCollabCopy(), self.obj1.name, caller=self.player2)
+        self.assertIsNone(self.retrieve(self.player2))

--- a/evennia/contrib/collab/test_perms.py
+++ b/evennia/contrib/collab/test_perms.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+import json
+from dateutil.parser import parse
+from django.conf import settings
+from evennia.contrib.collab.perms import (
+    set_owner, quota_queryset, get_limit_for, quota_check, get_owner,
+    is_owner, owner_tag_key, prefix_check, attr_check)
+from evennia.contrib.collab.test_base import CollabTest
+from evennia.contrib.collab.typeclasses import (
+    WizHiddenAttributeHandler, UserHiddenAttributeHandler, UserAttributeHandler
+)
+from evennia.typeclasses.models import AttributeHandler
+from evennia.utils.create import create_object
+from mock import patch
+
+ga = object.__getattribute__
+
+
+class QuotaTest(CollabTest):
+    """
+    Test Quotas, their limits and their counts.
+    """
+    def test_quota_queryset(self):
+        """
+        Verify we get all objects of a certain type owned by the user.
+        """
+        set_owner(self.player, self.obj1)
+        set_owner(self.player, self.obj2)
+        tc_path = settings.COLLAB_TYPES['object']['typeclass']
+        self.assertEqual(quota_queryset(self.player, tc_path).count(), 2)
+        self.obj2.delete()
+        self.assertEqual(quota_queryset(self.player, tc_path).count(), 1)
+
+    def test_quota_bypass(self):
+        """
+        Verify immortals are no subject to quotas.
+        """
+        # user1 is an immortal. The default lock should pass for infinite.
+        self.assertEqual(quota_check(self.player, 'object'), float('inf'))
+        set_owner(self.player, self.obj1)
+        self.assertEqual(quota_check(self.player, 'object'), float('inf'))
+
+    def test_quota_limit(self):
+        """
+        Check to make sure we can consistently set and track limits for
+        object types.
+        """
+        with patch.dict(settings.COLLAB_TYPES['object'], {'quota': 5}):
+            settings.COLLAB_TYPES['object']['quota'] = 5
+            self.assertEqual(get_limit_for(self.player2, 'object'), 5)
+            set_owner(self.player2, self.obj1)
+            # This function is not for how many are left, but how many may be
+            # made total.
+            self.assertEqual(get_limit_for(self.player2, 'object'), 5)
+            self.assertEqual(quota_check(self.player, 'object'), float('inf'))
+
+    def test_quota_check(self):
+        """
+        Verify that quota checks properly tally the number of remaining
+        available object creations of each type.
+        """
+        obj3 = create_object(self.object_typeclass, 'Obj3')
+        with patch.dict(settings.COLLAB_TYPES['object'], {'quota': 2}):
+            self.assertEqual(quota_check(self.player2, 'object'), 2)
+            set_owner(self.player2, self.obj1)
+            self.assertEqual(quota_check(self.player2, 'object'), 1)
+            set_owner(self.player2, self.obj2)
+            self.assertEqual(quota_check(self.player2, 'object'), 0)
+            set_owner(self.player2, obj3)
+            self.assertEqual(quota_check(self.player2, 'object'), 0)
+            obj3.delete()
+            self.assertEqual(quota_check(self.player2, 'object'), 0)
+            self.obj1.delete()
+            self.assertEqual(quota_check(self.player2, 'object'), 1)
+            self.obj2.delete()
+            self.assertEqual(quota_check(self.player2, 'object'), 2)
+
+    def test_quota_override(self):
+        """
+        Make sure that a user's quota can be set with an override.
+        """
+        self.player2.wizdb.quota_object = 5
+        self.assertEqual(quota_check(self.player2, 'object'), 5)
+        self.player2.wizdb.quota_object = 3
+        self.assertEqual(quota_check(self.player2, 'object'), 3)
+        set_owner(self.player2, self.obj1)
+        self.assertEqual(quota_check(self.player2, 'object'), 2)
+
+
+class OwnerTest(CollabTest):
+    """
+    Test functions dealing with ownership management and checking.
+    """
+    def test_set_get_owner(self):
+        """
+        Tests that set and get for owners works. Indirectly tests
+        parse_owner as well.
+        """
+        set_owner(self.player, self.obj1)
+        self.assertEqual(self.player, get_owner(self.obj1))
+        set_owner(self.player2, self.obj1)
+        self.assertEqual(self.player2, get_owner(self.obj1))
+
+    def test_is_owner(self):
+        """
+        Verify that is_owner returns True or False based on ownership, and
+        doesn't falsely report ownership for higher level privileges.
+        """
+        set_owner(self.player, self.obj1)
+        self.assertTrue(is_owner(self.player, self.obj1))
+        self.assertFalse(is_owner(self.player2, self.obj1))
+        # Player1 is an immortal, but not the owner.
+        self.assertFalse(is_owner(self.player, self.obj2))
+
+    def test_owner_tag_key(self):
+        """
+        Verify that the ownership tags contain the proper information and are
+        serialized correctly.
+        """
+        test_date = datetime(
+            year=2014, month=5, day=4, hour=6, minute=2, second=45,
+            microsecond=83)
+        self.player.db_date_created = test_date
+        old_id = self.player.id
+        self.player.id = 5
+        try:
+            tag = json.loads(owner_tag_key(self.player))
+            self.assertEqual(tag['id'], 5)
+            self.assertEqual(
+                parse(tag['date']),
+                test_date)
+            self.assertEqual(tag['cls'], 'player')
+        finally:
+            self.player.id = old_id
+
+
+class AttrTest(CollabTest):
+    def test_prefix_check(self):
+        """
+        Verify that the attribute prefix checker returns the right handler
+        for properly prefixed attributes.
+
+        Indirectly tests get_handler.
+        """
+        name, handler = prefix_check(self.player, 'wizh_test')
+        self.assertEqual(name, 'test')
+        self.assertEqual(ga(handler, '__class__'), WizHiddenAttributeHandler)
+        name, handler = prefix_check(self.obj1, 'usrh_stuff')
+        self.assertEqual(name, 'stuff')
+        self.assertEqual(ga(handler, '__class__'), UserHiddenAttributeHandler)
+        # Make sure the default is UserAttributeHandler.
+        name, handler = prefix_check(self.player, 'default')
+        self.assertEqual(name, 'default')
+        self.assertEqual(ga(handler, '__class__'), UserAttributeHandler)
+        # If there's nothing before the underscore, it's to be set on .db.
+        name, handler = prefix_check(self.player, '_things')
+        self.assertEqual(name, 'things')
+        self.assertEqual(ga(handler, '__class__'), AttributeHandler)
+
+    def perm_checks(self, player, checks, results, obj):
+        """
+        Helper method for test_attr_check. Runs a series of tests for
+        permissions against attribute handlers on an object given a player.
+        """
+        for check, result in zip(checks, results):
+            access_type, attr_type = check
+            self.assertIs(
+                attr_check(player, obj, access_type, attr_type),
+                result)
+
+    def test_attr_check(self):
+        """
+        Verify that permissions checks on attributes work as expected.
+
+        Indirectly tests controls() lockfunc.
+        """
+        checks = (
+            ('read', 'wizh'),
+            ('write', 'wizh'),
+            ('read', ''),
+            ('write', ''),
+            ('read', 'usr'),
+            ('write', 'usr'),
+            ('read', 'pub'),
+            ('write', 'pub')
+        )
+        # Player1 is an immortal. All of these should be True.
+        results = [True for _ in checks]
+        self.perm_checks(self.player, checks, results, self.obj1)
+
+        # Player2 is a normal player who does not own obj1.
+        results = [False, False, False, False, True, False, True, True]
+        self.perm_checks(self.player2, checks, results, self.obj1)
+
+        # Player2 is a normal player who owns obj2.
+        set_owner(self.player2, self.obj2)
+        results = [False, False, False, False, True, True, True, True]
+        self.perm_checks(self.player2, checks, results, self.obj2)

--- a/evennia/contrib/collab/typeclasses.py
+++ b/evennia/contrib/collab/typeclasses.py
@@ -1,0 +1,193 @@
+from evennia.commands import cmdset
+from evennia.contrib.collab.perms import collab_check
+from evennia.objects.objects import DefaultObject, DefaultRoom, DefaultExit, DefaultCharacter
+from evennia.players import DefaultPlayer
+from evennia.typeclasses.models import AttributeHandler, DbHolder
+
+# Separate namespaces for different attributes. Each of these classes'
+# docstrings explains their intended scope and permissions level. However,
+# the appropriate locks can be overwritten in the settings file. See
+# collab_settings.py
+from evennia.utils import lazy_property
+
+
+class WizHiddenAttributeHandler(AttributeHandler):
+    """
+    Attributes which are for wizards to read and write to, but which players
+    should not be able to see.
+
+    Examples include
+    """
+    _attrtype = 'wizh'
+
+
+class WizAttributeHandler(AttributeHandler):
+    """
+    Attributes which are accessible to wizards but which the player can
+    see.
+
+    Examples include quota overrides, values that are user-settable via
+    command but cannot be allowed to be set via the @set command, etc.
+    """
+    _attrtype = 'wiz'
+
+
+class ImmortalHiddenAttributeHandler(AttributeHandler):
+    """
+    Attributes which are more for internal accounting and/or security and
+    which should not be exposed to anyone less powerful than an immortal.
+
+    Examples include things like IP information, etc.
+
+    In most cases, the standard 'db' field will work fine for this, since
+    collab avoids touching it. However, this type provides a semantic
+    distinction, and prevents this data from being exposed should a command
+    that isn't collab-aware provide access to information on 'db'.
+    """
+    _attrtype = 'imh'
+
+
+class PublicAttributeHandler(AttributeHandler):
+    """
+    Handles attributes that are public for anyone to set or read.
+
+    These are inherently untrustworthy. They should primarily be used for
+    inconsequential storage to spruce up a room without requiring additional
+    modules. For example, a description might differ if someone has been to a
+    room before. The room could set an attribute on the user to check for this.
+    """
+    _attrtype = 'pub'
+
+
+class UserAttributeHandler(AttributeHandler):
+    """
+    Handles Attributes that are intended for the user to set on themselves.
+
+    These are publicly readable. Examples might include: description, species,
+    and sex
+    """
+    _attrtype = 'usr'
+
+
+class UserHiddenAttributeHandler(AttributeHandler):
+    """
+    Handles attributes that the user can set on themselves but which don't need
+    to be publicly readable, such as a user's inactive saved descriptions.
+    """
+    _attrtype = 'usrh'
+
+
+initializers = [WizHiddenAttributeHandler, WizAttributeHandler,
+                ImmortalHiddenAttributeHandler, PublicAttributeHandler,
+                UserAttributeHandler, UserHiddenAttributeHandler]
+
+
+class CollabBase(object):
+
+    def check_protected(self):
+        """
+        Objects may be marked as 'protected', preventing them from being
+        fiddled with by people who normally pass the bypass lock.
+        """
+        return self.imhdb.protected
+
+
+for init in initializers:
+    key = init._attrtype
+    name = init._attrtype + "attributes"
+    label = key + 'db'
+
+    # Need to be mindful of closure scoping. Names are looked up at runtime, so
+    # we need a function here to freeze the names for these functions.
+    # Note that we're doing some variable name shadowing here, taking advantage of
+    # variable scoping.
+    def make_descriptors(init, key, name, label):
+        def getter(self):
+            try:
+                return getattr(self, '_%s_holder' % key)
+            except AttributeError:
+                setattr(self, '_%s_holder' % key, DbHolder(self, name))
+                return getattr(self, '_%s_holder' % key)
+
+        def setter(self):
+            string = "Cannot assign directly to %s object! " % label
+            string += "Use %s.attr=value instead." % label
+            raise Exception(string)
+
+        def deleter(self):
+            "Stop accidental deletion."
+            raise Exception("Cannot delete the %s object!" % label)
+
+        def attributes(self):
+            return init(self)
+
+        # Needed for the lazy loader.
+        attributes.__name__ = name
+
+        return getter, setter, deleter, attributes
+
+    getter, setter, deleter, attributes = make_descriptors(init, key, name, label)
+
+    setattr(CollabBase, label, property(getter, setter, deleter))
+    setattr(CollabBase, name, lazy_property(attributes))
+
+
+class CollabObject(CollabBase, DefaultObject):
+    pass
+
+
+class CollabCharacter(CollabBase, DefaultCharacter):
+    pass
+
+
+class CollabExit(CollabBase, DefaultExit):
+    priority = -30
+
+    def create_exit_cmdset(self, exidbobj):
+        """
+        Helper function for creating an exit command set + command.
+
+        The command of this cmdset has the same name as the Exit
+        object and allows the exit to react when the player enter the
+        exit's name, triggering the movement between rooms.
+
+        Unlike the normal exit commandset, this one checks to make sure that it
+        has permission to create an exit within the container it resides.
+
+        Args:
+            exidbobj (Object): The DefaultExit object to base the command on.
+
+        """
+        if not (self.location and collab_check(self, self.location, locks=['open_exit'])):
+            return cmdset.CmdSet(None)
+
+        # create an exit command. We give the properties here,
+        # to always trigger metaclass preparations
+        cmd = self.exit_command(key=exidbobj.db_key.strip().lower(),
+                                aliases=exidbobj.aliases.all(),
+                                locks=str(exidbobj.locks),
+                                auto_help=False,
+                                destination=exidbobj.db_destination,
+                                arg_regex=r"^$",
+                                is_exit=True,
+                                obj=exidbobj)
+        # create a cmdset
+        exit_cmdset = cmdset.CmdSet(None)
+        exit_cmdset.key = '_exitset'
+        if self.wiz.exit_priority is not None:
+            priority = self.priority
+        else:
+            priority = self.wiz.exit_priority
+        exit_cmdset.priority = priority
+        exit_cmdset.duplicates = True
+        # add command to cmdset
+        exit_cmdset.add(cmd)
+        return exit_cmdset
+
+
+class CollabRoom(CollabBase, DefaultRoom):
+    pass
+
+
+class CollabPlayer(CollabBase, DefaultPlayer):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mock >= 1.0.1
 pillow == 2.9.0
 pytz
 future >= 0.15.2
+python-dateutil

--- a/win_requirements.txt
+++ b/win_requirements.txt
@@ -9,3 +9,4 @@ mock >= 1.0.1
 pillow == 2.9.0
 pytz
 future >= 0.15.2
+python-dateutil


### PR DESCRIPTION
This Pull request is the feature branch for comparison of Collab. Collab is an in-progress feature of Evennia that will allow public building. The default Evennia building commands assume builders are trusted. Collab assumes they are untrusted, and that anyone may build. Instructions for adding Collab to one's game are present in `collab_settings.py`.

Collab comes with its own permissions checking model that piggybacks on the existing locks and tags systems to create a concept of object ownership. Objects can have both a 'true owner', the player that created them, and a 'display owner'-- the character object that created them. This allows a layer of hiding between characters and players so that alts are not immediately revealed, a feature often important in games like these.

Collab provides a set of base collaborative typeclasses, as well as a 'collab mixin' that performs the meat of what these typeclasses do. The Collab typeclasses expose an interface of attribute handlers that are scoped to permission. For example, .usr is a version of 'db' that has a few indicative lock functions you can check against in the collab settings module. For an example of how this works, and what conventions should be presented to the user for setting attributes via these handlers, see the `@set` command.

Collab comes with its own implementation of the build commands. These are the meat of the PR at current, and a few are left to be implemented.

This PR **MUST** be highly tested. Several tests are already written, and tests need to be written for every feature. Full coverage, or as close as possible, must be maintained, as this feature is **designed to take abuse**.

**Workflow notes:** This PR is frequently rebased against master, and often commits are squashed. If anyone other than @Kelketek contributes a PR against this one, their commits may be reorganized in rebase slightly. At the moment, the current five commits keep getting squashed into by new code, but in order to give credit, outside commits won't be squashed into his existing commits (without permission).

This feature is a long work in progress, and notes are welcome on architecture, bugs, documentation, or anything that may help it mature and be ready for inclusion in the master branch.