### PR TITLE
ignore Windows files generated during setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ nosetests.xml
 
 # PyCharm config
 .idea
+
+# Windows files generated during setup
+bin/windows/evennia.bat
+evennia/server/twistd.bat
+


### PR DESCRIPTION
Add evennia.bat and twistd.bat to gitignore. Both are generated on Windows during the setup process.