### PR TITLE
Fix for Issue #981

### DIFF
--- a/evennia/contrib/extended_room.py
+++ b/evennia/contrib/extended_room.py
@@ -287,7 +287,10 @@ class CmdExtendedLook(default_cmds.CmdLook):
         caller = self.caller
         args = self.args
         if args:
-            looking_at_obj = caller.search(args, use_nicks=True, quiet=True)
+            looking_at_obj = caller.search(args,
+                                           candidates=caller.location.contents + caller.contents,
+                                           use_nicks=True,
+                                           quiet=True)
             if not looking_at_obj:
                 # no object found. Check if there is a matching
                 # detail at location.
@@ -299,7 +302,7 @@ class CmdExtendedLook(default_cmds.CmdLook):
                         caller.msg(detail)
                         return
                 # no detail found. Trigger delayed error messages
-                _AT_SEARCH_RESULT(caller, args, looking_at_obj, False)
+                _AT_SEARCH_RESULT(looking_at_obj, caller, args, quiet=False)
                 return
             else:
                 # we need to extract the match manually.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

* Fixed nonexistent detail error by correcting the order of arguments to `_AT_SEARCH_RESULT`.
* Fixed room/detail key collisions by excluding caller.location from candidates.

#### Motivation for adding to Evennia

Fixes bugs in the ExtendedLook command behavior associated with the extended_room contrib module.

#### Other info (issues closed, discussion etc)

Addresses Issue #981