### PR TITLE
#INSERT in batchcommands, issue #984

### DIFF
--- a/evennia/utils/batchprocessors.py
+++ b/evennia/utils/batchprocessors.py
@@ -274,7 +274,7 @@ class BatchCommandProcessor(object):
 
         def replace_insert(match):
             "Map replace entries"
-            return "\#\n".join(self.parse_file(match.group(1)))
+            return "\n#".join(self.parse_file(match.group(1)))
 
         # insert commands from inserted files
         text = RE_INSERT.sub(replace_insert, text)


### PR DESCRIPTION
* changed string to add newlines upon insert of batchcommand file fixes #984

Previously an `#INSERT` of batchcommands did not separate individual commands in 
the inserting batchcommand file. 