### PR TITLE
Adding aliases to help entries

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -145,6 +145,7 @@ class CmdHelp(Command):
         if len(match) == 1:
             self.msg(format_help_entry(match[0].key,
                      match[0].entrytext,
+                     aliases=match[0].aliases.all(),
                      suggested=suggestions))
             return
 

--- a/evennia/help/manager.py
+++ b/evennia/help/manager.py
@@ -42,6 +42,8 @@ class HelpEntryManager(TypedObjectManager):
         if dbref:
             return self.filter(id=dbref)
         topics = self.filter(db_key__iexact=topicstr)
+        if not topics:
+            topics = self.get_by_alias(topicstr)
         if not topics and not exact:
             topics = self.filter(db_key__istartswith=topicstr)
             if not topics:

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -14,7 +14,7 @@ from builtins import object
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 from evennia.help.manager import HelpEntryManager
-from evennia.typeclasses.models import Tag, TagHandler
+from evennia.typeclasses.models import Tag, TagHandler, AliasHandler
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import lazy_property
 __all__ = ("HelpEntry",)
@@ -78,6 +78,9 @@ class HelpEntry(SharedMemoryModel):
     def tags(self):
         return TagHandler(self)
 
+    @lazy_property
+    def aliases(self):
+        return AliasHandler(self)
 
     class Meta(object):
         "Define Django meta options"


### PR DESCRIPTION
Adding support for aliases on help files. This includes giving an AliasHandler to HelpEntry, updating HelpEntryManager to match searches on aliases, and modifying the default help command to display aliases in formatted topic help files.