### PR TITLE
@Cemit/sendername not functioning

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -441,7 +441,7 @@ class CmdCemit(MuxPlayerCommand):
             return
         message = self.rhs
         if "sendername" in self.switches:
-            message = "%s: %s" % (self.key, message)
+            message = "%s: %s" % (self.caller.key, message)
         channel.msg(message)
         if not "quiet" in self.switches:
             string = "Sent to channel %s: %s" % (channel.key, message)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Located by BlauFeuer

Instead of broadcasting players name (self.caller.key) it sends "@cemit" (self.key)

#### Motivation for adding to Evennia

Does not operate as intended.

#### Other info (issues closed, discussion etc)

if "sendername" in self.switches:
            message = "%s: %s" % (self.key, message)

Should read: message = "%s: %s" % (self.caller.key, message)

Not functioning as intended. Credit goes to BlauFeuer.