### PR TITLE
Have lockshandler fail gracefully rather than cause a server crash

### DIFF
--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -177,7 +177,10 @@ class LockHandler(object):
             _cache_lockfuncs()
         self.obj = obj
         self.locks = {}
-        self.reset()
+        try:
+            self.reset()
+        except LockException as err:
+            logger.log_trace(err)
 
     def __str__(self):
         return ";".join(self.locks[key][2] for key in sorted(self.locks))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If a lockstring in a channel has a syntax error (either due to being set with '@py', inside django admin, or from shell, it will cause a server crash when attempting to reload due the channelhandler being loaded on startup. This fixes that and causes the LockException to be logged while allowing server startup to proceed.

#### Motivation for adding to Evennia
To prevent the server crashing when your staff members decide that they don't need to use the @clock command and instead want to just copy and paste a lockstring into a new channel's entry in django admin while neglecting the closing parentheses, forcing you to frantically go through evennia shell to fix it manually. Hypothetically speaking.


