### PR TITLE
Change taghandler clear to delete through models, not Tags themselves

### DIFF
--- a/evennia/typeclasses/tags.py
+++ b/evennia/typeclasses/tags.py
@@ -325,10 +325,10 @@ class TagHandler(object):
                 category.
 
         """
-        query = {"db_model": self._model, "db_tagtype": self._tagtype}
+        query = {"%s__id" % self._model : self._objid, "tag__db_model": self._model, "tag__db_tagtype": self._tagtype}
         if category:
-            query["db_category"] = category.strip().lower()
-        getattr(self.obj, self._m2m_fieldname).filter(**query).delete()
+            query["tag__db_category"] = category.strip().lower()
+        getattr(self.obj, self._m2m_fieldname).through.objects.filter(**query).delete()
         self._cache = {}
         self._catcache = {}
         self._cache_complete = False


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`Taghandler.clear()` calls delete on a queryset of Tags, not the through model, resulting in deleting tags for all objects rather than just the object trying to clear the tags. It was easy to miss because of caching making the other tags appear to remain until a `@reload` wiped them.

#### Motivation for adding to Evennia
Fix other tags disappearing if tags are cleared.

#### Other info (issues closed, discussion etc)
N/A