### PR TITLE
Fix to error on django admin's objectdb creation

### DIFF
--- a/evennia/comms/admin.py
+++ b/evennia/comms/admin.py
@@ -6,6 +6,7 @@ This defines how Comm models are displayed in the web admin interface.
 from django.contrib import admin
 from evennia.comms.models import ChannelDB
 from evennia.typeclasses.admin import AttributeInline, TagInline
+from django.conf import settings
 
 
 class ChannelAttributeInline(AttributeInline):
@@ -69,5 +70,24 @@ class ChannelAdmin(admin.ModelAdmin):
 
         """
         return ", ".join([str(sub) for sub in obj.db_subscriptions.all()])
+
+    def save_model(self, request, obj, form, change):
+        """
+        Model-save hook.
+
+        Args:
+            request (Request): Incoming request.
+            obj (Object): Database object.
+            form (Form): Form instance.
+            change (bool): If this is a change or a new object.
+
+        """
+        obj.save()
+        if not change:
+            # adding a new object
+            # have to call init with typeclass passed to it
+            obj.set_class_from_typeclass(typeclass_path=settings.BASE_CHANNEL_TYPECLASS)
+        obj.at_init()
+
 
 admin.site.register(ChannelDB, ChannelAdmin)

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -147,13 +147,8 @@ class ObjectDBAdmin(admin.ModelAdmin):
         obj.save()
         if not change:
             # adding a new object
-            # no idea why this has to be called manually, __init__ does not seem to be called
-            from evennia.utils.utils import class_from_module
-            try:
-                typeclass = class_from_module(obj.db_typeclass_path)
-            except ImportError:
-                typeclass = class_from_module("evennia.objects.objects.DefaultObject")
-            obj.__class__ = typeclass
+            # have to call init with typeclass passed to it
+            obj.__init__(typeclass=obj.db_typeclass_path)
             obj.basetype_setup()
             obj.basetype_posthook_setup()
             obj.at_object_creation()

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -103,11 +103,6 @@ class ObjectDBAdmin(admin.ModelAdmin):
                            )}),
         )
 
-    def get_urls(self):
-        urls = super(ObjectDBAdmin, self).get_urls()
-        print urls
-        return urls
-
     def get_fieldsets(self, request, obj=None):
         """
         Return fieldsets.

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -103,6 +103,11 @@ class ObjectDBAdmin(admin.ModelAdmin):
                            )}),
         )
 
