### PR TITLE
Add a setting to handle absolute game time (assuing a standard calendar)

### DIFF
--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -601,11 +601,17 @@ class CmdTime(COMMAND_DEFAULT_CLASS):
 
     def func(self):
         "Show server time data in a table."
+        virtual_epoch = datetime.datetime.fromtimestamp(
+                gametime.virtual_epoch())
+        virtual_current = datetime.datetime.fromtimestamp(
+                gametime.abs_gametime())
         table = prettytable.PrettyTable(["{wserver time statistic","{wtime"])
         table.align = 'l'
         table.add_row(["Current server uptime", utils.time_format(gametime.uptime(), 3)])
         table.add_row(["Total server running time", utils.time_format(gametime.runtime(), 2)])
+        table.add_row(["Game time epoch", virtual_epoch])
         table.add_row(["Total in-game time (realtime x %g)" % (gametime.TIMEFACTOR), utils.time_format(gametime.gametime(), 2)])
+        table.add_row(["Current game time", virtual_current])
         table.add_row(["Server time stamp", datetime.datetime.now()])
         self.caller.msg(str(table))
 

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -420,6 +420,12 @@ TIME_HOUR_PER_DAY = 24
 TIME_DAY_PER_WEEK = 7
 TIME_WEEK_PER_MONTH = 4
 TIME_MONTH_PER_YEAR = 12
+# The initial timestamp of your virtual time (in-game)
+# You can set this setting to set a fixed, initial timestamp.  Your
+# game time will be this timestamp plus your current variable game time.
+# You can set this setting to a timestamp in 1980, or 2020, or 2500 if
+# you want to.  Leave it to None to deduce the timestamp from the runtime.
+TIME_VIRTUAL_START = None
 
 ######################################################################
 # Inlinefunc

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -14,6 +14,7 @@ from evennia.server.models import ServerConfig
 # to real time.
 
 TIMEFACTOR = settings.TIME_FACTOR
+TIME_VIRTUAL_START = settings.TIME_VIRTUAL_START
 
 # Only set if gametime_reset was called at some point.
 GAME_TIME_OFFSET = ServerConfig.objects.conf("gametime_offset", default=0)
@@ -105,6 +106,42 @@ def uptime(format=False):
         return _format(utime, 31536000, 2628000, 604800, 86400, 3600, 60)
     return utime
 
+def virtual_epoch():
+    """Return the number of VIRTUAL seconds since the server started.
+
+    This number is set in the TIME_VIRTUAL_START setting.  If not
+    set, it will be deduced from the current time and server runtime.
+    Notice, in this case, that it will be slightly fluctuant every
+    reload or restart.
+
+    Returns:
+        The number of virtual seconds since the game first started.
+
+    """
+    if TIME_VIRTUAL_START is None:
+        virtual_start = time.time() - runtime()
+    else:
+        virtual_start = TIME_VIRTUAL_START
+
+    return virtual_start
+
+def abs_gametime():
+    """Return the absolute number of virtual seconds (in game time).
+
+    This function returns the number of seconds, using your configured
+    virtual start (setting TIME_VIRTUAL_START), and adding the
+    current relative gametime().  If you want to use a standard
+    calendar, it might save you time and efforts.  You could easily
+    convert the value like this:
+    >>> from datetime import datetime
+    >>> current = datetime.fromtimestamp(abs_gametime())
+
+    Returns:
+        The number of virtual seconds using the virtual epoch as a basis.
+
+    """
+    virtual_start = virtual_epoch()
+    return virtual_start + gametime()
 
 def gametime(format=False):
     """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The goal of this pull request is to add a way to handle absolute game time.  By "absolute", I mean Evennia is aware of the current game time, not just the number of virtual seconds.  The information is displayed in the `@time` command.

#### Motivation for adding to Evennia

The current `gametime` module handles relative virtual game: while being aware of the number of seconds since the time was last reset, it doesn't handle absolute game time.  This is definitely open for debate, as the functions I have added may not be useful, for instance, if one wants to use a specific calendar.  However, it provides some basic settings and handles all calculations in seconds, which means even a custom calendar could easily be applied on top of the absolute time system.

#### This PR adds

- A function `virtual_epoch` in the `gametime` module, to return the virtual number of seconds since the MUD started.
- A function `abs_gametime` in the `gametime` module, to return the absolute number of game seconds.
- A setting `TIME_VIRTUAL_START` to set the virtual epoch (timestamp).
- A few new lines in the `@time` command to display this information.
