### PR TITLE
set the from_obj for CmdSay and CmdPose, so they can be used properly

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -417,7 +417,7 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
         emit_string = '%s says, "%s{n"' % (caller.name,
                                                speech)
         caller.location.msg_contents(emit_string,
-                                     exclude=caller)
+                                     exclude=caller, from_obj=caller)
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):
@@ -460,7 +460,7 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents(msg)
+            self.caller.location.msg_contents(msg, from_obj=self.caller)
 
 
 class CmdAccess(COMMAND_DEFAULT_CLASS):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just a little change to CmdSay and CmdPose to set from_obj to be the caller, so that it can be used in msg_contents/msg.

#### Motivation for adding to Evennia
Allow from_obj to be used for CmdSay and CmdPose to identify the person who executed the command from various hooks, for things like logging and so on.

#### Other info (issues closed, discussion etc)
N/A

