### PR TITLE
Request for change to ChannelHandler defaults

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -112,7 +112,10 @@ class CmdAddCom(COMMAND_DEFAULT_CLASS):
             else:
                 string += "You now listen to the channel %s. " % channel.key
         else:
-            string += "You are already connected to channel %s." % channel.key
+            if channel.unmute(player):
+                string += "You unmute channel %s." % channel.key
+            else:
+                string += "You are already connected to channel %s." % channel.key
 
         if alias:
             # create a nick and add it to the caller.
@@ -130,10 +133,12 @@ class CmdDelCom(COMMAND_DEFAULT_CLASS):
 
     Usage:
        delcom <alias or channel>
+       delcom/all <channel>
 
     If the full channel name is given, unsubscribe from the
     channel. If an alias is given, remove the alias but don't
-    unsubscribe.
+    unsubscribe. If the 'all' switch is used, remove all aliases
+    for that channel.
     """
 
     key = "delcom"
@@ -162,13 +167,16 @@ class CmdDelCom(COMMAND_DEFAULT_CLASS):
                 self.msg("You are not listening to that channel.")
                 return
             chkey = channel.key.lower()
+            delnicks = "all" in self.switches
             # find all nicks linked to this channel and delete them
-            for nick in [nick for nick in make_iter(caller.nicks.get(category="channel", return_obj=True))
-                         if nick and nick.pk and nick.value[3].lower() == chkey]:
-                nick.delete()
+            if delnicks:
+                for nick in [nick for nick in make_iter(caller.nicks.get(category="channel", return_obj=True))
+                             if nick and nick.pk and nick.value[3].lower() == chkey]:
+                    nick.delete()
             disconnect = channel.disconnect(player)
             if disconnect:
-                self.msg("You stop listening to channel '%s'. Eventual aliases were removed." % channel.key)
+                wipednicks = " Eventual aliases were removed." if delnicks else ""
+                self.msg("You stop listening to channel '%s'.%s" % channel.key)
             return
         else:
             # we are removing a channel nick

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -514,7 +514,7 @@ class CmdCWho(COMMAND_DEFAULT_CLASS):
             self.msg(string)
             return
         string = "\n{CChannel subscriptions{n"
-        string += "\n{w%s:{n\n %s" % (channel.key, channel.wholist)       
+        string += "\n{w%s:{n\n  %s" % (channel.key, channel.wholist)       
         self.msg(string.strip())
 
 

--- a/evennia/comms/channelhandler.py
+++ b/evennia/comms/channelhandler.py
@@ -43,6 +43,8 @@ class ChannelCommand(command.Command):
     Usage:
        {lower_channelkey}  <message>
        {lower_channelkey}/history [start]
+       {lower_channelkey} off - mutes the channel
+       {lower_channelkey} on  - unmutes the channel
 
     Switch:
         history: View 20 previous messages, either from the end or
@@ -107,6 +109,22 @@ class ChannelCommand(command.Command):
             string = _("You are not permitted to send to channel '%s'.")
             self.msg(string % channelkey)
             return
+        if msg == "on":
+            caller = caller if not hasattr(caller, 'player') else caller.player
+            unmuted = channel.unmute(caller)
+            if unmuted:
+                self.msg("You start listening to %s." % channel)
+                return
+            self.msg("You were already listening to %s." % channel)
+            return
+        if msg == "off":
+            caller = caller if not hasattr(caller, 'player') else caller.player
+            muted = channel.mute(caller)
+            if muted:
+                self.msg("You stop listening to %s." % channel)
+                return
+            self.msg("You were already not listening to %s." % channel)
+            return
         if self.history_start is not None:
             # Try to view history
             log_file = channel.attributes.get("log_file", default="channel_%s.log" % channel.key)
@@ -114,6 +132,10 @@ class ChannelCommand(command.Command):
                                                     if "[-]" in line else line for line in lines))
             tail_log_file(log_file, self.history_start, 20, callback=send_msg)
         else:
+            caller = caller if not hasattr(caller, 'player') else caller.player
+            if caller in channel.mutelist:
+                self.msg("You currently have %s muted." % channel)
+                return
             channel.msg(msg, senders=self.caller, online=True)
 
     def get_extra_info(self, caller, **kwargs):
@@ -234,12 +256,13 @@ class ChannelHandler(object):
             # create a new cmdset holding all viable channels
             chan_cmdset = None
             chan_cmds = [channelcmd for channel, channelcmd in self.cached_channel_cmds.iteritems()
-                                if channelcmd.access(source_object, 'send')]
+                                if channel.subscriptions.has(source_object) and
+                                channelcmd.access(source_object, 'send')]
             if chan_cmds:
                 chan_cmdset = cmdset.CmdSet()
                 chan_cmdset.key = 'ChannelCmdSet'
                 chan_cmdset.priority = 101
-                chan_cmdset.duplicates = False
+                chan_cmdset.duplicates = True
                 for cmd in chan_cmds:
                     chan_cmdset.add(cmd)
             self.cached_cmdsets[source_object] = chan_cmdset

--- a/evennia/comms/channelhandler.py
+++ b/evennia/comms/channelhandler.py
@@ -234,13 +234,12 @@ class ChannelHandler(object):
             # create a new cmdset holding all viable channels
             chan_cmdset = None
             chan_cmds = [channelcmd for channel, channelcmd in self.cached_channel_cmds.iteritems()
-                                if channel.subscriptions.has(source_object)
-                                    and channelcmd.access(source_object, 'send')]
+                                if channelcmd.access(source_object, 'send')]
             if chan_cmds:
                 chan_cmdset = cmdset.CmdSet()
                 chan_cmdset.key = 'ChannelCmdSet'
                 chan_cmdset.priority = 101
-                chan_cmdset.duplicates = True
+                chan_cmdset.duplicates = False
                 for cmd in chan_cmds:
                     chan_cmdset.add(cmd)
             self.cached_cmdsets[source_object] = chan_cmdset

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -79,6 +79,34 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
             has_sub = self.subscriptions.has(subscriber.player)
         return has_sub
 
+    @property
+    def mutelist(self):
+        return self.db.mute_list or []
+
+    def mute(self, subscriber):
+        """
+        Adds an entity to the list of muted subscribers.
+        A muted subscriber will no longer see channel messages,
+        but may use channel commands.
+        """
+        mutelist = self.mutelist
+        if subscriber not in mutelist:
+            mutelist.append(subscriber)
+            self.db.mute_list = mutelist
+            return True
+
+    def unmute(self, subscriber):
+        """
+        Removes an entity to the list of muted subscribers.
+        A muted subscriber will no longer see channel messages,
+        but may use channel commands.
+        """
+        mutelist = self.mutelist
+        if subscriber in mutelist:
+            mutelist.remove(subscriber)
+            self.db.mute_list = mutelist
+            return True
+
 
     def connect(self, subscriber):
         """
