### PR TITLE
This fixes channel aliases not working while in an OOC state.

### DIFF
--- a/evennia/server/inputfuncs.py
+++ b/evennia/server/inputfuncs.py
@@ -74,7 +74,7 @@ def text(session, *args, **kwargs):
                           categories=("inputline", "channel"), include_player=True)
         else:
             text = session.player.nicks.nickreplace(text,
-                        categories=("inputline", "channels"), include_player=False)
+                        categories=("inputline", "channel"), include_player=False)
     kwargs.pop("options", None)
     cmdhandler(session, text, callertype="session", session=session, **kwargs)
     session.update_session_counters()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I noticed that channel aliases didn't work while in an ooc state, and it was a typo in the input_func.


