### PR TITLE
Allow user-defined extensions of ansi mappings in ansi parser

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -319,7 +319,10 @@ PROTOTYPE_MODULES = ["world.prototypes"]
 # Module holding settings/actions for the dummyrunner program (see the
 # dummyrunner for more information)
 DUMMYRUNNER_SETTINGS_MODULE = "evennia.server.profiling.dummyrunner_settings"
-
+# Additional mappings used to extend the existing Evennia ANSI mappings.
+# All mappings should be a tuple of a string to one of the constants provided
+# in ansi.py. For example, (r'%r', "\r\n")
+ADDITIONAL_ANSI_MAPPINGS = []
 ######################################################################
 # Default command sets
 ######################################################################

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -414,6 +414,7 @@ class ANSIParser(object):
         (r'|[W', ANSI_BACK_WHITE),    # light grey background
         (r'|[X', ANSI_BACK_BLACK)     # pure black background
         ]
+    ext_ansi_map += settings.ADDITIONAL_ANSI_MAPPINGS
 
     ansi_bright_bgs = [
         # "bright" ANSI backgrounds using xterm256 since ANSI

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -16,6 +16,9 @@ user.
 from builtins import object, range
 
 import re
+
+from django.conf import settings
+
 from evennia.utils import utils
 from evennia.utils.utils import to_str, to_unicode
 from future.utils import with_metaclass


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The mention of the deprecation of the '{' format of ansi codes made me think that a painless way to handle this might just be to have a setting in which a game can set as many additional mappings as they like, so they can continue to support any mappings that are deprecated/removed without the need for pre-parsing in a msg override or the like. This change just has ansi.py look in settings for a list of additional mappings to add to itself, but otherwise will be unchanged.

#### Motivation for adding to Evennia
Allow for easy customization of the ansi parser's mappings with a user-defined list in `settings.py`.

#### Other info (issues closed, discussion etc)
An alternate implementation that seems trickier but is a little more consistent with the rest of the settings would be to have a text pathname to an ansi-parser module, with the default being the current. I personally felt that aside from the mappings, there wouldn't be much demand to change the actual behavior of the ansi parser itself, so that degree of customization wouldn't be desired.
