### PR TITLE
TagAdmin tweaks

### DIFF
--- a/evennia/comms/admin.py
+++ b/evennia/comms/admin.py
@@ -14,6 +14,7 @@ class ChannelAttributeInline(AttributeInline):
 
     """
     model = ChannelDB.db_attributes.through
+    related_field = "channeldb"
 
 
 class ChannelTagInline(TagInline):
@@ -22,6 +23,7 @@ class ChannelTagInline(TagInline):
 
     """
     model = ChannelDB.db_tags.through
+    related_field = "channeldb"
 
 
 class MsgAdmin(admin.ModelAdmin):

--- a/evennia/comms/managers.py
+++ b/evennia/comms/managers.py
@@ -133,7 +133,7 @@ def to_object(inp, objtype='player'):
 # Msg manager
 #
 
-class MsgManager(models.Manager):
+class MsgManager(TypedObjectManager):
     """
     This MsgManager implements methods for searching and manipulating
     Messages directly from the database.

--- a/evennia/help/admin.py
+++ b/evennia/help/admin.py
@@ -6,6 +6,11 @@ from builtins import object
 from django import forms
 from django.contrib import admin
 from evennia.help.models import HelpEntry
+from evennia.typeclasses.admin import TagInline
+
+class HelpTagInline(TagInline):
+    model = HelpEntry.db_tags.through
+    related_field = "helpentry"
 
 
 
@@ -22,7 +27,7 @@ class HelpEntryForm(forms.ModelForm):
 
 class HelpEntryAdmin(admin.ModelAdmin):
     "Sets up the admin manaager for help entries"
-
+    inlines = [HelpTagInline]
     list_display = ('id', 'db_key', 'db_help_category', 'db_lock_storage')
     list_display_links = ('id', 'db_key')
     search_fields = ['^db_key', 'db_entrytext']

--- a/evennia/help/manager.py
+++ b/evennia/help/manager.py
@@ -3,10 +3,11 @@ Custom manager for HelpEntry objects.
 """
 from django.db import models
 from evennia.utils import logger, utils
+from evennia.typeclasses.managers import TypedObjectManager
 __all__ = ("HelpEntryManager",)
 
 
-class HelpEntryManager(models.Manager):
+class HelpEntryManager(TypedObjectManager):
     """
     This HelpEntryManager implements methods for searching
     and manipulating HelpEntries directly from the database.

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -18,6 +18,7 @@ class ObjectAttributeInline(AttributeInline):
 
     """
     model = ObjectDB.db_attributes.through
+    related_field = "objectdb"
 
 
 class ObjectTagInline(TagInline):

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -26,6 +26,7 @@ class ObjectTagInline(TagInline):
 
     """
     model = ObjectDB.db_tags.through
+    related_field = "objectdb"
 
 
 class ObjectCreateForm(forms.ModelForm):

--- a/evennia/players/admin.py
+++ b/evennia/players/admin.py
@@ -182,6 +182,7 @@ class PlayerAttributeInline(AttributeInline):
 
     """
     model = PlayerDB.db_attributes.through
+    related_field = "playerdb"
 
 
 class PlayerDBAdmin(BaseUserAdmin):

--- a/evennia/players/admin.py
+++ b/evennia/players/admin.py
@@ -173,6 +173,7 @@ class PlayerTagInline(TagInline):
 
     """
     model = PlayerDB.db_tags.through
+    related_field = "playerdb"
 
 
 class PlayerAttributeInline(AttributeInline):

--- a/evennia/scripts/admin.py
+++ b/evennia/scripts/admin.py
@@ -23,6 +23,7 @@ class ScriptAttributeInline(AttributeInline):
 
     """
     model = ScriptDB.db_attributes.through
+    related_field = "scriptdb"
 
 
 class ScriptDBAdmin(admin.ModelAdmin):

--- a/evennia/scripts/admin.py
+++ b/evennia/scripts/admin.py
@@ -14,6 +14,7 @@ class ScriptTagInline(TagInline):
 
     """
     model = ScriptDB.db_tags.through
+    related_field = "scriptdb"
 
 
 class ScriptAttributeInline(AttributeInline):

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -1,14 +1,14 @@
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
-from django.core.urlresolvers import reverse
 from evennia.typeclasses.models import Attribute, Tag
 from django import forms
+from evennia.utils.picklefield import PickledFormField
+import traceback
 
 
 class TagAdmin(admin.ModelAdmin):
     """
     A django Admin wrapper for Tags.
