### PR TITLE
Attempt to fix aliases for channels not working (#1038)

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -800,9 +800,9 @@ class NickHandler(AttributeHandler):
 
         """
         if category == "channel":
-            key += " $1"
-            replacement += " $1"
-        nick_regex, nick_template = initialize_nick_templates(key, replacement)
+            nick_regex, nick_template = initialize_nick_templates(key + " $1", replacement + " $1")
+        else:
+            nick_regex, nick_template = initialize_nick_templates(key, replacement)
         super(NickHandler, self).add(key, (nick_regex, nick_template, key, replacement), category=category, **kwargs)
 
     def remove(self, key, category="inputline", **kwargs):

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -799,6 +799,9 @@ class NickHandler(AttributeHandler):
             kwargs (any, optional): These are passed on to `AttributeHandler.get`.
 
         """
+        if category == "channel":
+            key += " $1"
+            replacement += " $1"
         nick_regex, nick_template = initialize_nick_templates(key, replacement)
         super(NickHandler, self).add(key, (nick_regex, nick_template, key, replacement), category=category, **kwargs)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
So from what I was able to gather, when the nickname/alias was added for the channel, it didn't follow the template format specified, and was just adding the nickname/channel keys. In order to function, they need to have '$1' to specify that they take arguments. As a note, I tried using '*' initially first for both of them, but that doesn't build allowed arguments in the outgoing template, so wouldn't work.

I couldn't figure out why this was a problem specific to channel commands, so the category check for channels probably isn't the best way of doing things. It does seem to work when I tested it, but I'm going to guess there's a better way of doing this.

