### PR TITLE
Bug: when calling create_script on a script that had kwargs set as de…

### DIFF
--- a/evennia/utils/create.py
+++ b/evennia/utils/create.py
@@ -180,13 +180,13 @@ def create_script(typeclass=None, key=None, obj=None, player=None, locks=None,
 
     # validate input
     kwarg = {}
-    if key: kwarg["db_key"] = key
+    kwarg["db_key"] = key if key else typeclass.key if typeclass.key else None
     if player: kwarg["db_player"] = dbid_to_obj(player, _ScriptDB)
     if obj: kwarg["db_obj"] = dbid_to_obj(obj, _ScriptDB)
-    if interval: kwarg["db_interval"] = interval
-    if start_delay: kwarg["db_start_delay"] = start_delay
-    if repeats: kwarg["db_repeats"] = repeats
-    if persistent: kwarg["db_persistent"] = persistent
+    kwarg["db_interval"] = interval if interval else typeclass.interval if typeclass.interval else None
+    kwarg["db_start_delay"] = start_delay if start_delay else typeclass.start_delay if typeclass.start_delay else None
+    kwarg["db_repeats"] = repeats if repeats else typeclass.repeats if typeclass.repeats else None
+    kwarg["db_persistent"] = persistent if persistent else typeclass.persistent if typeclass.persistent else None
 
     # create new instance
     new_script = typeclass(**kwarg)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)

…fault/globals on the class, create_script would override them even when no kwargs were specified in the command. Code now checks to see if there's a create_script kwargs override and if that doesn't exist, it tries to pull the default from the typeclass global itself.