### PR TITLE
modified msg_contents to allow objects without get_display_name

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -559,14 +559,16 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             {}-style format syntax. The keys of `mapping` should match
             named format tokens, and its values will have their
             `get_display_name()` function called for  each object in
-            the room before substitution.
+            the room before substitution. If an item in the mapping does
+            not have `get_display_name()`, its string value will be used.
 
         Example:
             Say char is a Character object and npc is an NPC object:
 
+            action = 'kicks'
             char.location.msg_contents(
-                "{attacker} attacks {defender}",
-                mapping=dict(attacker=char, defender=npc),
+                "{attacker} {action} {defender}",
+                mapping=dict(attacker=char, defender=npc, action=action),
                 exclude=(char, npc))
         """
         contents = self.contents
@@ -575,7 +577,10 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             contents = [obj for obj in contents if obj not in exclude]
         for obj in contents:
             if mapping:
-                substitutions = {t: sub.get_display_name(obj) for t, sub in mapping.items()}
+                substitutions = {t: sub.get_display_name(obj)
+                                    if hasattr(sub, 'get_display_name')
+                                    else str(sub)
+                                 for t, sub in mapping.items()}
                 obj.msg(message.format(**substitutions), from_obj=from_obj, **kwargs)
             else:
                 obj.msg(message, from_obj=from_obj, **kwargs)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

We recently merged a PR that updated the signature of DefaultObject.msg_contents to accept a mapping of objects for which it would call get_display_name(looker) for each looker in the room's contents. This PR is a minor modification to that which will allow objects without `get_display_name()` (such as plain strings) to be passed in as part of the mapping.

#### Motivation for adding to Evennia

The original modification to `msg_contents` required that only typeclassed objects be passed in as part of the mapping. This change relaxes that requirement, and allows any object.

#### Other info (issues closed, discussion etc)
