### PR TITLE
Fix (maybe) to Windows evennia stop weirdness

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -714,12 +714,13 @@ def kill(pidfile, signal=SIG, succmsg="", errmsg="",
                 f.write("shutdown")
         try:
             if os.name == 'nt':
-                from win32api import GenerateConsoleCtrlEvent
+                from win32api import GenerateConsoleCtrlEvent, SetConsoleCtrlHandler
                 try:
                     # Windows can only send a SIGINT-like signal to
                     # *every* process spawned off the same console, so we must
                     # avoid killing ourselves here.
                     GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0)
+                    SetConsoleCtrlHandler(None, True)
                 except KeyboardInterrupt:
                     pass
             else:
@@ -732,12 +733,8 @@ def kill(pidfile, signal=SIG, succmsg="", errmsg="",
                   "The PID file 'server/%(pidfile)s' seems stale. "\
                   "Try removing it." % {'pid': pid, 'pidfile': pidfile})
             return
-        try:
-            print("Evennia:", succmsg)
-            return
-        except KeyboardInterrupt:
-            print("Evennia:", succmsg)
-            return
+        print("Evennia:", succmsg)
+        return
     print("Evennia:", errmsg)
 
 

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -732,8 +732,12 @@ def kill(pidfile, signal=SIG, succmsg="", errmsg="",
                   "The PID file 'server/%(pidfile)s' seems stale. "\
                   "Try removing it." % {'pid': pid, 'pidfile': pidfile})
             return
-        print("Evennia:", succmsg)
-        return
+        try:
+            print("Evennia:", succmsg)
+            return
+        except KeyboardInterrupt:
+            print("Evennia:", succmsg)
+            return
     print("Evennia:", errmsg)
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
These changes fixed two different tracebacks that kept popping up into evennia on windows for me - when doing 'evennia stop', I would consistently see a traceback from twisted about the reactor already being stopped, which was fixed by catching the exception in evennia_runner. The other was seeing a KeyboardInterrupt exception occasionally (not always) being raised by the message that prints out that the portal/server have been stopped in evennia_launcher's kill() function. It seems completely redundant, but catching KeyboardInterrupt just for that print statement fixed it.

#### Motivation for adding to Evennia
Fix some display error/traceback stuff on Windows. Was it just my install of Windows 7? Not sure!

#### Other info (issues closed, discussion etc)
I have no idea if this affected anyone else on Windows 7, since as you mentioned, it seems very finicky. Hopefully this wouldn't break anything for anyone else, though.