### PR TITLE
Fix an issues were exit aliases weren't being check when interating o…

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1240,7 +1240,8 @@ class CmdOpen(ObjManipCommand):
                 if old_destination.id != destination.id:
                     # reroute the old exit.
                     exit_obj.destination = destination
-                    [exit_obj.aliases.add(alias) for alias in exit_aliases]
+                    if exit_aliases:
+                        [exit_obj.aliases.add(alias) for alias in exit_aliases]
                     string += " Rerouted its old destination '%s' to '%s' and changed aliases." % \
                         (old_destination.name, destination.name)
                 else:
@@ -1258,9 +1259,10 @@ class CmdOpen(ObjManipCommand):
             if exit_obj:
                 # storing a destination is what makes it an exit!
                 exit_obj.destination = destination
-                string = "Created new Exit '%s' from %s to %s (aliases: %s)." % (exit_name,location.name,
-                                                                                 destination.name,
-                                                                                 ", ".join([str(e) for e in exit_aliases]))
+                string = "" if not exit_aliases else " (aliases: %s)" % (
+                    ", ".join([str(e) for e in exit_aliases]))
+                string = "Created new Exit '%s' from %s to %s%s." % (
+                    exit_name, location.name, destination.name, string)
             else:
                 string = "Error: Exit '%s' not created." % (exit_name)
         # emit results


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The create_exit method for CmdOpen uses None as a default value for exit_aliases. Within the body of the code, exit_aliases is iterated over in two parts of the body. Neither verify if it contains a valid value. If exit_aliases is left as None, a NoneType exception is thrown. 

#### Motivation for adding to Evennia
CmdOpen will never throw an exception because it always passes an array (even if empty) to the create_exit method. However, anyone unknowing inheriting this class and extending it might try to reuse the command and run into the error. If the method defaults the parameter to a None value, then it's the responsibility of the method to error check this. The alternatives would be to default exit_alises to an empty array (which I believe isn't recommended due to how scoping and manipulations work), or making it a required variable.

#### Other info (issues closed, discussion etc)
N/A