### PR TITLE
modified `has_cmdset` to accept either a cmdset's python path or key

### DIFF
--- a/evennia/commands/cmdsethandler.py
+++ b/evennia/commands/cmdsethandler.py
@@ -553,7 +553,8 @@ class CmdSetHandler(object):
         if must_be_default:
             return self.cmdset_stack and self.cmdset_stack[0].key == cmdset_key
         else:
-            return any([cmdset.key == cmdset_key for cmdset in self.cmdset_stack])
+            return any([cmdset.key == cmdset_key or cmdset.path == cmdset_key
+                        for cmdset in self.cmdset_stack])
 
     def reset(self):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The cmdsethandler's `add` and `remove` methods all will accept a python module path as their argument, but it appears that `has_cmdset` only returns true if you search on the cmdset's key. Added logic to enable it to work with either key or module path.

#### Motivation for adding to Evennia

Ainneve's turn-based combat handler does a lot of adding and removing cmdsets to combat participants during different phases of the combat turn. I found I needed to use `has_cmdset` to ensure that a given cmdset is added no more than once. For these cmdset operations I chose to manage cmdsets by module path string and forego the use of cmdset keys, but it revealed this problem with `has_cmdset`.

#### Other info (issues closed, discussion etc)

This arose during Ainneve development and is a one-line fix, so I do not believe there is an existing Issue for this.