### PR TITLE
Typo in create_exit_cmdset docstring.

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1525,7 +1525,7 @@ class DefaultExit(DefaultObject):
         command handler. If changes need to be done on the fly to the
         cmdset before passing them on to the cmdhandler, this is the
         place to do it. This is called also if the object currently
-        have no cmdsets.
+        has no cmdsets.
 
         Kwargs:
           force_init (bool): If `True`, force a re-build of the cmdset

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1132,8 +1132,8 @@ class DefaultObject(ObjectDB):
         normally by calling
         `traversing_object.move_to(target_location)`. It is normally
         only implemented by Exit objects. If it returns False (usually
-        because move_to returned False), at_after_traverse below
-        should not be called and instead at_failed_traverse should be
+        because move_to returned False), `at_after_traverse` below
+        should not be called and instead `at_failed_traverse` should be
         called.
 
         Args:

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1452,7 +1452,7 @@ class DefaultExit(DefaultObject):
         exit's name, triggering the movement between rooms.
 
         Args:
-            exiddobj (Object): The DefaultExit object to base the command on.
+            exidbobj (Object): The DefaultExit object to base the command on.
 
         """
         class ExitCommand(command.Command):

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1132,7 +1132,7 @@ class DefaultObject(ObjectDB):
         normally by calling
         `traversing_object.move_to(target_location)`. It is normally
         only implemented by Exit objects. If it returns False (usually
-        because move_to returned False), `at_after_traverse` below
+        because `move_to` returned False), `at_after_traverse` below
         should not be called and instead `at_failed_traverse` should be
         called.
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -130,7 +130,7 @@ class DefaultObject(ObjectDB):
     It is recommended to create children of this class using the
     `evennia.create_object()` function rather than to initialize the class
     directly - this will both set things up and efficiently save the object
-    without obj.save() having to be called explicitly.
+    without `obj.save()` having to be called explicitly.
 
     """
     # typeclass setup


### PR DESCRIPTION
Just a typo in the docstring of `create_exit_cmdset()` in module `evennia\objects\objects.py`