### PR TITLE
Webclient: don't strip single leading space at the start of a line

### DIFF
--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -93,7 +93,7 @@ class TextToHTMLparser(object):
     re_uline = re.compile("(?:%s)(.*?)(?=%s|%s)" % (underline.replace("[", r"\["), fgstop, bgstop))
     re_blink = re.compile("(?:%s)(.*?)(?=%s|%s)" % (blink.replace("[", r"\["), fgstop, bgstop))
     re_inverse = re.compile("(?:%s)(.*?)(?=%s|%s)" % (inverse.replace("[", r"\["), fgstop, bgstop))
-    re_string = re.compile(r'(?P<htmlchars>[<&>])|(?P<space> [ \t]+)|(?P<lineend>\r\n|\r|\n)', re.S|re.M|re.I)
+    re_string = re.compile(r'(?P<htmlchars>[<&>])|(?P<space> [ \t]+)|(?P<spacestart>^ )|(?P<lineend>\r\n|\r|\n)', re.S|re.M|re.I)
     re_url = re.compile(r'((?:ftp|www|https?)\W+(?:(?!\.(?:\s|$)|&\w+;)[^"\',;$*^\\(){}<>\[\]\s])+)(\.(?:\s|$)|&\w+;|)')
     re_mxplink =  re.compile(r'\|lc(.*?)\|lt(.*?)\|le', re.DOTALL)
 
@@ -269,7 +269,7 @@ class TextToHTMLparser(object):
             return '<br>'
         elif cdict['space'] == '\t':
             return ' ' * self.tabstop
-        elif cdict['space']:
+        elif cdict['space'] or cdict["spacestart"]:
             text = match.group().replace('\t', '&nbsp;' * self.tabstop)
             text = text.replace(' ', '&nbsp;')
             return text


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When displaying a line that starts with a single space, the webclient won't render it.
Quick example:
```
>>> me.msg("|_This is a line.")
This is a line.
None
>>> me.msg("|_|_This is a line.")
  This is a line.
None
```
The second line with two leading spaces shows both spaces.
The first line with only one leading space won't render that space.

This is an issue only in the webclient. Telnet works fine.

#### Motivation for adding to Evennia
Bugfix.

#### Other info (issues closed, discussion etc)
