### PR TITLE
at_post_puppet should be called after cache_lock_bypass.

### DIFF
--- a/evennia/players/players.py
+++ b/evennia/players/players.py
@@ -244,10 +244,10 @@ class DefaultPlayer(with_metaclass(TypeclassBase, PlayerDB)):
         # validate/start persistent scripts on object
         obj.scripts.validate()
 
-        obj.at_post_puppet()
-
         # re-cache locks to make sure superuser bypass is updated
         obj.locks.cache_lock_bypass(obj)
+
+        obj.at_post_puppet()
 
     def unpuppet_object(self, sessid):
         """


### PR DESCRIPTION
at_post_puppet does a look, which results in a perms check, which is wrong
for the superuser because the lock bypass is not up to date.