### PR TITLE
Send an OOB message to the client once a player logs in.

### DIFF
--- a/evennia/players/players.py
+++ b/evennia/players/players.py
@@ -725,6 +725,10 @@ class DefaultPlayer(with_metaclass(TypeclassBase, PlayerDB)):
         if session and protocol_flags:
             session.update_flags(**protocol_flags)
 
+        # inform the client that we logged in through an OOB message
+        if session:
+            session.msg(logged_in={})
+            
         self._send_to_connect_channel("|G%s connected|n" % self.key)
         if _MULTISESSION_MODE == 0:
             # in this mode we should have only one character available. We

--- a/evennia/web/webclient/static/webclient/js/webclient_gui.js
+++ b/evennia/web/webclient/static/webclient/js/webclient_gui.js
@@ -220,6 +220,10 @@ function onPrompt(args, kwargs) {
     doWindowResize();
 }
 
+// Called when the user logged in
+function onLoggedIn() {
+}
+
 // Silences events we don't do anything with.
 function onSilence(cmdname, args, kwargs) {}
 
@@ -337,6 +341,7 @@ $(document).ready(function() {
     Evennia.emitter.on("prompt", onPrompt);
     Evennia.emitter.on("default", onDefault);
     Evennia.emitter.on("connection_close", onConnectionClose);
+    Evennia.emitter.on("logged_in", onLoggedIn);
     // silence currently unused events
     Evennia.emitter.on("connection_open", onSilence);
     Evennia.emitter.on("connection_error", onSilence);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This sends an OOB message to the client once the player logs in.

#### Motivation for adding to Evennia
This is useful so that the client knows it can retrieve character/player specific data (like player avatar, player description, client settings, ...).
The idea is that, once the client gets this message, it sends OOB messages back to the server to retrieve whatever it needs.

#### Other info (issues closed, discussion etc)
I think this is better than the other way around (as soon as the player logs in, the server sending the data the client wants straight away).
This makes making different clients easier (for instance a desktop webclient and another phone webclient): the server doesn't need to know the difference between the different clients as they each are responsible for retrieving the data they need.

I plan on using this as part of #614: this step will allow the client to start monitoring/retrieving the saved settings from the server.