### PR TITLE
Fixed typo in wilderness.py

### DIFF
--- a/evennia/contrib/wilderness.py
+++ b/evennia/contrib/wilderness.py
@@ -85,7 +85,7 @@ Customisation example:
             else:
                 return "Inside a pyramid."
 
-        def at_prepare_room(self, coordinats, caller, room):
+        def at_prepare_room(self, coordinates, caller, room):
             "Any other changes done to the room before showing it"
             x, y = coordinates
             desc = "This is a room in the pyramid.


### PR DESCRIPTION
Changed instance 'coordinats' to 'coordinates' in pyramid example map code

#### Brief overview of PR changes/additions
Just a typo fix!

#### Motivation for adding to Evennia
There should be less typos!
