### PR TITLE
Printing traces to the user is usually bad.

### DIFF
--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -140,8 +140,7 @@ class CmdUnconnectedConnect(MuxCommand):
                     # We are in the middle between logged in and -not, so we have
                     # to handle tracebacks ourselves at this point. If we don't,
                     # we won't see any errors at all.
-                    string = "%s\nThis is a bug. Please e-mail an admin if the problem persists."
-                    session.msg(string % (traceback.format_exc()))
+                    session.msg("An error occurred. Please e-mail an admin if the problem persists.")
                     logger.log_errmsg(traceback.format_exc())
                 finally:
                     return
@@ -287,8 +286,7 @@ class CmdUnconnectedCreate(MuxCommand):
             # We are in the middle between logged in and -not, so we have
             # to handle tracebacks ourselves at this point. If we don't,
             # we won't see any errors at all.
-            string = "%s\nThis is a bug. Please e-mail an admin if the problem persists."
-            session.msg(string % (traceback.format_exc()))
+            session.msg("An error occurred. Please e-mail an admin if the problem persists.")
             logger.log_errmsg(traceback.format_exc())
 
 

--- a/evennia/contrib/email_login.py
+++ b/evennia/contrib/email_login.py
@@ -257,8 +257,7 @@ its and @/./+/-/_ only.") # this echoes the restrictions made by django's auth m
             # We are in the middle between logged in and -not, so we have
             # to handle tracebacks ourselves at this point. If we don't,
             # we won't see any errors at all.
-            string = "%s\nThis is a bug. Please e-mail an admin if the problem persists."
-            session.msg(string % (traceback.format_exc()))
+            session.msg("An error occurred. Please e-mail an admin if the problem persists.")
             logger.log_errmsg(traceback.format_exc())
 
 class CmdUnconnectedQuit(MuxCommand):

--- a/evennia/contrib/menu_login.py
+++ b/evennia/contrib/menu_login.py
@@ -235,8 +235,7 @@ class CmdPasswordCreate(Command):
             # We are in the middle between logged in and -not, so we have
             # to handle tracebacks ourselves at this point. If we don't, we
             # won't see any errors at all.
-            string = "%s\nThis is a bug. Please e-mail an admin if the problem persists."
-            self.caller.msg(string % (traceback.format_exc()))
+            self.caller.msg("An error occurred. Please e-mail an admin if the problem persists."
             logger.log_errmsg(traceback.format_exc())
 
 


### PR DESCRIPTION
This could, in theory, expose more information about how the server
works than would be advised, benefiting potential attackers.