### PR TITLE
Removed reference to target after target.at_desc. This allows the tar…

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1386,9 +1386,14 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
                 return "Could not view '%s'." % target.get_display_name(self)
             except AttributeError:
                 return "Could not view '%s'." % target.key
+
+        description = target.return_appearance(self)
+
         # the target's at_desc() method.
+        # this must be the last reference to target so it may delete itself when acted on.
         target.at_desc(looker=self)
-        return target.return_appearance(self)
+
+        return description
 
     def at_desc(self, looker=None):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Moves the target.at_desc() call to the bottom of at_look.  If this is the last call to target, the object that is looked at can take self modifying actions such as self.delete().


#### Motivation for adding to Evennia

This provides a clearer code pattern for verbs on consumables.  For example, if a developer wants to implement `at_drink` and `at_drunk` following the pattern of `at_look`, `at_desc`, it will work without any modification.


#### Other info (issues closed, discussion etc)

…get to delete itself in response to being looked at without throwing an error.