### PR TITLE
Change to make strip() in EvTable more specific for fixing align

### DIFF
--- a/evennia/utils/evtable.py
+++ b/evennia/utils/evtable.py
@@ -575,9 +575,9 @@ class EvCell(object):
         hfill_char = self.hfill_char
         width = self.width
         if align == "l":
-            return [(line.lstrip() if line.startswith(" ") and not line.startswith("  ") else line) + hfill_char * (width - m_len(line)) for line in data]
+            return [(line.lstrip(" ") if line.startswith(" ") and not line.startswith("  ") else line) + hfill_char * (width - m_len(line)) for line in data]
         elif align == "r":
-            return [hfill_char * (width - m_len(line)) + (line.rstrip() if line.endswith(" ") and not line.endswith("  ") else line) for line in data]
+            return [hfill_char * (width - m_len(line)) + (line.rstrip(" ") if line.endswith(" ") and not line.endswith("  ") else line) for line in data]
         else: # center, 'c'
             return [self._center(line, self.width, self.hfill_char) for line in data]
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Try to make lstrip and rstrip in EvTable only strip out an offending whitespace character from improper alignment, rather than anything like ANSI codes, newlines, etc.

#### Motivation for adding to Evennia
Attempt to resolve issue #1117 

#### Other info (issues closed, discussion etc)
There might be other stuff going on there, but hopefully this does it. I should have realized that rstrip/lstrip should have been lstrip(" ") and rstrip(" ") originally when that unit test failed, my bad.

