### PR TITLE
added the `append` saver method

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -272,6 +272,10 @@ class _SaverDeque(_SaverMutable):
         self._data = deque()
 
     @_save
+    def append(self, *args, **kwargs):
+        self._data.append(*args, **kwargs)
+
+    @_save
     def appendleft(self, *args, **kwargs):
         self._data.appendleft(*args, **kwargs)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Recently, `_SaverDequeue` was added to the dbserialize module, so I used it in Ainneve combat. However, I found that the `append` method was not present. This PR adds it.

#### Motivation for adding to Evennia

To support the deque API.

#### Other info (issues closed, discussion etc)

I do not believe there is an issue for this problem. 