### PR TITLE
AttributeHandler fix when db_category or db_attrtype saved as blank string from django admin

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -221,7 +221,7 @@ class AttributeHandler(object):
                      "attribute__db_attrtype" : self._attrtype}
             query = Q(**query)
         else:
-            id_dict = {"%s__id" % self._model : self.objid}
+            id_dict = {"%s__id" % self._model : self._objid}
             blank_dict = {"attribute__db_attrtype": ''}
             null_dict = {"attribute__db_attrtype": None}
             query = Q(**id_dict) & Q(Q(**blank_dict) | Q(**null_dict))

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -219,7 +219,7 @@ class AttributeHandler(object):
                  "attribute__db_attrtype" : self._attrtype}
         attrs = [conn.attribute for conn in getattr(self.obj, self._m2m_fieldname).through.objects.filter(**query)]
         self._cache = dict(("%s-%s" % (to_str(attr.db_key).lower(),
-                                       attr.db_category.lower() if attr.db_category else None),
+                                       attr.db_category.lower() if attr.db_category else 'None'),
                             attr) for attr in attrs)
         self._cache_complete = True
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When saving Attributes in django admin, it can save the category or attrtype as a blank string rather than a null object. The attributehandler created its cache dict keys with a string conversion of the db_category field, which caused any attribute saved with a db_category value of '' to not show up where those with a db_category of None did. In addition, the queries for getting the objects originally when building the cache also checked for Null, not for empty strings, which prevented them from being found.

#### Motivation for adding to Evennia
Fix to mismatch of db_category and db_attrtype for AttributeHandler when either were saved as blank strings from django admin

