### PR TITLE
Get JQuery over HTTPS to prevent browsers from blocking it

### DIFF
--- a/evennia/web/webclient/templates/webclient/base.html
+++ b/evennia/web/webclient/templates/webclient/base.html
@@ -21,7 +21,7 @@ JQuery available.
 
     <!-- Import JQuery and warn if there is a problem -->
     {% block jquery_import %}
-        <script src="http://code.jquery.com/jquery-2.1.1.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://code.jquery.com/jquery-2.1.1.min.js" type="text/javascript" charset="utf-8"></script>
     {% endblock %}
 
     <script type="text/javascript" charset="utf-8">


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This does nothing more than get JQuery over HTTPS.

#### Motivation for adding to Evennia

In the current state (getting JQuery over HTTP), the webclient raises a security error when running on a remote server and accessed in a browser (I encountered this when running Evennia on c9.io). The webclient then fails to load, stating that JQuery was unavailable. This is possible for the user to get around by opting to "run unsafe scripts" in their browser, but that's a suboptimal experience. This is a simple fix with no potential fallout which will make the user experience smoother and improve security.

#### Other info (issues closed, discussion etc)

I think this is a no-brainer, but interested if there's anything that needs to be discussed around it. I didn't upgrade the JQuery version while I was in there because that's outside the focus of this fix, which is simply to make the webclient get JQuery with no fussing by the user.