### PR TITLE
Update utils.py

### DIFF
--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -299,7 +299,9 @@ def time_format(seconds, style=0):
         """
         Full-detailed, long-winded format. We ignore seconds.
         """
-        days_str = hours_str = minutes_str = seconds_str = ''
+        days_str = hours_str = ''
+        minutes_str = '0 minutes'
+        
         if days > 0:
             if days == 1:
                 days_str = '%i day, ' % days


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The changes merely adds a default value to be returned in the fringe case of calling for a formatted time period under 60 seconds in style 2. The default is set as "0 minutes".

Whilst there I discovered the variable "seconds_str" was defined but never used. It appears to be a result of copy and pasting as the code is used a number of times. That was removed.

#### Motivation for adding to Evennia
Currently, the time_format style 2 does not allow for time periods under 60 seconds. When used for such a time period it would merely return an empty string, i.e. ''. At first I believed this to be a bug in my code. The change means it would now return "0 minutes" if the time period passed to it is below 60 seconds.

#### Other info (issues closed, discussion etc)

Changes only effect time_format.
Line 302 - Removed seconds_str. Superfluous.
Line 303 - Provides minutes_str a default value which remains if value is below lowest descriptor. Previously if seconds was below a minute style 2 would return absolutely nothing.