### PR TITLE
Added unicode to list of permitted types for db_value in AttributeAdmin.

### DIFF
--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -64,7 +64,7 @@ class AttributeAdmin(ModelAdmin):
     """
     search_fields = ('db_key', 'db_strvalue', 'db_value')
     list_display = ('db_key', 'db_strvalue', 'db_value')
-    permitted_types = ('str', 'int', 'float', 'NoneType', 'bool')
+    permitted_types = ('str', 'unicode', 'int', 'float', 'NoneType', 'bool')
 
     fields = ('db_key', 'db_value', 'db_strvalue', 'db_category',
               'db_lock_storage', 'db_model', 'db_attrtype')


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Small fix of letting unicode strings be editable in AttributeAdmin.


