### PR TITLE
Update format_output on CmdExamine to display obj.email.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1913,7 +1913,7 @@ class CmdExamine(ObjManipCommand):
             string += "\n|wSession id(s)|n: %s" % (", ".join("#%i" % sess.sessid
                                                 for sess in obj.sessions.all()))
         if hasattr(obj, "email") and obj.email:
-            string += "\n|wE-Mail:|n: |c%s|n" % obj.email              
+            string += "\n|wEmail|n: |c%s|n" % obj.email              
         if hasattr(obj, "has_player") and obj.has_player:
             string += "\n|wPlayer|n: |c%s|n" % obj.player.name
             perms = obj.player.permissions.all()

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1912,6 +1912,8 @@ class CmdExamine(ObjManipCommand):
         if hasattr(obj, "sessions") and obj.sessions.all():
             string += "\n|wSession id(s)|n: %s" % (", ".join("#%i" % sess.sessid
                                                 for sess in obj.sessions.all()))
+        if hasattr(obj, "email") and obj.email:
+            string += "\n|wE-Mail:|n: |c%s|n" % obj.email              
         if hasattr(obj, "has_player") and obj.has_player:
             string += "\n|wPlayer|n: |c%s|n" % obj.player.name
             perms = obj.player.permissions.all()


### PR DESCRIPTION
Updated format_output on CmdExamine to add a check for email attribute. If true, it displays the email address.

#### Motivation for adding to Evennia
Several other contribs ask for an email , and setting up the superuser adds this attribute in stock Evennia. Spent several hours trying to figure out why it wasn't displaying in exam before @Days4121 and I realized that it was set as a direct attribute, and not a db.attribute. Made it display in exam.
