### PR TITLE
When calling EvMenu as a player, the session is not passed through wh…

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -510,7 +510,10 @@ class EvMenu(object):
             startnode_input (str, optional): Send an input text to `startnode` as if
                 a user input text from a fictional previous node. When the server reloads,
                 the latest visited node will be re-run using this kwarg.
-
+            session(Session, optional): If the caller is a player and specifies
+                a player command (a command with the player_caller set to true)
+                for the cmd_on_exit value, the session needs to be set in to 
+                execute properly.
         Kwargs:
             any (any): All kwargs will become initialization variables on `caller.ndb._menutree`,
                 to be available at run.

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -420,7 +420,8 @@ class EvMenu(object):
                  options_formatter=evtable_options_formatter,
                  node_formatter=underline_node_formatter,
                  input_parser=evtable_parse_input,
-                 persistent=False, startnode_input="", **kwargs):
+                 persistent=False, startnode_input="", 
+                 session=None, **kwargs):
         """
         Initialize the menu tree and start the caller onto the first node.
 
@@ -544,7 +545,7 @@ class EvMenu(object):
         self.auto_look = auto_look
         self.auto_help = auto_help
         if isinstance(cmd_on_exit, str):
-            self.cmd_on_exit = lambda caller, menu: caller.execute_cmd(cmd_on_exit)
+            self.cmd_on_exit = lambda caller, menu: caller.execute_cmd(cmd_on_exit, session)
         elif callable(cmd_on_exit):
             self.cmd_on_exit = cmd_on_exit
         else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When calling EvMenu as a player, the session is not passed which causes issues for cmd_on_exit commands that have player_caller = true. EvMenu executes cmd_on_exit via execute_cmd function, but leave session empty. In the parse() of the MuxCommand, it attempts to retrieve a player's puppet via the session but has no check to see if it's None. The change just opens up an optional keyword argument to pass the session through to avoid this issue.

Alternatively, the MuxCommand parse() could have defensive measure to check to see if a session not none before attempting to retrieve a puppet. (https://github.com/evennia/evennia/blob/master/evennia/commands/default/muxcommand.py#L206) I'm conflicted on which one would make more sense as a player should always have a session and by putting a None check, the code reads as though it's possible to have a player without a session.

#### Motivation for adding to Evennia
I'm honestly not sure how much is to be gained fixing this bug because I'm not sure who else would actually run into the issue because I do realize that have a menu on a player level may cause a multitude of issues. I'll leave it for 3rd parties to comment on the usefulness.

#### Other info (issues closed, discussion etc)
If this change is accepted,  a note on the wiki should probably be added to document the addition of the new keyword parameter to specify that if the caller is a player and the cmd_on_exit command is a player_caller = true command, this field needs to be set.
