### PR TITLE
Typos correction in `contrib` folder

### DIFF
--- a/evennia/contrib/email_login.py
+++ b/evennia/contrib/email_login.py
@@ -167,7 +167,7 @@ class CmdUnconnectedCreate(MuxCommand):
             session.msg(string)
             return
         if not re.findall('^[\w. @+-]+$', playername) or not (0 < len(playername) <= 30):
-            session.msg("\n\r Playername can max be 30 characters or fewer. Letters, spaces, dig\
+            session.msg("\n\r Playername can be max 30 characters, or less. Letters, spaces, dig\
 its and @/./+/-/_ only.") # this echoes the restrictions made by django's auth module.
             return
         if not email or not password:

--- a/evennia/contrib/extended_room.py
+++ b/evennia/contrib/extended_room.py
@@ -91,7 +91,7 @@ REGEXMAP = {"morning": (RE_MORNING, RE_AFTERNOON, RE_EVENING, RE_NIGHT),
 
 # set up the seasons and time slots. This assumes gametime started at the
 # beginning of the year (so month 1 is equivalent to January), and that
-# one CAN divive the game's year into four seasons in the first place ...
+# one CAN divide the game's year into four seasons in the first place ...
 MONTHS_PER_YEAR = settings.TIME_MONTH_PER_YEAR
 SEASONAL_BOUNDARIES = (3 / 12.0, 6 / 12.0, 9 / 12.0)
 HOURS_PER_DAY = settings.TIME_HOUR_PER_DAY
@@ -329,7 +329,7 @@ class CmdExtendedDesc(default_cmds.CmdDesc):
     Text marked this way will only display when the server is truly at the given
     timeslot. The available times are night, morning, afternoon and evening.
 
-    Note that `@detail`, seasons and time-of-day slots only works on rooms in this
+    Note that `@detail`, seasons and time-of-day slots only work on rooms in this
     version of the `@desc` command.
 
     """
@@ -419,9 +419,9 @@ class CmdExtendedDesc(default_cmds.CmdDesc):
                 else:
                     text = self.args
                     obj = location
-                obj.db.desc = self.rhs # a compatability fallback
+                obj.db.desc = self.rhs # a compatibility fallback
                 if utils.inherits_from(obj, ExtendedRoom):
-                    # this is an extendedroom, we need to reset
+                    # this is an extended room, we need to reset
                     # times and set general_desc
                     obj.db.general_desc = text
                     self.reset_times(obj)

--- a/evennia/contrib/menusystem.py
+++ b/evennia/contrib/menusystem.py
@@ -6,7 +6,7 @@ Contribution - Griatch 2011
 This module offers the ability for admins to let their game be fully
 or partly menu-driven. Menu choices can be numbered or use arbitrary
 keys. There are also some formatting options, such a putting options
-in one or more collumns.
+in one or more columns.
 
 The menu system consists of a MenuTree object populated by MenuNode
 objects. Nodes are linked together with automatically created commands
@@ -79,7 +79,7 @@ class CmdMenuLook(default_cmds.CmdLook):
 
     This is a Menu version of the look command. It will normally show
     the options available, otherwise works like the normal look
-    command..
+    command.
     """
     key = "look"
     aliases = ["l", "ls"]
@@ -171,7 +171,7 @@ class MenuTree(object):
         """
         We specify startnode/endnode so that the system knows where to
         enter and where to exit the menu tree. If nodes is given, it
-        shuld be a list of valid node objects to add to the tree.
+        should be a list of valid node objects to add to the tree.
 
         exec_end - if not None, will execute the given command string
                    directly after the menu system has been exited.
@@ -332,7 +332,7 @@ class MenuNode(object):
         if text:
             string += "%s\n" % text
 
-        # format the choices into as many collumns as specified
+        # format the choices into as many columns as specified
         choices = []
         for ilink, link in enumerate(self.links):
             choice = ""
@@ -480,14 +480,14 @@ def prompt_yesno(caller, question="", yesfunc=None, nofunc=None, yescode="", noc
 def prompt_choice(caller, question="", prompts=None, choicefunc=None, force_choose=False):
     """
     This sets up a simple choice questionnaire. Question will be
-    asked, followed by a serie of prompts. Note that this isn't
+    asked, followed by a series of prompts. Note that this isn't
     making use of the menu node system.
 
     caller - the object calling and being offered the choice
     question - text describing the offered choice
     prompts - list of choices
     choicefunc - functions callback to be called as func(self) when
-                 make choice (self.caller is available) The function's definision
+                 make choice (self.caller is available) The function's definition
                  should be like func(self, menu_node), and menu_node.key is user's
                  choice.
     force_choose - force user to make a choice or not
@@ -553,7 +553,7 @@ def prompt_choice(caller, question="", prompts=None, choicefunc=None, force_choo
     choicecmdset.add(CmdMenuLook())
     choicecmdset.add(CmdMenuHelp())
 
-    # assinging menu data flags to caller.
+    # assigning menu data flags to caller.
     caller.db._menu_data = {"help": "Please select.",
                             "look": prompt}
 

--- a/evennia/contrib/tutorial_examples/bodyfunctions.py
+++ b/evennia/contrib/tutorial_examples/bodyfunctions.py
@@ -1,6 +1,6 @@
 """
 Example script for testing. This adds a simple timer that
-has your character make observations and noices at irregular
+has your character make observations and notices at irregular
 intervals.
 
 To test, use

--- a/evennia/contrib/tutorial_examples/example_batch_cmds.ev
+++ b/evennia/contrib/tutorial_examples/example_batch_cmds.ev
@@ -10,8 +10,8 @@
 # marks the end of a previous command definition (important!).
 #
 # All supplied commands are given as normal, on their own line
-# and accepts arguments in any format up until the first next
-# comment line  begins. Extra whitespace is removed; an empty
+# and accept arguments in any format up until the first next
+# comment line begins. Extra whitespace is removed; an empty
 # line in a command definition translates into a newline.
 #
 
@@ -43,10 +43,10 @@ know you want to!
 # in the argument are not considered. A completely empty line
 # translates to a \n newline in the command; two empty lines will thus
 # create a new paragraph. (note that few commands support it though, you
-# mainly want to use it for descriptions)
+# mainly want to use it for descriptions).
 
 # Now let's place the button where it belongs (let's say limbo #2 is
-# the evil lair in our example)
+# the evil lair in our example).
 
 @teleport #2
 

--- a/evennia/contrib/tutorial_examples/example_batch_code.py
+++ b/evennia/contrib/tutorial_examples/example_batch_code.py
@@ -2,9 +2,9 @@
 # Batchcode script
 #
 #
-# The Batch-code processor accepts full python modules (e.g. "batch.py") that
-# looks identical to normal Python files with a few exceptions that allows them
-# to the executed in blocks. This way of working assures a sequential execution
+# The Batch-code processor accepts full Python modules (e.g. "batch.py") that
+# look identical to normal Python files with a few exceptions that allows them
+# to be executed in blocks. This way of working assures a sequential execution
 # of the file and allows for features like stepping from block to block
 # (without executing those coming before), as well as automatic deletion
 # of created objects etc. You can however also run a batch-code python file
@@ -15,13 +15,13 @@
 # #HEADER - this denotes commands global to the entire file, such as
 #           import statements and global variables. They will
 #           automatically be made available for each block.  Observe
-#           that changes to these variables made in one block is not
+#           that changes to these variables made in one block are not
 #           preserved between blocks!)
 # #CODE (infotext) [objname, objname, ...] - This designates a code block that
 #            will be executed like a stand-alone piece of code together with
 #            any #HEADER defined.
-#            infotext is a describing text about what goes in in this block.
-#            It will be shown by the batchprocessing command.
+#            infotext is a describing text about what goes on in this block.
+#            It will be shown by the batch-processing command.
 #            <objname>s mark the (variable-)names of objects created in
 #            the code, and which may be auto-deleted by the processor if
 #            desired (such as when debugging the script). E.g., if the code
@@ -54,7 +54,7 @@ limbo = search_object('Limbo')[0]
 
 #CODE (create red button)
 
-# This is the first code block. Within each block, python
+# This is the first code block. Within each block, Python
 # code works as normal. Note how we make use if imports and
 # 'limbo' defined in the #HEADER block. This block's header
 # offers no information about red_button variable, so it
@@ -75,7 +75,7 @@ caller.msg("A %s was created." % red_button.key)
 # again (so as to avoid duplicate objects when testing the script many
 # times).
 
-# the python variables we assign to must match the ones given in the
+# the Python variables we assign to must match the ones given in the
 # header for the system to be able to delete them afterwards during a
 # debugging run.
 table = create_object(DefaultObject, key="Table", location=limbo)

--- a/evennia/contrib/tutorial_world/README.md
+++ b/evennia/contrib/tutorial_world/README.md
@@ -26,7 +26,7 @@ the tutorial as intended.
 
 ## Comments
 
-The tutorial world is intended for you playing around with the engine.
+The tutorial world is intended for your playing around with the engine.
 It will help you learn how to accomplish some more advanced effects
 and might give some good ideas along the way.
 
@@ -88,13 +88,13 @@ tutorial game**
 * The Cliff is a good place to get an overview of the surroundings.
 * The Bridge may seem like a big room, but it is really only one room
   with custom move commands to make it take longer to cross. You can
-  also fall off the bridge if youare unlucky or take your time to
+  also fall off the bridge if you are unlucky or take your time to
   take in the view too long.
 * In the Castle areas an aggressive mob is patrolling. It implements
   rudimentary AI but packs quite a punch unless you have
   found yourself a weapon that can harm it. Combat is only
   possible once you find a weapon.
-* The Antechamber feature a puzzle for finding the correct Grave
+* The Antechamber features a puzzle for finding the correct Grave
   chamber.
 * The Cell  is your reward if you fail in various ways. Finding a
   way out of it is a small puzzle of its own.

--- a/evennia/contrib/tutorial_world/rooms.py
+++ b/evennia/contrib/tutorial_world/rooms.py
@@ -28,12 +28,12 @@ _SEARCH_AT_RESULT = utils.object_from_module(settings.SEARCH_AT_RESULT)
 #
 # This room is the parent of all rooms in the tutorial.
 # It defines a tutorial command on itself (available to
-# all who is in a tutorial room).
+# all those who are in a tutorial room).
 #
 #------------------------------------------------------------
 
 #
-# Special command avaiable in all tutorial rooms
+# Special command available in all tutorial rooms
 #
 
 class CmdTutorial(Command):
@@ -301,7 +301,7 @@ class WeatherRoom(TutorialRoom):
         We set up a ticker to update this room regularly.
 
         Note that we could in principle also use a Script to manage
-        the ticking of the room, the TickerHandler is works fine for
+        the ticking of the room; the TickerHandler works fine for
         simple things like this though.
         """
         super(WeatherRoom, self).at_object_creation()
@@ -380,10 +380,10 @@ class IntroRoom(TutorialRoom):
 #
 # Bridge - unique room
 #
-# Defines a special west-eastward "bridge"-room, a large room it takes
+# Defines a special west-eastward "bridge"-room, a large room that takes
 # several steps to cross. It is complete with custom commands and a
 # chance of falling off the bridge. This room has no regular exits,
-# instead the exiting are handled by custom commands set on the player
+# instead the exitings are handled by custom commands set on the player
 # upon first entering the room.
 #
 # Since one can enter the bridge room from both ends, it is


### PR DESCRIPTION
Some typos in docstrings, comments and user-output strings.

Please note: in example_batch_code.py (10-11):
```python
# of created objects etc. You can however also run a batch-code python file
# directly using Python (and can also be de).
```
`can also be de`?? something missing here! Couldn't correct that because I have no clue what it's missing.

Also, at 31-35:
```python
# #INSERT filename - this includes another code batch file. The named file will
#            be loaded and run at this point. Note that code from the inserted
#            file will NOT share #HEADERs with the importing file, but will
#            only use the headers in the importing file. Make sure to not
#            create a cyclic import here!
```
Is not too clear: is it (1) the imported file doesn't share its headers with the importing file; or (2) the imported file doesn't have access to the importing file's headers; or (3) the imported file doesn't share its headers with the importing file but will make use of the importing file's header.
This sentence could be made simpler and clearer (in my opinion).

