### PR TITLE
Fix for multisession mode 1 switching locations on login

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1494,7 +1494,7 @@ class DefaultCharacter(DefaultObject):
             session (Session): Session controlling the connection.
 
         """
-        if self.db.prelogout_location:
+        if self.db.prelogout_location and not self.location:
             # try to recover
             self.location = self.db.prelogout_location
         if self.location is None:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In `MULTISESSION_MODE = 1`, logging in another session of the character would switch their location. Prevented that with the check.

#### Motivation for adding to Evennia
Prevent snapping back to `_prelogout_location` on login of another session.

#### Other info (issues closed, discussion etc)
N/A
