### PR TITLE
Tiny fix to @color command's help file

### DIFF
--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -680,7 +680,7 @@ class CmdColorTest(COMMAND_DEFAULT_CLASS):
     testing which colors your client support
 
     Usage:
-      @color ansi|xterm256
+      @color ansi||xterm256
 
     Prints a color map along with in-mud color codes to use to produce
     them.  It also tests what is supported in your client. Choices are


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Very small fix to the help file of the '@color' command, which used the | symbol, but didn't escape it after it became an ansi control character.

