### PR TITLE
CmdHelp Aesthetic Improvement

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -29,12 +29,12 @@ def format_help_entry(title, help_text, aliases=None, suggested=None):
     if title:
         string += "{CHelp topic for {w%s{n" % title
     if aliases:
-        string += " {C(aliases: {w%s{n{C){n" % (", ".join(aliases))
+        string += " {C(aliases: {w%s{n{C){n" % ("{C,{n ".join(aliases))
     if help_text:
         string += "\n%s" % dedent(help_text.rstrip())
     if suggested:
         string += "\n\n{CSuggested:{n "
-        string += "{w%s{n" % fill(", ".join(suggested))
+        string += "{w%s{n" % fill("{C,{n ".join(suggested))
     string.strip()
     string += "\n" + _SEP
     return string


### PR DESCRIPTION
Color Cyan the comma in Cmd aliases and suggestions...
When Help lists aliases and suggestions, text is cyan except for aliases and suggested commands (which are white). The separating commas are also white; I've turned them cyan because it's better in separating items from output, and its more consistent.

Nothing big, but something I though worth to implement in my own game.