### PR TITLE
Add a method to customize the help message of a command

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -127,7 +127,11 @@ class Command(with_metaclass(CommandMeta, object)):
 
     (Note that if auto_help is on, this initial string is also used by the
     system to create the help entry for the command, so it's a good idea to
-    format it similar to this one)
+    format it similar to this one).  This behavior can be changed by
+    overriding the method 'get_help' of a command: by default, this
+    method returns cmd.__doc__ (that is, this very docstring, or
+    the docstring of your command).  You can, however, extend or
+    replace this without disabling auto_help.
     """
 
     # the main way to call this command (e.g. 'look')
@@ -423,3 +427,22 @@ class Command(with_metaclass(CommandMeta, object)):
         if hasattr(self, 'obj') and self.obj != caller:
             return " (%s)" % self.obj.get_display_name(caller).strip()
         return ""
+
+    def get_help(self, caller, cmdset):
+        """
+        Return the help message for this command and this caller.
+
+        By default, return self.__doc__ (the docstring just under
+        the class definition).  You can override this behavior,
+        though, and even customize it depending on the caller.
+
+        Args:
+            self: the command itself.
+            caller: the caller asking for help on the command.
+            cmdset: the command set (if you need additional commands).
+
+        This should return the string of the help message for this
+        command.
+
+        """
+        return self.__doc__

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -434,15 +434,15 @@ class Command(with_metaclass(CommandMeta, object)):
 
         By default, return self.__doc__ (the docstring just under
         the class definition).  You can override this behavior,
-        though, and even customize it depending on the caller.
+        though, and even customize it depending on the caller, or other
+        commands the caller can use.
 
         Args:
-            self: the command itself.
-            caller: the caller asking for help on the command.
-            cmdset: the command set (if you need additional commands).
+            caller (Object or Player): the caller asking for help on the command.
+            cmdset (CmdSet): the command set (if you need additional commands).
 
-        This should return the string of the help message for this
-        command.
+        Returns:
+            docstring (str): the help text to provide the caller for this command.
 
         """
         return self.__doc__

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -196,7 +196,7 @@ class CmdHelp(Command):
         match = [cmd for cmd in all_cmds if cmd == query]
         if len(match) == 1:
             formatted = self.format_help_entry(match[0].key,
-                     match[0].__doc__,
+                     match[0].get_help(caller, cmdset),
                      aliases=match[0].aliases,
                      suggested=suggestions)
             if type(self).help_more:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This pull request adds a method 'get_help' to all commands.  By default, this method simply returns the command's docstring, but one can create a command that still uses 'auto_help', but displays a customizable message.

#### Motivation for adding to Evennia

The 'auto_help' system is great, but it's either on or off.  This pull request offers an alternative: a way to customize the help of commands without rejecting their docstring.

Example: I have a set of commands with sub-commands (separated by spaces), like "room" (master command), "room list" (see the list of rooms in the area), "room name" (change the name of the room) and so on.  When one enters "help room", he/she should see the other sub-commands available.  Updating the "room" docstring could increase the potential for errors.  But the help system could auto-generate help for this command (and sub-commands) very easily.