### PR TITLE
Put in check for maximum character size in input strings

### DIFF
--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -18,9 +18,11 @@ _MOD_IMPORT = None
 # throttles
 _MAX_CONNECTION_RATE = float(settings.MAX_CONNECTION_RATE)
 _MAX_COMMAND_RATE = float(settings.MAX_COMMAND_RATE)
+_MAX_CHAR_LIMIT = settings.MAX_CHAR_LIMIT
 
 _MIN_TIME_BETWEEN_CONNECTS = 1.0 / float(settings.MAX_CONNECTION_RATE)
 _ERROR_COMMAND_OVERFLOW = settings.COMMAND_RATE_WARNING
+_ERROR_MAX_CHAR = settings.MAX_CHAR_LIMIT_WARNING
 
 _CONNECTION_QUEUE = deque()
 
@@ -354,7 +356,14 @@ class PortalSessionHandler(SessionHandler):
         """
         #from evennia.server.profiling.timetrace import timetrace
         #text = timetrace(text, "portalsessionhandler.data_in")
-
+        try:
+            text = kwargs['text']
+            if _MAX_CHAR_LIMIT and len(text) > _MAX_CHAR_LIMIT:
+                if session:
+                    self.data_out(session, text=[[_ERROR_MAX_CHAR], {}])
+                return
+        except Exception:
+            pass
         if session:
             now = time()
             if self.command_counter > _MAX_COMMAND_RATE:

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -18,7 +18,7 @@ _MOD_IMPORT = None
 # throttles
 _MAX_CONNECTION_RATE = float(settings.MAX_CONNECTION_RATE)
 _MAX_COMMAND_RATE = float(settings.MAX_COMMAND_RATE)
-_MAX_CHAR_LIMIT = settings.MAX_CHAR_LIMIT
+_MAX_CHAR_LIMIT = int(settings.MAX_CHAR_LIMIT)
 
 _MIN_TIME_BETWEEN_CONNECTS = 1.0 / float(settings.MAX_CONNECTION_RATE)
 _ERROR_COMMAND_OVERFLOW = settings.COMMAND_RATE_WARNING
@@ -358,7 +358,7 @@ class PortalSessionHandler(SessionHandler):
         #text = timetrace(text, "portalsessionhandler.data_in")
         try:
             text = kwargs['text']
-            if _MAX_CHAR_LIMIT and len(text) > _MAX_CHAR_LIMIT:
+            if (_MAX_CHAR_LIMIT > 0) and len(text) > _MAX_CHAR_LIMIT:
                 if session:
                     self.data_out(session, text=[[_ERROR_MAX_CHAR], {}])
                 return

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -203,10 +203,9 @@ MAX_COMMAND_RATE = 80
 COMMAND_RATE_WARNING ="You entered commands too fast. Wait a moment and try again."
 # Determine how large of a string can be sent to the server in number
 # of characters. If they attempt to enter a string over this character
-# limit, we stop them and send a message. Set to None by default. To
-# change it, just set it to a number of characters - ie, 6000 to be
-# roughly two pages of text.
-MAX_CHAR_LIMIT = None
+# limit, we stop them and send a message. To make unlimited, set to
+# 0 or less.
+MAX_CHAR_LIMIT = 6000
 # The warning to echo back to users if they enter a very large string
 MAX_CHAR_LIMIT_WARNING="You entered a string that was too large. Please break it up into separate commands."
 # If this is true, errors and tracebacks from the engine will be

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -201,6 +201,14 @@ MAX_CONNECTION_RATE = 2
 MAX_COMMAND_RATE = 80
 # The warning to echo back to users if they send commands too fast
 COMMAND_RATE_WARNING ="You entered commands too fast. Wait a moment and try again."
+# Determine how large of a string can be sent to the server in number
+# of characters. If they attempt to enter a string over this character
+# limit, we stop them and send a message. Set to None by default. To
+# change it, just set it to a number of characters - ie, 6000 to be
+# roughly two pages of text.
+MAX_CHAR_LIMIT = None
+# The warning to echo back to users if they enter a very large string
+MAX_CHAR_LIMIT_WARNING="You entered a string that was too large. Please break it up into separate commands."
 # If this is true, errors and tracebacks from the engine will be
 # echoed as text in-game as well as to the log. This can speed up
 # debugging. Showing full tracebacks to regular users could be a


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just an optional setting, MAX_CHAR_LIMIT, that lets you specify the maximum length of any string passed on from the portalsessionhandler to the server, to prevent people from obnoxiously spamming and the like.

#### Motivation for adding to Evennia
Just a little optional anti-troll protection.

#### Other info (issues closed, discussion etc)
I made the default None, which leaves it uncapped, so current behavior is unaffected.