### PR TITLE
Overload the 'last', 'first', and 'count' queryset methods

### DIFF
--- a/evennia/typeclasses/managers.py
+++ b/evennia/typeclasses/managers.py
@@ -557,6 +557,44 @@ class TypeclassManager(TypedObjectManager):
         """
         return super(TypedObjectManager, self).all().filter(db_typeclass_path=self.model.path)
 
+    def first(self):
+        """
+        Overload method to return first match, filtering for typeclass.
+
+        Returns:
+            object (object): The object found.
+
+        Raises:
+            ObjectNotFound: The exact name of this exception depends
+                on the model base used.
+
+        """
+        return super(TypedObjectManager, self).filter(db_typeclass_path=self.model.path).first()
+
+    def last(self):
+        """
+        Overload method to return last match, filtering for typeclass.
+
+        Returns:
+            object (object): The object found.
+
+        Raises:
+            ObjectNotFound: The exact name of this exception depends
+                on the model base used.
+
+        """
+        return super(TypedObjectManager, self).filter(db_typeclass_path=self.model.path).last()
+
+    def count(self):
+        """
+        Overload method to return number of matches, filtering for typeclass.
+
+        Returns:
+            integer : Number of objects found.
+
+        """
+        return super(TypedObjectManager, self).filter(db_typeclass_path=self.model.path).count()
+
     def _get_subclasses(self, cls):
         """
         Recursively get all subclasses to a class.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adding the last(), first(), and count() methods for the TypedObjectManager so that we can do things like Character.objects.count() or Room.objects.last() and so on and get the expected object for that typeclass, rather than the unfiltered ObjectDB object.

#### Motivation for adding to Evennia
Currently, doing MyTypeclass.objects.first(), .last(), or count() will produce unexpected/inaccurate results, because it will return the method for the parent model (ObjectDB, PlayerDB, etc), rather than filtered by the typeclass path as expected. This change causes them to produce the expected result.

#### Other info (issues closed, discussion etc
N/A

