### PR TITLE
New feature: xterm grayscale palette (2+24 colors)

### DIFF
--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -751,6 +751,18 @@ class CmdColorTest(COMMAND_DEFAULT_CLASS):
             string = "Xterm256 colors (if not all hues show, your client might not report that it can handle xterm256):"
             for row in table:
                 string += "\n" + "".join(row)
+            table = [[], [], [], [], [], [], [], [], [], [], [], []]
+            for ibatch in range(4):
+                for igray in range(6):
+                    letter = chr(97 + 1 + (ibatch*6 + igray))
+                    table[0 + igray].append("|=%s%s |n" % (letter, "||=%s" % (letter)))
+                    table[6 + igray].append("|%i%i%i|[=%s%s |n" % (5, 0, 0, letter, "||[=%s" % (letter)))
+            table = self.table_format(table)
+            string += "\n"
+            string += "\n   Pure black (||=a)      |=a||=a |n |[=a      Pure black (||[=a)       |500||[=a |n|[=a|n "
+            for row in table:
+                string += "\n" + "".join(row)
+            string += "\n   Pure white (||=z)      |=z||=z |n |[=z      Pure white (||[=z)       |500||[=z |n|[=z|n "
             self.msg(string)
             #self.msg("(e.g. %%123 and %%[123 also work)")
         else:
@@ -819,4 +831,3 @@ class CmdQuell(COMMAND_DEFAULT_CLASS):
             else:
                 self.msg("Quelling Player permissions%s. Use @unquell to get them back." % permstr)
         self._recache_locks(player)
-

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -426,12 +426,6 @@ class ANSIParser(object):
     xterm256_map = [
         (r'\{[0-5]{3}', ""),   # {123 - foreground colour
         (r'\{\[[0-5]{3}', ""),   # {[123 - background colour
-        ## -style
-        (r'\|[0-5]{3}', ""),  # |123 - foreground colour
-        (r'\|\[[0-5]{3}', ""),  # |[123 - background colour
-
-        (r'\{[0-5]{3}', ""),   # {123 - foreground colour
-        (r'\{\[[0-5]{3}', ""),   # {[123 - background colour
         ## |-style
         (r'\|[0-5]{3}', ""),  # |123 - foreground colour
         (r'\|\[[0-5]{3}', ""),  # |[123 - background colour

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -141,9 +141,9 @@ class ANSIParser(object):
             # grayscale values (xterm indexes 0, 232-255, 15) for full spectrum
             letter = rgbtag[int(background) + 1]
             if (letter == 'a'):
-                colval = 0         # ansi black @ index 0
+                colval = 16     # pure black @ index 16 (first color cube entry)
             elif (letter == 'z'):
-                colval = 15        # ansi white @ index 15
+                colval = 231    # pure white @ index 231 (last color cube entry)
             else:
                 # letter in range [b..y] (exactly 24 values!)
                 colval = 134 + ord(letter)

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -130,13 +130,33 @@ class ANSIParser(object):
         rgbtag = rgbmatch.group()[1:]
 
         background = rgbtag[0] == '['
-        if background:
-            red, green, blue = int(rgbtag[1]), int(rgbtag[2]), int(rgbtag[3])
+        grayscale  = rgbtag[0 + int(background)] == '='
+        if not grayscale:
+            # 6x6x6 color-cube (xterm indexes 16-231)
+            if background:
+                red, green, blue = int(rgbtag[1]), int(rgbtag[2]), int(rgbtag[3])
+            else:
+                red, green, blue = int(rgbtag[0]), int(rgbtag[1]), int(rgbtag[2])
         else:
-            red, green, blue = int(rgbtag[0]), int(rgbtag[1]), int(rgbtag[2])
+            # grayscale values (xterm indexes 0, 232-255, 15) for full spectrum
+            letter = rgbtag[int(background) + 1]
+            if (letter == 'a'):
+                colval = 0         # ansi black @ index 0
+            elif (letter == 'z'):
+                colval = 15        # ansi white @ index 15
+            else:
+                # letter in range [b..y] (exactly 24 values!)
+                colval = 134 + ord(letter)
+
+            # ansi fallback logic expects r,g,b values in [0..5] range
+            gray = (ord(letter)-97)/5.0
+            r, g, b = gray, gray, gray
 
         if use_xterm256:
-            colval = 16 + (red * 36) + (green * 6) + blue
+
+            if not grayscale:
+                colval = 16 + (red * 36) + (green * 6) + blue
+
             return "\033[%s8;5;%sm" % (3 + int(background), colval)
             # replaced since some cliens (like Potato) does not accept codes with leading zeroes, see issue #1024.
             #return "\033[%s8;5;%s%s%sm" % (3 + int(background), colval // 100, (colval % 100) // 10, colval%10)
@@ -429,6 +449,12 @@ class ANSIParser(object):
         ## |-style
         (r'\|[0-5]{3}', ""),  # |123 - foreground colour
         (r'\|\[[0-5]{3}', ""),  # |[123 - background colour
+
+        ## grayscale entries including ansi extremes: {=a .. {=z
+        (r'\{=[a-z]', ""),
+        (r'\{\[=[a-z]', ""),
+        (r'\|=[a-z]', ""),
+        (r'\|\[=[a-z]', ""),
         ]
 
     mxp_re = r'\|lc(.*?)\|lt(.*?)\|le'

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -150,7 +150,7 @@ class ANSIParser(object):
 
             # ansi fallback logic expects r,g,b values in [0..5] range
             gray = (ord(letter)-97)/5.0
