### PR TITLE
Make portal log less noisy

### DIFF
--- a/evennia/server/amp.py
+++ b/evennia/server/amp.py
@@ -85,6 +85,7 @@ class AmpServerFactory(protocol.ServerFactory):
     This factory creates the Server as a new AMPProtocol instance for accepting
     connections from the Portal.
     """
+    noisy = False
     def __init__(self, server):
         """
         Initialize the factory.
@@ -124,6 +125,7 @@ class AmpClientFactory(protocol.ReconnectingClientFactory):
     initialDelay = 1
     factor = 1.5
     maxDelay = 1
+    noisy = False
 
     def __init__(self, portal):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
My portal logs have been rotating several times a day, and they're mostly filled with lines of amp factory starting and stopping, which happens every time someone connects/disconnects. I found that you can suppress these messages with the 'noisy=False' argument for factories, and I can't really think of a reason why someone would want to see them, since they make the portal logs pretty hard to read.

#### Motivation for adding to Evennia
Make portal logs less spammy and fill up much slower.

#### Other info (issues closed, discussion etc)

N/A