### PR TITLE
Removed complex parsing in favor of disallowing spaces in passwords.

### DIFF
--- a/evennia/commands/connection_screen.py
+++ b/evennia/commands/connection_screen.py
@@ -15,7 +15,7 @@ DEFAULT_SCREEN = \
  If you need to create an account, type (without the <>'s):
       {wcreate <username> <password>{n
 
- If you have spaces in your username, enclose it in quotes.
+ Passwords cannot contain spaces.
  Enter {whelp{n for more info. {wlook{n will re-show this screen.
 {b=============================================================={n""" \
 % (settings.SERVERNAME, utils.get_evennia_version())


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Removed the complex parsing of doublequotes on `create` and `connect` commands in favor of a parse light system that disallows spaces in the password.

#### Motivation for adding to Evennia

bugfix - https://github.com/evennia/evennia/issues/1076

#### Other info (issues closed, discussion etc)

######Passwords with spaces:
Future goal: create/connect module to accept password in response to a `create` or `connect` command instead of on the same line.  Use a python module for securely handling passwords.

######Single Quotes in Names:
Please submit an enhancement request to use single quotes in names.
