### PR TITLE
@lock typo fix and added note about apostrophes in help

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1654,7 +1654,7 @@ class CmdLock(ObjManipCommand):
     object.
 
     Lockstring is on the form
-       'access_type:[NOT] func1(args)[ AND|OR][ NOT] func2(args) ...]
+       'access_type:[NOT] func1(args)[ AND|OR][ NOT] func2(args) ...]'
     Where func1, func2 ... valid lockfuncs with or without arguments.
     Separator expressions need not be capitalized.
 
@@ -1667,6 +1667,11 @@ class CmdLock(ObjManipCommand):
     You can add several access_types after oneanother by separating
     them by ';', i.e:
        'get:id(25);delete:perm(Builders)'
+       
+    Note:
+    Please keep in mind that although the command will take commands
+    in apostrophes ('') and it will not affect the functionality, it
+    will make the locks harder to read and break the lockstring order.
     """
     key = "@lock"
     aliases = ["@locks", "lock", "locks"]


### PR DESCRIPTION
Added a missing apostrophe to the end of lockstring form line.

Added a note about the use of apostrophes when passing the lockstring to the command.