+    def get_urls(self):
+        urls = super(ObjectDBAdmin, self).get_urls()
+        print urls
+        return urls
+
     def get_fieldsets(self, request, obj=None):
         """
         Return fieldsets.
@@ -153,6 +158,13 @@ class ObjectDBAdmin(admin.ModelAdmin):
             obj.basetype_posthook_setup()
             obj.at_object_creation()
         obj.at_init()
+
+    def response_add(self, request, obj, post_url_continue=None):
+        if '_continue' in request.POST:
+            from django.http import HttpResponseRedirect
+            from django.core.urlresolvers import reverse
+            return HttpResponseRedirect(reverse("admin:objects_objectdb_change", args=[obj.id]))
+        return super(ObjectDBAdmin, self).response_add(request, obj, post_url_continue)
 
 
 admin.site.register(ObjectDB, ObjectDBAdmin)

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -147,6 +147,13 @@ class ObjectDBAdmin(admin.ModelAdmin):
         obj.save()
         if not change:
             # adding a new object
+            # no idea why this has to be called manually, __init__ does not seem to be called
+            from evennia.utils.utils import class_from_module
+            try:
+                typeclass = class_from_module(obj.db_typeclass_path)
+            except ImportError:
+                typeclass = class_from_module("evennia.objects.objects.DefaultObject")
+            obj.__class__ = typeclass
             obj.basetype_setup()
             obj.basetype_posthook_setup()
             obj.at_object_creation()

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -148,7 +148,7 @@ class ObjectDBAdmin(admin.ModelAdmin):
         if not change:
             # adding a new object
             # have to call init with typeclass passed to it
-            obj.__init__(typeclass=obj.db_typeclass_path)
+            obj.set_class_from_typeclass(typeclass_path=obj.db_typeclass_path)
             obj.basetype_setup()
             obj.basetype_posthook_setup()
             obj.at_object_creation()

--- a/evennia/players/admin.py
+++ b/evennia/players/admin.py
@@ -241,9 +241,16 @@ class PlayerDBAdmin(BaseUserAdmin):
         obj.save()
         if not change:
             #calling hooks for new player
-            ply = obj
-            ply.basetype_setup()
-            ply.at_player_creation()
+            obj.set_class_from_typeclass(typeclass_path=settings.BASE_PLAYER_TYPECLASS)
+            obj.basetype_setup()
+            obj.at_player_creation()
+
+    def response_add(self, request, obj, post_url_continue=None):
+        from django.http import HttpResponseRedirect
+        from django.core.urlresolvers import reverse
+        if '_continue' in request.POST:
+            return HttpResponseRedirect(reverse("admin:players_playerdb_change", args=[obj.id]))
+        return HttpResponseRedirect(reverse("admin:players_playerdb_change", args=[obj.id]))
 
     ## TODO! Remove User reference!
     #def save_formset(self, request, form, formset, change):

--- a/evennia/scripts/admin.py
+++ b/evennia/scripts/admin.py
@@ -2,6 +2,8 @@
 # This sets up how models are displayed
 # in the web admin interface.
 #
+from django.conf import settings
+
 from evennia.typeclasses.admin import AttributeInline, TagInline
 
 from evennia.scripts.models import ScriptDB
@@ -49,6 +51,23 @@ class ScriptDBAdmin(admin.ModelAdmin):
                             'db_obj')}),
         )
     inlines = [ScriptTagInline, ScriptAttributeInline]
+
+    def save_model(self, request, obj, form, change):
+        """
+        Model-save hook.
+
+        Args:
+            request (Request): Incoming request.
+            obj (Object): Database object.
+            form (Form): Form instance.
+            change (bool): If this is a change or a new object.
+
+        """
+        obj.save()
+        if not change:
+            # adding a new object
+            # have to call init with typeclass passed to it
+            obj.set_class_from_typeclass(typeclass_path=obj.db_typeclass_path)
 
 
 admin.site.register(ScriptDB, ScriptDBAdmin)

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -195,39 +195,7 @@ class TypedObject(SharedMemoryModel):
 
     # typeclass mechanism
 
-    def __init__(self, *args, **kwargs):
-        """
-        The `__init__` method of typeclasses is the core operational
-        code of the typeclass system, where it dynamically re-applies
-        a class based on the db_typeclass_path database field rather
-        than use the one in the model.
-
-        Args:
-            Passed through to parent.
-
-        Kwargs:
-            Passed through to parent.
-
-        Notes:
-            The loading mechanism will attempt the following steps:
-
-            1. Attempt to load typeclass given on command line
-            2. Attempt to load typeclass stored in db_typeclass_path
-            3. Attempt to load `__settingsclasspath__`, which is by the
-               default classes defined to be the respective user-set
-               base typeclass settings, like `BASE_OBJECT_TYPECLASS`.
-            4. Attempt to load `__defaultclasspath__`, which is the
-               base classes in the library, like DefaultObject etc.
-            5. If everything else fails, use the database model.
-
-            Normal operation is to load successfully at either step 1
-            or 2 depending on how the class was called. Tracebacks
-            will be logged for every step the loader must take beyond
-            2.
-
-        """
-        typeclass_path = kwargs.pop("typeclass", None)
-        super(TypedObject, self).__init__(*args, **kwargs)
+    def set_class_from_typeclass(self, typeclass_path=None):
         if typeclass_path:
             try:
                 self.__class__ = class_from_module(typeclass_path, defaultpaths=settings.TYPECLASS_PATHS)
@@ -265,6 +233,42 @@ class TypedObject(SharedMemoryModel):
             self.__dbclass__ = class_from_module("evennia.objects.models.ObjectDB")
             self.db_typeclass_path = "evennia.objects.objects.DefaultObject"
             log_trace("Critical: Class %s of %s is not a valid typeclass!\nTemporarily falling back to %s." % (err_class, self, self.__class__))
+
+    def __init__(self, *args, **kwargs):
+        """
+        The `__init__` method of typeclasses is the core operational
+        code of the typeclass system, where it dynamically re-applies
+        a class based on the db_typeclass_path database field rather
+        than use the one in the model.
+
+        Args:
+            Passed through to parent.
+
+        Kwargs:
+            Passed through to parent.
+
+        Notes:
+            The loading mechanism will attempt the following steps:
+
+            1. Attempt to load typeclass given on command line
+            2. Attempt to load typeclass stored in db_typeclass_path
+            3. Attempt to load `__settingsclasspath__`, which is by the
+               default classes defined to be the respective user-set
+               base typeclass settings, like `BASE_OBJECT_TYPECLASS`.
+            4. Attempt to load `__defaultclasspath__`, which is the
+               base classes in the library, like DefaultObject etc.
+            5. If everything else fails, use the database model.
+
+            Normal operation is to load successfully at either step 1
+            or 2 depending on how the class was called. Tracebacks
+            will be logged for every step the loader must take beyond
+            2.
+
+        """
+        typeclass_path = kwargs.pop("typeclass", None)
+        super(TypedObject, self).__init__(*args, **kwargs)
+        self.set_class_from_typeclass(typeclass_path=typeclass_path)
+
 
     # initialize all handlers in a lazy fashion
     @lazy_property

--- a/evennia/utils/picklefield.py
+++ b/evennia/utils/picklefield.py
@@ -147,8 +147,11 @@ class PickledFormField(CharField):
         super(PickledFormField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        if not value.strip():
-            # Field was left blank. Make this None.
+        try:
+            if not value.strip():
+                # Field was left blank. Make this None.
+                value = 'None'
+        except AttributeError:
             value = 'None'
         try:
             return literal_eval(value)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
For some reason, the save_model method in ObjectDB admin doesn't seem to properly assign the typeclass when an object is being created, which causes server errors in creating the object. Additionally, it prevents the server from being reloaded, as ObjectDB.get_all_cached_instances() will fail with an ObjectDB lacking a typeclass and raising an AttributeError when at_server_reload is called.

#### Motivation for adding to Evennia
Prevent nasty errors on attempting to create an object from django admin.

#### Other info (issues closed, discussion etc)
The real question is why the typeclass isn't assigned normally from `TypedObject.__init__`, and I don't have an answer there. I even tried explicitly importing and calling `TypedObject.__init__(obj)` just to see if it would work, and nothing. Apparently the `__class__` has to be specifically assigned here, and I have no idea why.

