### PR TITLE
Fix get_all_scripts to not return [None]

### DIFF
--- a/evennia/scripts/manager.py
+++ b/evennia/scripts/manager.py
@@ -85,7 +85,7 @@ class ScriptDBManager(TypedObjectManager):
             script = []
             dbref = self.dbref(key)
             if dbref or dbref == 0:
-                script = [self.dbref_search(dbref)]
+                script = filter(None, [self.dbref_search(dbref)])
             if not script:
                 script = self.filter(db_key=key)
             return script


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This is a small fix for get_all_script to return [] instead of [None] when searching for a script by `#dbref` and that script does not exist.

#### Motivation for adding to Evennia
When using `@script/stop #nonexistendid` the user would get a python traceback. Now they'll get a nice error message saying the script can't be found.

#### Other info (issues closed, discussion etc)
