### PR TITLE
Added {u to the ansi parser for underlining text.

### DIFF
--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -592,7 +592,7 @@ class CmdColorTest(MuxPlayerCommand):
                 string += "\n " + " ".join(row)
             #print string
             self.msg(string)
-            self.msg("{{X : black. {{/ : return, {{- : tab, {{_ : space, {{* : invert")
+            self.msg("{{X : black. {{/ : return, {{- : tab, {{_ : space, {{* : invert, {{u : underline")
             self.msg("To combine background and foreground, add background marker last, e.g. {{r{{[b.")
 
         elif self.args.startswith("x"):

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -252,6 +252,7 @@ class ANSIParser(object):
         (r'{_', ANSI_SPACE),           # space
         (r'{*', ANSI_INVERSE),        # invert
         (r'{^', ANSI_BLINK),          # blinking text (very annoying and not supported by all clients)
+        (r'{u', ANSI_UNDERLINE),       # underline
 
         (r'{r', hilite + ANSI_RED),
         (r'{g', hilite + ANSI_GREEN),


### PR DESCRIPTION
Description of the suggested feature and how it is supposed to work for the admin/end user:

On MUX, one can use %cu, and on Penn, one can use [ansi(u, ... )] to underline selected text. On Evennia, one would theoretically use {u to underline text but it is not implemented.

A list of arguments for why you think this new feature should be included in Evennia:

Feature compatability with MUX/Penn
Ability to create cleaner-looking tables and headers for those not using xterm256.
Extra information, such as requirements or ideas on implementation:

After doing some digging around in the code, I noticed that ANSI_UNDERLINE is defined in utils/ansi.py, but it is never used. All I had to do to get this to work was add the appropriate map to ext_ansi_map on line 255: (r'{u', ANSI_UNDERLINE), and I was able to implement this feature on my home game.

One would also want to modify the default 'color ansi' command to show this feature as well