### PR TITLE
help command display tweak, adds `?` alias

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -20,7 +20,7 @@ COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 # limit symbol import for API
 __all__ = ("CmdHelp", "CmdSetHelp")
 _DEFAULT_WIDTH = settings.CLIENT_DEFAULT_WIDTH
-_SEP = "{C" + "-" * _DEFAULT_WIDTH + "{n"
+_SEP = "|C" + "-" * _DEFAULT_WIDTH + "|n"
 
 
 class CmdHelp(Command):
@@ -36,6 +36,7 @@ class CmdHelp(Command):
     topics related to the game.
     """
     key = "help"
+    aliases = ['?']
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 
@@ -89,14 +90,14 @@ class CmdHelp(Command):
         """
         string = _SEP + "\n"
         if title:
-            string += "{CHelp for {w%s{n" % title
+            string += "|CHelp for |w%s|n" % title
         if aliases:
-            string += " {C(aliases: %s{C){n" % ("{C,{n ".join("{w%s{n" % ali for ali in aliases))
+            string += " |C(aliases: %s|C)|n" % ("|C,|n ".join("|w%s|n" % ali for ali in aliases))
         if help_text:
             string += "\n%s" % dedent(help_text.rstrip())
         if suggested:
-            string += "\n\n{CSuggested:{n "
-            string += "%s" % fill("{C,{n ".join("{w%s{n" % sug for sug in suggested))
+            string += "\n\n|CSuggested:|n "
+            string += "%s" % fill("|C,|n ".join("|w%s|n" % sug for sug in suggested))
         string.strip()
         string += "\n" + _SEP
         return string
@@ -111,15 +112,15 @@ class CmdHelp(Command):
         """
         string = ""
         if hdict_cmds and any(hdict_cmds.values()):
-            string += "\n" + _SEP + "\n   {CCommand help entries{n\n" + _SEP
+            string += "\n" + _SEP + "\n   |CCommand help entries|n\n" + _SEP
             for category in sorted(hdict_cmds.keys()):
-                string += "\n  {w%s{n:\n" % (str(category).title())
-                string += "{G" + fill(", ".join(sorted(hdict_cmds[category]))) + "{n"
+                string += "\n  |w%s|n:\n" % (str(category).title())
+                string += "|G" + fill("|C, |G".join(sorted(hdict_cmds[category]))) + "|n"
         if hdict_db and any(hdict_db.values()):
-            string += "\n\n" + _SEP + "\n\r  {COther help entries{n\n" + _SEP
+            string += "\n\n" + _SEP + "\n\r  |COther help entries|n\n" + _SEP
             for category in sorted(hdict_db.keys()):
-                string += "\n\r  {w%s{n:\n" % (str(category).title())
-                string += "{G" + fill(", ".join(sorted([str(topic) for topic in hdict_db[category]]))) + "{n"
+                string += "\n\r  |w%s|n:\n" % (str(category).title())
+                string += "|G" + fill(", ".join(sorted([str(topic) for topic in hdict_db[category]]))) + "|n"
         return string
 
     def check_show_help(self, cmd, caller):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This display tweak to the help command listing resolves difference in display color markup between Telnet and Webclient where coloration of command in format_help_list was not persisting across new lines.

It adds the `?` alias for the `help` command.

Also updates depreciated markup

#### Motivation for adding to Evennia
Makes display of format_help_list's color markup look consistent between Webclient and Telnet, by ensuring that each line listing commands within a category are colored as intended.

Also, the `?` for help as a default gives a single character shortcut to help.

and lastly, also updates depreciated markup where present.


#### Other info (issues closed, discussion etc)

The call to `fill` to format the lines might not be considering the additional length of the color markup.