### PR TITLE
Cmd default msg share

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -7,6 +7,9 @@ All commands in Evennia inherit from the 'Command' class in this module.
 from builtins import range
 
 import re
+
+from django.conf import settings
+
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import is_iter, fill, lazy_property, make_iter
 from future.utils import with_metaclass
@@ -140,17 +143,17 @@ class Command(with_metaclass(CommandMeta, object)):
     aliases = []
     # a list of lock definitions on the form
     #   cmd:[NOT] func(args) [ AND|OR][ NOT] func2(args)
-    locks = ""
+    locks = settings.DEFAULT_COMMAND_LOCKS
     # used by the help system to group commands in lists.
-    help_category = "general"
+    help_category = settings.DEFAULT_COMMAND_HELP_CATEGORY
     # This allows to turn off auto-help entry creation for individual commands.
     auto_help = True
     # optimization for quickly separating exit-commands from normal commands
     is_exit = False
     # define the command not only by key but by the regex form of its arguments
-    arg_regex = None
+    arg_regex = settings.DEFAULT_COMMAND_ARG_REGEX
     # whether we share msgs automatically with all sessions
-    share_msgs = False
+    share_msgs = settings.DEFAULT_COMMAND_MSG_SHARE
 
     # auto-set (by Evennia on command instantiation) are:
     #   obj - which object this command is defined on

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -149,6 +149,8 @@ class Command(with_metaclass(CommandMeta, object)):
     is_exit = False
     # define the command not only by key but by the regex form of its arguments
     arg_regex = None
+    # whether we share msgs automatically with all sessions
+    share_msgs = False
 
     # auto-set (by Evennia on command instantiation) are:
     #   obj - which object this command is defined on
@@ -304,7 +306,7 @@ class Command(with_metaclass(CommandMeta, object)):
         """
         This is a shortcut instad of calling msg() directly on an
         object - it will detect if caller is an Object or a Player and
-        also appends self.session automatically.
+        also appends self.session automatically if self.share_msgs is False.
 
         Args:
             text (str, optional): Text string of message to send.
@@ -321,7 +323,7 @@ class Command(with_metaclass(CommandMeta, object)):
         """
         from_obj = from_obj or self.caller
         to_obj = to_obj or from_obj
-        if not session:
+        if not session and not self.share_msgs:
             if to_obj == self.caller:
                 session = self.session
             else:

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -347,6 +347,11 @@ COMMAND_DEFAULT_CLASS = "evennia.commands.default.muxcommand.MuxCommand"
 # default class logs channel messages to a file and allows for /history.
 # This setting allows to override the command class used with your own.
 CHANNEL_COMMAND_CLASS = "evennia.comms.channelhandler.ChannelCommand"
+# These specify defaults to the base Command parent class
+DEFAULT_COMMAND_ARG_REGEX = None
+DEFAULT_COMMAND_MSG_SHARE = False
+DEFAULT_COMMAND_HELP_CATEGORY = "general"
+DEFAULT_COMMAND_LOCKS = ""
 
 ######################################################################
 # Typeclasses and other paths

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -347,10 +347,18 @@ COMMAND_DEFAULT_CLASS = "evennia.commands.default.muxcommand.MuxCommand"
 # default class logs channel messages to a file and allows for /history.
 # This setting allows to override the command class used with your own.
 CHANNEL_COMMAND_CLASS = "evennia.comms.channelhandler.ChannelCommand"
-# These specify defaults to the base Command parent class
+# These specify defaults to the base Command parent class. Override them
+# in order to change default behavior for your commands.
+# If specified, DEFAULT_COMMAND_ARG_REGEX forces a command's structure
+# to match the given regular expression.
 DEFAULT_COMMAND_ARG_REGEX = None
+# If True, DEFAULT_COMMAND_MSG_SHARE will share a self.msg() to all sessions
+# associated with the caller.
+# If False, self.msg() will send a message only self.session.
 DEFAULT_COMMAND_MSG_SHARE = False
+# The help category of a command if not otherwise specified.
 DEFAULT_COMMAND_HELP_CATEGORY = "general"
+# The default lockstring of a command.
 DEFAULT_COMMAND_LOCKS = ""
 
 ######################################################################


### PR DESCRIPTION
#### Brief overview of PR changes/additions
For a while, I had been using 'self.msg' in all my commands as a shortcut to sending messages to the command's caller. After enabling multisession mode, players were confused about not receiving echoes to their other sessions from commands. I decided to put in a way to change the base behavior of the Command class by making it look in the settings file, while keeping existing behavior the same for anyone who doesn't change the defaults.

#### Motivation for adding to Evennia
Make Command defaults more customizable. The options I included are changing the default arg_regex, the default help_category, whether `self.msg` will be shared across sessions, and default locks.

#### Other info (issues closed, discussion etc)
N/A
