### PR TITLE
Added missing import for subscriptionhandler.remove()

### DIFF
--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -511,6 +511,9 @@ class SubscriptionHandler(object):
                 entities to un-subscribe from the channel.
 
         """
+        global _CHANNELHANDLER
+        if not _CHANNELHANDLER:
+            from evennia.comms.channelhandler import CHANNEL_HANDLER as _CHANNELHANDLER
         for subscriber in make_iter(entity):
             if subscriber:
                 clsname = subscriber.__dbclass__.__name__


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Very small fix - the .remove method of SubscriptionHandler didn't do the _ChannelHandler import, so caused a traceback if it was called before other methods.

#### Motivation for adding to Evennia
Small import fix

#### Other info (issues closed, discussion etc)
N/A

