### PR TITLE
Fixed EvMenu error when caller does not have a player attribute

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -234,18 +234,19 @@ class CmdEvMenuNode(Command):
             if _restore(caller):
                 return
             orig_caller = caller
-            caller = caller.player
-            menu = caller.ndb._menutree
-            if not menu:
-                if _restore(caller):
-                    return
-                caller = self.session
+            if hasattr(caller, 'player'):
+                caller = caller.player
                 menu = caller.ndb._menutree
                 if not menu:
-                    # can't restore from a session
-                    err = "Menu object not found as %s.ndb._menutree!" % (orig_caller)
-                    orig_caller.msg(err)
-                    raise EvMenuError(err)
+                    if _restore(caller):
+                        return
+            caller = self.session
+            menu = caller.ndb._menutree
+            if not menu:
+                # can't restore from a session
+                err = "Menu object not found as %s.ndb._menutree!" % (orig_caller)
+                orig_caller.msg(err)
+                raise EvMenuError(err)
 
         # we have a menu, use it.
         menu._input_parser(menu, self.raw_string, caller)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added a check that the caller has a `player` property before attempting to access it.

#### Motivation for adding to Evennia

This issue has completely broken chargen in Ainneve.

#### Other info (issues closed, discussion etc)

Addresses issue #1042. 