-
     """
     search_fields = ('db_key', 'db_category', 'db_tagtype')
     list_display = ('db_key', 'db_category', 'db_tagtype', 'db_data')
@@ -17,22 +17,54 @@ class TagAdmin(admin.ModelAdmin):
 
 
 class TagForm(forms.ModelForm):
+    """
+    This form overrides the base behavior of the ModelForm that would be used for a Tag-through-model.
+    Since the through-models only have access to the foreignkeys of the Tag and the Object that they're
+    attached to, we need to spoof the behavior of it being a form that would correspond to its tag,
+    or the creation of a tag. Instead of being saved, we'll call to the Object's handler, which will handle
+    the creation, change, or deletion of a tag for us, as well as updating the handler's cache so that all
+    changes are instantly updated in-game.
+    """
     tag_key = forms.CharField(label='Tag Name')
     tag_category = forms.CharField(label="Category", required=False)
     tag_type = forms.CharField(label="Type", required=False)
     tag_data = forms.CharField(label="Data", required=False)
 
     def __init__(self, *args, **kwargs):
+        """
+         If we have a tag, then we'll prepopulate our instance with the fields we'd expect it
+         to have based on the tag. tag_key, tag_category, tag_type, and tag_data all refer to
+         the corresponding tag fields. The initial data of the form fields will similarly be
+         populated.
+        """
         super(TagForm, self).__init__(*args, **kwargs)
+        tagkey = None
+        tagcategory = None
+        tagtype = None
+        tagdata = None
         if hasattr(self.instance, 'tag'):
-            self.fields['tag_key'].initial = self.instance.tag.db_key
-            self.fields['tag_category'].initial = self.instance.tag.db_category
-            self.fields['tag_type'].initial = self.instance.tag.db_tagtype
-            self.fields['tag_data'].initial = self.instance.tag.db_data
+            tagkey = self.instance.tag.db_key
+            tagcategory = self.instance.tag.db_category
+            tagtype = self.instance.tag.db_tagtype
+            tagdata = self.instance.tag.db_data
+            self.fields['tag_key'].initial = tagkey
+            self.fields['tag_category'].initial = tagcategory
+            self.fields['tag_type'].initial = tagtype
+            self.fields['tag_data'].initial = tagdata
+        self.instance.tag_key = tagkey
+        self.instance.tag_category = tagcategory
+        self.instance.tag_type = tagtype
+        self.instance.tag_data = tagdata
 
     def save(self, commit=True):
+        """
+        One thing we want to do here is the or None checks, because forms are saved with an empty
+        string rather than null from forms, usually, and the Handlers may handle empty strings
+        differently than None objects. So for consistency with how things are handled in game,
+        we'll try to make sure that empty form fields will be None, rather than ''.
+        """
         # we are spoofing a tag for the Handler that will be called
-        #instance = super(TagForm, self).save(commit=False)
+        # instance = super(TagForm, self).save(commit=False)
         instance = self.instance
         instance.tag_key = self.cleaned_data['tag_key']
         instance.tag_category = self.cleaned_data['tag_category'] or None
@@ -42,8 +74,16 @@ class TagForm(forms.ModelForm):
 
 
 class TagFormSet(forms.BaseInlineFormSet):
+    """
+    The Formset handles all the inline forms that are grouped together on the change page of the
+    corresponding object. All the tags will appear here, and we'll save them by overriding the
+    formset's save method. The forms will similarly spoof their save methods to return an instance
+    which hasn't been saved to the database, but have the relevant fields filled out based on the
+    contents of the cleaned form. We'll then use that to call to the handler of the corresponding
+    Object, where the handler is an AliasHandler, PermissionsHandler, or TagHandler, based on the
+    type of tag.
+    """
     def save(self, commit=True):
-        print "inside TagFormSet"
         def get_handler(finished_object):
             related = getattr(finished_object, self.related_field)
             try:
@@ -58,32 +98,30 @@ class TagFormSet(forms.BaseInlineFormSet):
                 handler_name = "tags"
             return getattr(related, handler_name)
         instances = super(TagFormSet, self).save(commit=False)
+        # self.deleted_objects is a list created when super of save is called, we'll remove those
         for obj in self.deleted_objects:
             handler = get_handler(obj)
-            try:
-                tagkey = obj.tag_key
-            except AttributeError:
-                tagkey = obj.tag.db_key
-            handler.remove(tagkey)
+            handler.remove(obj.tag_key, category=obj.tag_category)
         for instance in instances:
             handler = get_handler(instance)
-            handler.add(instance.tag_key)
+            handler.add(instance.tag_key, category=instance.tag_category, data=instance.tag_data)
 
 
 class TagInline(admin.TabularInline):
     """
