### PR TITLE
rpsystem.py minor fixes to CmdEmote (issue #1052)

### DIFF
--- a/evennia/contrib/rpsystem.py
+++ b/evennia/contrib/rpsystem.py
@@ -791,8 +791,7 @@ class CmdEmote(RPCommand):  # replaces the main emote
             self.caller.msg("What do you want to do?")
         else:
             # we also include ourselves here.
-            emote = self.args.replace('{', '{{')  # Escape open curly brace in later formatting.
-            emote = emote.replace('}', '}}')  # Also escape close curly brace.
+            emote = self.args
             targets = self.caller.location.contents
             if not emote.endswith((".", "?", "!")):  # If emote is not punctuated,
                 emote = "%s." % emote  # add a full-stop for good measure.

--- a/evennia/contrib/rpsystem.py
+++ b/evennia/contrib/rpsystem.py
@@ -791,10 +791,11 @@ class CmdEmote(RPCommand):  # replaces the main emote
             self.caller.msg("What do you want to do?")
         else:
             # we also include ourselves here.
-            emote = self.args
+            emote = self.args.replace('{', '{{')  # Escape open curly brace in later formatting.
+            emote = emote.replace('}', '}}')  # Also escape close curly brace.
             targets = self.caller.location.contents
-            if not emote.endswith((".", "!")):
-                emote = "%s." % emote
+            if not emote.endswith((".", "?", "!")):  # If emote is not punctuated,
+                emote = "%s." % emote  # add a full-stop for good measure.
             send_emote(self.caller, targets, emote, anonymous_add='first')
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fix for traceback when emoting curly braces in RP System contrib
Fix for full-stop being added even when emote ended with question mark.

#### Motivation for adding to Evennia

Emote might contain `{` or `}` and should not cause traceback if so.  Issue #1052
Emote might terminate with `?` and should not have full-stop added if so.


#### Other info (issues closed, discussion etc)

+Escape curly braces in emote
+Check for ? as ending punctuation before adding full-stop