### PR TITLE
Fixes error messages on the boot command

### DIFF
--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -67,12 +67,12 @@ class CmdBoot(COMMAND_DEFAULT_CLASS):
             # Boot by player object
             pobj = search.player_search(args)
             if not pobj:
-                self.caller("Player %s was not found." % args)
+                caller.msg("Player %s was not found." % args)
                 return
             pobj = pobj[0]
             if not pobj.access(caller, 'boot'):
-                string = "You don't have the permission to boot %s."
-                pobj.msg(string)
+                string = "You don't have the permission to boot %s." % (pobj.key, )
+                caller.msg(string)
                 return
             # we have a bootable object with a connected user
             matches = SESSIONS.sessions_from_player(pobj)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Two small fixes for the `@boot` command:

- No traceback if the booted player is not found
- Send a message to the correct player if the lockfunc fails

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
