### PR TITLE
Removed 'self' from _get_mysql_db_version()

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -36,7 +36,7 @@ __all__ = ("to_pickle", "from_pickle", "do_pickle", "do_unpickle",
 
 PICKLE_PROTOCOL = 2
 
-def _get_mysql_db_version(self):
+def _get_mysql_db_version():
     """
     This is a helper method for specifically getting the version
     string of a MySQL database.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
There was an error when checking for mysql version, so I removed `self` from `_get_mysql_db_vesion(self)`, as it is not in an object.

File modified: `evennia/utils/dbserialize.py`