-    A handler for inline Tags.
-
+    A handler for inline Tags. This class should be subclassed in the admin of your models,
+    and the 'model' and 'related_field' class attributes must be set. model should be the
+    through model (ObjectDB_db_tag', for example), while related field should be the name
+    of the field on that through model which points to the model being used: 'objectdb',
+    'msg', 'playerdb', etc.
     """
     # Set this to the through model of your desired M2M when subclassing.
     model = None
     form = TagForm
     formset = TagFormSet
-    related_field = None
-    #fields = ('tag', 'key', 'category', 'data', 'tagtype')
+    related_field = None  # Must be 'objectdb', 'playerdb', 'msg', etc. Set when subclassing
     raw_id_fields = ('tag',)
     readonly_fields = ('tag',)
-    #readonly_fields = ('key', 'category', 'data', 'tagtype')
     extra = 0
 
     def get_formset(self, request, obj=None, **kwargs):
@@ -94,68 +132,182 @@ class TagInline(admin.TabularInline):
         people used the admin at the same time
         """
         formset = super(TagInline, self).get_formset(request, obj, **kwargs)
+
         class ProxyFormset(formset):
             pass
         ProxyFormset.related_field = self.related_field
         return ProxyFormset
 
-    def key(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return '<strong><a href="%s">%s</a></strong>' % (
-            reverse("admin:typeclasses_tag_change",
-                    args=[instance.tag.id]),
-            instance.tag.db_key)
-    key.allow_tags = True
-    
-    def category(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return instance.tag.db_category
 
-    def data(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return instance.tag.db_data
-    
-    def tagtype(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return instance.tag.db_tagtype
+class AttributeForm(forms.ModelForm):
+    """
+    This form overrides the base behavior of the ModelForm that would be used for a Tag-through-model.
+    Since the through-models only have access to the foreignkeys of the Tag and the Object that they're
+    attached to, we need to spoof the behavior of it being a form that would correspond to its tag,
+    or the creation of a tag. Instead of being saved, we'll call to the Object's handler, which will handle
+    the creation, change, or deletion of a tag for us, as well as updating the handler's cache so that all
+    changes are instantly updated in-game.
+    """
+    attr_key = forms.CharField(label='Attribute Name')
+    attr_category = forms.CharField(label="Category", help_text="type of attribute, for sorting", required=False)
+    attr_value = PickledFormField(label="Value", help_text="Value to pickle/save", required=False)
+    attr_type = forms.CharField(label="Type", help_text="nick for nickname, else leave blank", required=False)
+    attr_strvalue = forms.CharField(label="String Value",
+                                    help_text="Only enter this if value is blank and you want to save as a string",
+                                    required=False)
+    attr_lockstring = forms.CharField(label="Locks", required=False, widget=forms.Textarea)
+
+    def __init__(self, *args, **kwargs):
+        """
+         If we have a tag, then we'll prepopulate our instance with the fields we'd expect it
+         to have based on the tag. tag_key, tag_category, tag_type, and tag_data all refer to
+         the corresponding tag fields. The initial data of the form fields will similarly be
+         populated.
+        """
+        super(AttributeForm, self).__init__(*args, **kwargs)
+        attr_key = None
+        attr_category = None
+        attr_value = None
+        attr_strvalue = None
+        attr_type = None
+        attr_lockstring = None
+        if hasattr(self.instance, 'attribute'):
+            attr_key = self.instance.attribute.db_key
+            attr_category = self.instance.attribute.db_category
+            attr_value = self.instance.attribute.db_value
+            attr_strvalue = self.instance.attribute.db_strvalue
+            attr_type = self.instance.attribute.db_attrtype
+            attr_lockstring = self.instance.attribute.db_lock_storage
+            self.fields['attr_key'].initial = attr_key
+            self.fields['attr_category'].initial = attr_category
+            self.fields['attr_type'].initial = attr_type
+            self.fields['attr_value'].initial = attr_value
+            self.fields['attr_strvalue'].initial = attr_strvalue
+            self.fields['attr_lockstring'].initial = attr_lockstring
+        self.instance.attr_key = attr_key
+        self.instance.attr_category = attr_category
+        self.instance.attr_value = attr_value
+        self.instance.attr_strvalue = attr_strvalue
+        self.instance.attr_type = attr_type
+        self.instance.attr_lockstring = attr_lockstring
+
+    def save(self, commit=True):
+        """
+        One thing we want to do here is the or None checks, because forms are saved with an empty
+        string rather than null from forms, usually, and the Handlers may handle empty strings
+        differently than None objects. So for consistency with how things are handled in game,
+        we'll try to make sure that empty form fields will be None, rather than ''.
+        """
+        # we are spoofing a tag for the Handler that will be called
+        # instance = super(TagForm, self).save(commit=False)
+        instance = self.instance
+        instance.attr_key = self.cleaned_data['attr_key']
+        instance.attr_category = self.cleaned_data['attr_category'] or None
+        instance.attr_value = self.cleaned_data['attr_value'] or None
+        instance.attr_strvalue = self.cleaned_data['attr_strvalue'] or None
+        instance.attr_type = self.cleaned_data['attr_type'] or None
+        instance.attr_lockstring = self.cleaned_data['attr_lockstring']
+        return instance
+
+
+class AttributeFormSet(forms.BaseInlineFormSet):
+    """
+    Attribute version of TagFormSet, as above.
+    """
+    def save(self, commit=True):
+        def get_handler(finished_object):
+            related = getattr(finished_object, self.related_field)
+            try:
+                attrtype = finished_object.attr_type
+            except AttributeError:
+                attrtype = finished_object.attribute.db_attrtype
+            if attrtype == "nick":
+                handler_name = "nicks"
+            else:
+                handler_name = "attributes"
+            return getattr(related, handler_name)
+        instances = super(AttributeFormSet, self).save(commit=False)
+        # self.deleted_objects is a list created when super of save is called, we'll remove those
+        for obj in self.deleted_objects:
+            handler = get_handler(obj)
+            handler.remove(obj.attr_key, category=obj.attr_category)
+        for instance in instances:
+            handler = get_handler(instance)
+            strattr = True if instance.attr_strvalue else False
+            value = instance.attr_value or instance.attr_strvalue
+            try:
+                handler.add(instance.attr_key, value, category=instance.attr_category, strattr=strattr,
+                            lockstring=instance.attr_lockstring)
+            except (TypeError, ValueError):
+                # catch errors in nick templates and continue
+                traceback.print_exc()
+                continue
 
 
 class AttributeInline(admin.TabularInline):
     """
-    Inline creation of player attributes.j
-
+    A handler for inline Tags. This class should be subclassed in the admin of your models,
+    and the 'model' and 'related_field' class attributes must be set. model should be the
+    through model (ObjectDB_db_tag', for example), while related field should be the name
+    of the field on that through model which points to the model being used: 'objectdb',
+    'msg', 'playerdb', etc.
     """
     # Set this to the through model of your desired M2M when subclassing.
     model = None
-    extra = 1
-    #form = AttributeForm
-    fields = ('attribute', 'key', 'value', 'strvalue')
+    form = AttributeForm
+    formset = AttributeFormSet
+    related_field = None  # Must be 'objectdb', 'playerdb', 'msg', etc. Set when subclassing
     raw_id_fields = ('attribute',)
-    readonly_fields = ('key', 'value', 'strvalue')
+    readonly_fields = ('attribute',)
+    extra = 0
 
-    def key(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return '<strong><a href="%s">%s</a></strong>' % (
-            reverse("admin:typeclasses_attribute_change",
-                    args=[instance.attribute.id]),
-            instance.attribute.db_key)
+    def get_formset(self, request, obj=None, **kwargs):
+        """
+        get_formset has to return a class, but we need to make the class that we return
+        know about the related_field that we'll use. Returning the class itself rather than
+        a proxy isn't threadsafe, since it'd be the base class and would change if multiple
+        people used the admin at the same time
+        """
+        formset = super(AttributeInline, self).get_formset(request, obj, **kwargs)
 
-    key.allow_tags = True
+        class ProxyFormset(formset):
+            pass
 
-    def value(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return instance.attribute.value
+        ProxyFormset.related_field = self.related_field
+        return ProxyFormset
 
-    def strvalue(self, instance):
-        if not instance.id:
-            return "Not yet set or saved."
-        return instance.attribute.strvalue
+# class AttributeInline(admin.TabularInline):
+#     """
+#     Inline creation of player attributes.j
+#
+#     """
+#     # Set this to the through model of your desired M2M when subclassing.
+#     model = None
+#     extra = 1
+#     # form = AttributeForm
+#     fields = ('attribute', 'key', 'value', 'strvalue')
+#     raw_id_fields = ('attribute',)
+#     readonly_fields = ('key', 'value', 'strvalue')
+#
+#     def key(self, instance):
+#         if not instance.id:
+#             return "Not yet set or saved."
+#         return '<strong><a href="%s">%s</a></strong>' % (
+#             reverse("admin:typeclasses_attribute_change",
+#                     args=[instance.attribute.id]),
+#             instance.attribute.db_key)
+#
+#     key.allow_tags = True
+#
+#     def value(self, instance):
+#         if not instance.id:
+#             return "Not yet set or saved."
+#         return instance.attribute.value
+#
+#     def strvalue(self, instance):
+#         if not instance.id:
+#             return "Not yet set or saved."
+#         return instance.attribute.strvalue
 
 
 class AttributeAdmin(ModelAdmin):
@@ -163,7 +315,7 @@ class AttributeAdmin(ModelAdmin):
     Defines how to display the attributes.
 
     """
-    search_fields = ('db_key', 'db_strvalue', 'db_value')
+    search_fields = ('db_key', 'db_category')
     list_display = ('db_key', 'db_strvalue', 'db_value')
     permitted_types = ('str', 'unicode', 'int', 'float', 'NoneType', 'bool')
 

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -148,7 +148,7 @@ class AttributeForm(forms.ModelForm):
     the creation, change, or deletion of an Attribute for us, as well as updating the handler's cache so that all
     changes are instantly updated in-game.
     """
-    attr_key = forms.CharField(label='Attribute Name')
+    attr_key = forms.CharField(label='Attribute Name', required=False, initial="Enter Attribute Name Here")
     attr_category = forms.CharField(label="Category", help_text="type of attribute, for sorting", required=False)
     attr_value = PickledFormField(label="Value", help_text="Value to pickle/save", required=False)
     attr_type = forms.CharField(label="Type", help_text="nick for nickname, else leave blank", required=False)
@@ -201,7 +201,7 @@ class AttributeForm(forms.ModelForm):
         """
         # we are spoofing an Attribute for the Handler that will be called
         instance = self.instance
-        instance.attr_key = self.cleaned_data['attr_key']
+        instance.attr_key = self.cleaned_data['attr_key'] or "no_name_entered_for_attribute"
         instance.attr_category = self.cleaned_data['attr_category'] or None
         instance.attr_value = self.cleaned_data['attr_value'] or None
         # convert the serialized string value into an object, if necessary, for AttributeHandler
@@ -216,12 +216,6 @@ class AttributeFormSet(forms.BaseInlineFormSet):
     """
     Attribute version of TagFormSet, as above.
     """
-    def clean(self):
-        if any(self.errors):
-            from django.core.exceptions import FieldError
-            raise FieldError("Sorry, there was an error in saving that form. You may have forgotten to add a name "
-                             "for the Attribute, or you may have provided an invalid literal for an Attribute's value.")
-        super(AttributeFormSet, self).clean()
 
     def save(self, commit=True):
         def get_handler(finished_object):

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -9,7 +9,10 @@ class TagAdmin(admin.ModelAdmin):
     A django Admin wrapper for Tags.
 
     """
-    fields = ('db_key', 'db_category', 'db_data')
+    search_fields = ('db_key', 'db_category', 'db_tagtype')
+    list_display = ('db_key', 'db_category', 'db_tagtype', 'db_data')
+    fields = ('db_key', 'db_category', 'db_tagtype', 'db_data')
+    list_filter = ('db_tagtype',)
 
 
 class TagInline(admin.TabularInline):
@@ -19,8 +22,33 @@ class TagInline(admin.TabularInline):
     """
     # Set this to the through model of your desired M2M when subclassing.
     model = None
+    fields = ('tag', 'key', 'category', 'data', 'tagtype')
     raw_id_fields = ('tag',)
+    readonly_fields = ('key', 'category', 'data', 'tagtype')
     extra = 0
+    def key(self, instance):
+        if not instance.id:
+            return "Not yet set or saved."
+        return '<strong><a href="%s">%s</a></strong>' % (
+            reverse("admin:typeclasses_tag_change",
+                    args=[instance.tag.id]),
+            instance.tag.db_key)
+    key.allow_tags = True
+    
+    def category(self, instance):
+        if not instance.id:
+            return "Not yet set or saved."
+        return instance.tag.db_category
+
+    def data(self, instance):
+        if not instance.id:
+            return "Not yet set or saved."
+        return instance.tag.db_data
+    
+    def tagtype(self, instance):
+        if not instance.id:
+            return "Not yet set or saved."
+        return instance.tag.db_tagtype
 
 
 class AttributeInline(admin.TabularInline):

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
-from django.contrib.admin import ModelAdmin
-from evennia.typeclasses.models import Attribute, Tag
+from evennia.typeclasses.models import Tag
 from django import forms
 from evennia.utils.picklefield import PickledFormField
 from evennia.utils.dbserialize import from_pickle
@@ -200,8 +199,7 @@ class AttributeForm(forms.ModelForm):
         differently than None objects. So for consistency with how things are handled in game,
         we'll try to make sure that empty form fields will be None, rather than ''.
         """
-        # we are spoofing a tag for the Handler that will be called
-        # instance = super(TagForm, self).save(commit=False)
+        # we are spoofing an Attribute for the Handler that will be called
         instance = self.instance
         instance.attr_key = self.cleaned_data['attr_key']
         instance.attr_category = self.cleaned_data['attr_category'] or None
@@ -218,6 +216,13 @@ class AttributeFormSet(forms.BaseInlineFormSet):
     """
     Attribute version of TagFormSet, as above.
     """
+    def clean(self):
+        if any(self.errors):
+            from django.core.exceptions import FieldError
+            raise FieldError("Sorry, there was an error in saving that form. You may have forgotten to add a name "
+                             "for the Attribute, or you may have provided an invalid literal for an Attribute's value.")
+        super(AttributeFormSet, self).clean()
+
     def save(self, commit=True):
         def get_handler(finished_object):
             related = getattr(finished_object, self.related_field)

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.core.urlresolvers import reverse
 from evennia.typeclasses.models import Attribute, Tag
+from django import forms
 
 
 class TagAdmin(admin.ModelAdmin):
@@ -15,6 +16,60 @@ class TagAdmin(admin.ModelAdmin):
     list_filter = ('db_tagtype',)
 
 
+class TagForm(forms.ModelForm):
+    tag_key = forms.CharField(label='Tag Name')
+    tag_category = forms.CharField(label="Category", required=False)
+    tag_type = forms.CharField(label="Type", required=False)
+    tag_data = forms.CharField(label="Data", required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(TagForm, self).__init__(*args, **kwargs)
+        if hasattr(self.instance, 'tag'):
+            self.fields['tag_key'].initial = self.instance.tag.db_key
+            self.fields['tag_category'].initial = self.instance.tag.db_category
+            self.fields['tag_type'].initial = self.instance.tag.db_tagtype
+            self.fields['tag_data'].initial = self.instance.tag.db_data
+
+    def save(self, commit=True):
+        # we are spoofing a tag for the Handler that will be called
+        #instance = super(TagForm, self).save(commit=False)
+        instance = self.instance
+        instance.tag_key = self.cleaned_data['tag_key']
+        instance.tag_category = self.cleaned_data['tag_category'] or None
+        instance.tag_type = self.cleaned_data['tag_type'] or None
+        instance.tag_data = self.cleaned_data['tag_data'] or None
+        return instance
+
+
+class TagFormSet(forms.BaseInlineFormSet):
+    def save(self, commit=True):
+        print "inside TagFormSet"
+        def get_handler(finished_object):
+            related = getattr(finished_object, self.related_field)
+            try:
+                tagtype = finished_object.tag_type
+            except AttributeError:
+                tagtype = finished_object.tag.db_tagtype
+            if tagtype == "alias":
+                handler_name = "aliases"
+            elif tagtype == "permission":
+                handler_name = "permissions"
+            else:
+                handler_name = "tags"
+            return getattr(related, handler_name)
+        instances = super(TagFormSet, self).save(commit=False)
+        for obj in self.deleted_objects:
+            handler = get_handler(obj)
+            try:
+                tagkey = obj.tag_key
+            except AttributeError:
+                tagkey = obj.tag.db_key
+            handler.remove(tagkey)
+        for instance in instances:
+            handler = get_handler(instance)
+            handler.add(instance.tag_key)
+
+
 class TagInline(admin.TabularInline):
     """
     A handler for inline Tags.
@@ -22,10 +77,28 @@ class TagInline(admin.TabularInline):
     """
     # Set this to the through model of your desired M2M when subclassing.
     model = None
-    fields = ('tag', 'key', 'category', 'data', 'tagtype')
+    form = TagForm
+    formset = TagFormSet
+    related_field = None
+    #fields = ('tag', 'key', 'category', 'data', 'tagtype')
     raw_id_fields = ('tag',)
-    readonly_fields = ('key', 'category', 'data', 'tagtype')
+    readonly_fields = ('tag',)
+    #readonly_fields = ('key', 'category', 'data', 'tagtype')
     extra = 0
+
+    def get_formset(self, request, obj=None, **kwargs):
+        """
+        get_formset has to return a class, but we need to make the class that we return
+        know about the related_field that we'll use. Returning the class itself rather than
+        a proxy isn't threadsafe, since it'd be the base class and would change if multiple
+        people used the admin at the same time
+        """
+        formset = super(TagInline, self).get_formset(request, obj, **kwargs)
+        class ProxyFormset(formset):
+            pass
+        ProxyFormset.related_field = self.related_field
+        return ProxyFormset
+
     def key(self, instance):
         if not instance.id:
             return "Not yet set or saved."

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -160,10 +160,10 @@ class AttributeForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         """
-         If we have a tag, then we'll prepopulate our instance with the fields we'd expect it
-         to have based on the tag. tag_key, tag_category, tag_type, and tag_data all refer to
-         the corresponding tag fields. The initial data of the form fields will similarly be
-         populated.
+         If we have an Attribute, then we'll prepopulate our instance with the fields we'd expect it
+         to have based on the Attribute. attr_key, attr_category, attr_value, attr_strvalue, attr_type,
+         and attr_lockstring all refer to the corresponding Attribute fields. The initial data of the form fields will
+         similarly be populated.
         """
         super(AttributeForm, self).__init__(*args, **kwargs)
         attr_key = None
@@ -250,7 +250,7 @@ class AttributeFormSet(forms.BaseInlineFormSet):
 
 class AttributeInline(admin.TabularInline):
     """
-    A handler for inline Tags. This class should be subclassed in the admin of your models,
+    A handler for inline Attributes. This class should be subclassed in the admin of your models,
     and the 'model' and 'related_field' class attributes must be set. model should be the
     through model (ObjectDB_db_tag', for example), while related field should be the name
     of the field on that through model which points to the model being used: 'objectdb',
@@ -280,56 +280,5 @@ class AttributeInline(admin.TabularInline):
         ProxyFormset.related_field = self.related_field
         return ProxyFormset
 
-# class AttributeInline(admin.TabularInline):
-#     """
-#     Inline creation of player attributes.j
-#
-#     """
-#     # Set this to the through model of your desired M2M when subclassing.
-#     model = None
-#     extra = 1
-#     # form = AttributeForm
-#     fields = ('attribute', 'key', 'value', 'strvalue')
-#     raw_id_fields = ('attribute',)
-#     readonly_fields = ('key', 'value', 'strvalue')
-#
-#     def key(self, instance):
-#         if not instance.id:
-#             return "Not yet set or saved."
-#         return '<strong><a href="%s">%s</a></strong>' % (
-#             reverse("admin:typeclasses_attribute_change",
-#                     args=[instance.attribute.id]),
-#             instance.attribute.db_key)
-#
-#     key.allow_tags = True
-#
-#     def value(self, instance):
-#         if not instance.id:
-#             return "Not yet set or saved."
-#         return instance.attribute.value
-#
-#     def strvalue(self, instance):
-#         if not instance.id:
-#             return "Not yet set or saved."
-#         return instance.attribute.strvalue
 
-
-class AttributeAdmin(ModelAdmin):
-    """
-    Defines how to display the attributes.
-
-    """
-    search_fields = ('db_key', 'db_category')
-    list_display = ('db_key', 'db_strvalue', 'db_value')
-    permitted_types = ('str', 'unicode', 'int', 'float', 'NoneType', 'bool')
-
-    fields = ('db_key', 'db_value', 'db_strvalue', 'db_category',
-              'db_lock_storage', 'db_model', 'db_attrtype')
-
-    def get_readonly_fields(self, request, obj=None):
-        if obj.db_value.__class__.__name__ not in self.permitted_types:
-            return ['db_value']
-        return []
-
-admin.site.register(Attribute, AttributeAdmin)
 admin.site.register(Tag, TagAdmin)

--- a/evennia/typeclasses/admin.py
+++ b/evennia/typeclasses/admin.py
@@ -3,6 +3,7 @@ from django.contrib.admin import ModelAdmin
 from evennia.typeclasses.models import Attribute, Tag
 from django import forms
 from evennia.utils.picklefield import PickledFormField
+from evennia.utils.dbserialize import from_pickle
 import traceback
 
 
@@ -141,11 +142,11 @@ class TagInline(admin.TabularInline):
 
 class AttributeForm(forms.ModelForm):
     """
-    This form overrides the base behavior of the ModelForm that would be used for a Tag-through-model.
-    Since the through-models only have access to the foreignkeys of the Tag and the Object that they're
-    attached to, we need to spoof the behavior of it being a form that would correspond to its tag,
-    or the creation of a tag. Instead of being saved, we'll call to the Object's handler, which will handle
-    the creation, change, or deletion of a tag for us, as well as updating the handler's cache so that all
+    This form overrides the base behavior of the ModelForm that would be used for a Attribute-through-model.
+    Since the through-models only have access to the foreignkeys of the Attribute and the Object that they're
+    attached to, we need to spoof the behavior of it being a form that would correspond to its Attribute,
+    or the creation of an Attribute. Instead of being saved, we'll call to the Object's handler, which will handle
+    the creation, change, or deletion of an Attribute for us, as well as updating the handler's cache so that all
     changes are instantly updated in-game.
     """
     attr_key = forms.CharField(label='Attribute Name')
@@ -187,6 +188,7 @@ class AttributeForm(forms.ModelForm):
         self.instance.attr_key = attr_key
         self.instance.attr_category = attr_category
         self.instance.attr_value = attr_value
+        self.instance.deserialized_value = from_pickle(attr_value)
         self.instance.attr_strvalue = attr_strvalue
         self.instance.attr_type = attr_type
         self.instance.attr_lockstring = attr_lockstring
@@ -204,6 +206,8 @@ class AttributeForm(forms.ModelForm):
         instance.attr_key = self.cleaned_data['attr_key']
         instance.attr_category = self.cleaned_data['attr_category'] or None
         instance.attr_value = self.cleaned_data['attr_value'] or None
+        # convert the serialized string value into an object, if necessary, for AttributeHandler
+        instance.attr_value = from_pickle(instance.attr_value)
         instance.attr_strvalue = self.cleaned_data['attr_strvalue'] or None
         instance.attr_type = self.cleaned_data['attr_type'] or None
         instance.attr_lockstring = self.cleaned_data['attr_lockstring']

--- a/evennia/utils/picklefield.py
+++ b/evennia/utils/picklefield.py
@@ -128,7 +128,7 @@ class PickledWidget(Textarea):
         final_attrs = self.build_attrs(attrs, name=name)
         return format_html('<textarea{0}>\r\n{1}</textarea>',
                            flatatt(final_attrs),
-                           force_text(value))
+                           value)
 
 
 class PickledFormField(CharField):
@@ -154,7 +154,7 @@ class PickledFormField(CharField):
             return literal_eval(value)
         except (ValueError, SyntaxError):
             try:
-                value = "u'%s'" % force_text(value)
+                value = repr(value)
                 return literal_eval(value)
             except (ValueError, SyntaxError):
                 raise ValidationError(self.error_messages['invalid'])

--- a/evennia/utils/picklefield.py
+++ b/evennia/utils/picklefield.py
@@ -147,13 +147,17 @@ class PickledFormField(CharField):
         super(PickledFormField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        if value == '':
+        if not value.strip():
             # Field was left blank. Make this None.
             value = 'None'
         try:
             return literal_eval(value)
         except (ValueError, SyntaxError):
-            raise ValidationError(self.error_messages['invalid'])
+            try:
+                value = "u'%s'" % force_text(value)
+                return literal_eval(value)
+            except (ValueError, SyntaxError):
+                raise ValidationError(self.error_messages['invalid'])
 
 
 class PickledObjectField(models.Field):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When I tried to mess around with Tags in django admin, I saw that trying to add one wouldn't work - there wasn't a search function, so I'd need to manually look for one out of 17000+ tags from aliases. I put in search fields and a list filter to allow separating aliases, permissions, and normal tags, then set the inline to mirror the appearance of AttributeInline.
#### Motivation for adding to Evennia

Allow for search of tags to be viable, have adding tags look roughly the same as adding attributes.
#### Other info (issues closed, discussion etc)

Adding a tag via django admin will not presently update the object's taghandler. My guess is that I'd need to add a custom form to the Tag and Attribute admins to reload the caches of taghandler and attributehandlers of objects with the tags/attributes.