-            r, g, b = gray, gray, gray
+            red, green, blue = gray, gray, gray
 
         if use_xterm256:
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR adds support for the grayscale range of the 256-color palette (palette entries 232-255). It makes these available for both foreground and background colors. Because the numbers worked out nicely (24 grayscale xterm entries @ index 232..255 + pure black @ index 0 + pure white @ index 15), the roman alphabet is leveraged to index the entire grayscale spectrum from one command.

The new markup should match the existing logic behind the formatting of existing Evennia-specific markup; first the PIPE / ACCOLADE, then a possible BACKGROUND marker, then the specification of the color. For existing markup codes, this could be an ANSI 'letter' or xterm RGB number.

I have chosen the EQUALS SIGN (=) as the 'grayscale marker'; it is not yet used, easily accessible on most keyboards and the two-lines give me a feeling of belonging with the monochrome nature of the palette.

All of the above reasoning combined gives the following new markup codes which are implemented in this PR:

`|=a` thru `|=z` affect the foreground from BLACK to WHITE.
`|[=a` thru `|[=z` affect the background from BLACK to WHITE.

`{=` and `{[=` varieties have also been implemented.

#### Motivation for adding to Evennia

The game I play on (ARXmush) has a bunch of pretty good crafters, and while the six 'rgb' grayscale shades work alright for most cases, I do hear the occasional grumble about some gradients not being able to look nice. Which reminded me (having messed with the xterm spec on several occasions in the past) that it is a bit wasteful not to have the rest of the palette available for use. Having checked the Evennia codebase at an earlier date, I could verify that Evennia has zero support for these shades itself, thus making upstream the logical place to implement it. 

Additionally, Tehom is a wise man and wants to avoid editing stock files as much as possible to keep merging and conflicts to a minimum. ;-) Thus my arrival at the source of it all to help the greater world.

#### Other info (issues closed, discussion etc)

I noticed doubled entries in `xterm256_map` when I started; I have removed those because they seemed to serve no purpose. (Everything still works fine from what I could test.)

The implementation for this new functionality was added inside `ANSIParser.sub_xterm256()` for several reasons:

1. It minimally affects the rest of the codebase; otherwise I would have had to figure out the best way to add the regexes for these particular markup sequences.
2. It fits the name; it is still a xterm256 feature, and the mapping `xterm256_map` remains accurate.
3. The ansi-fallback code is inside of `ANSIParser.sub_xterm256()`; duplicating that into my own function would just cause code-duplication and make it harder to maintain the aspect of gracefully downgrading to ANSI in the future.

A grayscale color-swatch has also been added to @colors xterm256. I went through a couple of testing variations and ended up with something that matches the existing 6x6x6 color cube swatches in layout. However, due to this new palette covering 26 colors, there was no way to make it look perfect. Had I only included the grayscale palette entries (232..255) number 24 in total, it would have been perfect... save for the missing 'a' and 'z' entries. This could possibly lead to the confusion of users, so instead I decided to add the two extra colors as well for the sake of familiarity.

I opted for plain bright red (|500)as the foreground color for the background swatches; it appeared to me as the most legible out of a few things I tried.

#### Finally ...

Thanks to the Evennia project, its contributors and maintainers for allowing the game I play today to exist. (Also thanks to the actual people running it, but they might not have gotten it off the ground yet if it wasn't for you guys!)

If this PR is in any way lacking, please let me know and if it is in my capabilities, I'll do my best to alleviate / address you concerns and needs.