### PR TITLE
fix evmore sending messages to stale session object

### DIFF
--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -197,6 +197,14 @@ class EvMore(object):
         page = _DISPLAY.format(text=text,
                                pageno=pos + 1,
                                pagemax=self._npages)
+        # check to make sure our session is still valid
+        sessions = self._caller.sessions.get()
+        if not sessions:
+            self.page_quit()
+            return
+        # this must be an 'is', not == check
+        if not any(ses for ses in sessions if self._session is ses):
+            self._session = sessions[0]
         self._caller.msg(text=page, session=self._session, **self._kwargs)
 
     def page_top(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If a player is inside an EvMore page and disconnect then reconnect, they will only get blank messages from the pager, because it tries to send to a session object that is no longer attached to them. Changed display method to check for this and hook it back up to the correct session if necessary.

#### Motivation for adding to Evennia
Fix for players wondering why they can't see anything if they reconnect from when they were inside an EvMore pager.

#### Other info (issues closed, discussion etc)
N/A