@@ -102,6 +130,8 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
             return False
         # subscribe
         self.subscriptions.add(subscriber)
+        # unmute
+        self.unmute(subscriber)
         # post-join hook
         self.post_join_channel(subscriber)
         return True
@@ -125,6 +155,8 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
             return False
         # disconnect
         self.subscriptions.remove(subscriber)
+        # unmute
+        self.unmute(subscriber)
         # post-disconnect hook
         self.post_leave_channel(subscriber)
         return True
@@ -197,6 +229,9 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
         """
         # get all players connected to this channel and send to them
         for entity in self.subscriptions.all():
+            # if the entity is muted, we don't send them a message
+            if entity in self.mutelist:
+                continue
             try:
                 # note our addition of the from_channel keyword here. This could be checked
                 # by a custom player.msg() to treat channel-receives differently.

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -83,6 +83,17 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
     def mutelist(self):
         return self.db.mute_list or []
 
+    @property
+    def wholist(self):
+        subs = self.db_subscriptions.all()
+        listening = [ob for ob in subs if ob.is_connected and ob not in self.mutelist]
+        if subs:
+            # display listening subscribers in bold
+            string = ", ".join([player.key if player not in listening else "{w%s{n" % player.key for player in subs])
+        else:
+            string = "<None>"
+        return string
+
     def mute(self, subscriber):
         """
         Adds an entity to the list of muted subscribers.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The recent change to cmdsets included some changes to ChannelHandler which prevented some functionality that I was using: it prevents players from executing channel commands if they are no longer subscribed to the channel. You might wonder how that might come up, but there's a surprising amount of use cases for that - players often stop listening to a channel to avoid spam, but still might want to occasionally check channel history or the like, and most importantly, I had '<channelname> on' be an alias for addcom, which allowed people to use defined nicknames for their channels to toggle them back on. With the ChannelHandler checking subscriptions for whether they have the command or not, it would cause the situation of a player doing something like 'chan off', seeing that they had disconnected, then 'chan on', and being told it was an invalid command. I changed the allow_duplicates to False, because it's necessary to avoid redundant channel commands without the subscription check.

#### Motivation for adding to Evennia
To allow players to use channel commands without an active subscription, such as '<channelname> on'.

#### Other info (issues closed, discussion etc)
Slightly related to this, but I found players were confused by the default behavior of delcom and 'allcom off' to remove channel aliases. I just made override commands that removed the subscriptions without wiping aliases, but it might be more intuitive for the vanilla commands to not wipe aliases unless there's a switch to tell it to explicitly do so.