### PR TITLE
MXP tags to use double quote instead of single

### DIFF
--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -21,7 +21,7 @@ LINKS_SUB = re.compile(r'\|lc(.*?)\|lt(.*?)\|le', re.DOTALL)
 MXP = "\x5B"
 MXP_TEMPSECURE = "\x1B[4z"
 MXP_SEND = MXP_TEMPSECURE + \
-           "<SEND HREF='\\1'>" + \
+           "<SEND HREF=\"\\1\">" + \
            "\\2" + \
            MXP_TEMPSECURE + \
            "</SEND>"

--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -38,6 +38,7 @@ def mxp_parse(text):
 
     """
     text = text.replace("&", "&amp;") \
+               .replace('"', "&quot;") \
                .replace("<", "&lt;") \
                .replace(">", "&gt;")
 

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -234,7 +234,7 @@ class TextToHTMLparser(object):
 
     def convert_links(self, text):
         """
-        Replaces links with HTML code.
+        Replaces MXP links with HTML code.
 
         Args:
             text (str): Text to process.

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -243,7 +243,7 @@ class TextToHTMLparser(object):
             text (str): Processed text.
 
         """
-        return self.re_mxplink.sub(r"""<a id='mxplink' href='#' onclick='Evennia.msg("text",["\1"],{}); return false;'>\2</a>""", text)
+        return self.re_mxplink.sub(r'''<a id="mxplink" href="#" onclick="Evennia.msg(&quot;text&quot;,[&quot;\1&quot;],{}); return false;">\2</a>''', text)
 
     def do_sub(self, match):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Partially addressing issue #1002 - MXP commands and text can now contain a (simple) single quote/apostrophe without quoting issues. 
#### Motivation for adding to Evennia

This works around the problem of having to escape single quotes (apostrophes) in MXP commands or texts, but then requires (simple) double quotes to be escaped.
#### Other info (issues closed, discussion etc)

Caveat - webclient does not expect simple double quotes in MXP commands or text, so this is not a full solution when trying to include a double quote in MXP commands or texts.   Escaping them for webclient may need to be a separate issue or more needs to be done in this PR to address that.
