### PR TITLE
Changed example use of _menutree

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -511,7 +511,7 @@ class EvMenu(object):
                 the latest visited node will be re-run using this kwarg.
 
         Kwargs:
-            any (any): All kwargs will become initialization variables on `caller._menutree`,
+            any (any): All kwargs will become initialization variables on `caller.ndb._menutree`,
                 to be available at run.
 
         Raises:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Docstring left out ndb reference. Added