### PR TITLE
Edge case bug w/ Multisession_mode!= 0 on Evennia initial_setup.py

### DIFF
--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -83,10 +83,12 @@ class CmdOOCLook(MuxPlayerCommand):
         sessid = self.sessid
         # get all our characters and sessions
         characters = player.db._playable_characters
-        if None in characters:
-            # clean up list if character object was deleted in between
-            characters = [character for character in characters if character]
-            player.db._playable_characters = characters
+
+        if characters is not None:
+            if None in characters:
+                # clean up list if character object was deleted in between
+                characters = [character for character in characters if character]
+                player.db._playable_characters = characters
 
         sessions = player.get_all_sessions()
         is_su = player.is_superuser

--- a/evennia/server/initial_setup.py
+++ b/evennia/server/initial_setup.py
@@ -105,7 +105,11 @@ def create_objects():
 
     god_player.attributes.add("_first_login", True)
     god_player.attributes.add("_last_puppet", god_character)
-    god_player.db._playable_characters.append(god_character)
+
+    try:
+        god_player.db._playable_characters.append(god_character)
+    except AttributeError:
+        pass
 
     room_typeclass = settings.BASE_ROOM_TYPECLASS
     limbo_obj = create.create_object(room_typeclass, _('Limbo'), nohome=True)


### PR DESCRIPTION
Fix for NoneType exceptions when initial_setup.py is run where multisession_mode is not set to 0. To replicate:
1) Set up a new mygame
2) In the mygame folder conf/settings.py, set MULTISESSION_MODE = 3
3) run evennia start
3.5) It'll ask you to make a super user
4) Exceptions, Mister Anderson!

Note the same error for line 108, 111 (of original code), respectively.

![error 1](https://cloud.githubusercontent.com/assets/5124742/9422535/e47d01ba-4853-11e5-93cc-2702072bb150.gif)
![error 2](https://cloud.githubusercontent.com/assets/5124742/9422536/e47fc85a-4853-11e5-9752-6ea21fc1a911.gif)

