### PR TITLE
fixed login error for multisession_mode = 2

### DIFF
--- a/evennia/players/players.py
+++ b/evennia/players/players.py
@@ -709,7 +709,8 @@ class DefaultPlayer(with_metaclass(TypeclassBase, PlayerDB)):
         elif _MULTISESSION_MODE in (2, 3):
             # In this mode we by default end up at a character selection
             # screen. We execute look on the player.
-            self.msg(self.at_look(session=session))
+            self.msg(self.at_look(target=self.db._playable_characters,
+                                  session=session))
 
     def at_failed_login(self, session):
         """
@@ -794,8 +795,8 @@ class DefaultPlayer(with_metaclass(TypeclassBase, PlayerDB)):
             # single target - just show it
             return target.return_appearance()
         else:
-            # list of targets - make list
-            characters = target
+            # list of targets - make list to disconnect from db
+            characters = list(target)
             sessions = self.sessions.all()
             is_su = self.is_superuser
 


### PR DESCRIPTION
This PR addresses Issue #907. The problem was that the `at_look` hook was being called within `at_post_login` with target=None. Modified this to pass in the player's db._playable_characters attribute. 

This revealed a second problem, where the messaging would indicate there were characters, even with an empty character list. This happens because an empty _StorageList cast as boolean evaluates to True. Addressed this by using list() to disconnect the attribute from the db.