### PR TITLE
Make evennia -i block until process is closed. Fixes #803.

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1033,7 +1033,9 @@ def server_operation(mode, service, interactive, profiler):
             GAMEDIR, TWISTED_BINARY, SERVER_LOGFILE,
             PORTAL_LOGFILE, HTTP_LOGFILE])
         # start the server
-        Popen(cmdstr, env=getenv())
+        process = Popen(cmdstr, env=getenv())
+        if interactive:
+            process.wait()
 
     elif mode == 'reload':
         # restarting services


### PR DESCRIPTION
SIGINT handling will need some more work, but this will at least restore interactive mode to being interactive (which is critical for production deployments under a process supervisor like upstart, systemd, supervisor, etc). 