### PR TITLE
Add support for gametime scheduling

### DIFF
--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -28,23 +28,23 @@ TIMEFACTOR = settings.TIME_FACTOR
 # when defining in-game events. The words month, week and year can  be
 # used to mean whatever units of time are used in your game.
 SEC = 1
-MIN = 60          # seconds per minute
-HOUR = MIN * 60   # minutes per hour
-DAY = HOUR * 24   # hours per day
-WEEK = DAY * 7    # days per week
-MONTH = WEEK * 4  # weeks per month
-YEAR = MONTH * 12 # months per year
-UNITS = {
-    "sec": SEC,
-    "min": MIN,
-    "hr": HOUR,
-    "hour": HOUR,
-    "day": DAY,
-    "week": WEEK,
-    "month": MONTH,
-    "year": YEAR,
-    "yr": YEAR,
-}
+MIN = getattr(settings, "SECS_PER_MIN", 60)
+HOUR = getattr(settings, "MINS_PER_HOUR", 60) * MIN
+DAY = getattr(settings, "HOURS_PER_DAY", 24) * HOUR
+WEEK = getattr(settings, "DAYS_PER_WEEK", 7) * DAY
+MONTH = getattr(settings, "WEEKS_PER_MONTH", 4) * WEEK
+YEAR = getattr(settings, "MONTHS_PER_YEAR", 12) * MONTH
+UNITS = getattr(settings, "TIME_UNITS", {
+        "sec": SEC,
+        "min": MIN,
+        "hr": HOUR,
+        "hour": HOUR,
+        "day": DAY,
+        "week": WEEK,
+        "month": MONTH,
+        "year": YEAR,
+        "yr": YEAR,
+})
 
 
 def time_to_tuple(seconds, *divisors):

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -266,13 +266,6 @@ class GametimeScript(DefaultScript):
         self.start_delay = True
         self.persistent = True
 
-    def at_start(self):
-        """The script is started or restarted."""
-        if self.db.need_reset:
-            self.db.need_reset = False
-            seconds = real_seconds_until(**self.db.gametime)
-            self.restart(interval=seconds)
-
     def at_repeat(self):
         """Call the callback and reset interval."""
         callback = self.db.callback
@@ -281,11 +274,3 @@ class GametimeScript(DefaultScript):
 
         seconds = real_seconds_until(**self.db.gametime)
         self.restart(interval=seconds)
-
-    def at_server_reload(self):
-        """The server is about to reload.  Put the script in need of reset."""
-        self.db.need_reset = True
-
-    def at_server_shutdown(self):
-        """The server is about to shutdown.  Put the script in need of reset."""
-        self.db.need_reset = True

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -143,7 +143,7 @@ def realtime_to_gametime(secs=0, mins=0, hrs=0, days=0, weeks=0,
 
 def custom_gametime(absolute=False):
     """
-    Return the game time as a tuple of units, as defined in settings.
+    Return the custom game time as a tuple of units, as defined in settings.
 
     Args:
         absolute (bool, optional): return the relative or absolute time.
@@ -172,7 +172,7 @@ def real_seconds_until(**kwargs):
         times (str: int): the time units.
 
     Example:
-        real_seconds_until(hour-5, min=10)
+        real_seconds_until(hour=5, min=10, sec=0)
 
     Returns:
         The number of real seconds before the given game time is up.
@@ -230,8 +230,8 @@ def schedule(callback, repeat=False, **kwargs):
     delay.  If `repeat` is set to True, the callback will be called
     again next time the game time matches the given time.  The time
     is given in units as keyword arguments.  For instance:
-    >>> schedule(func, min=5) # Will call next hour at :05.
-    >>> schedule(func, hour=2, min=30) # Will call the next day at 02:30.
+    >>> schedule(func, min=5, sec=0) # Will call next hour at :05.
+    >>> schedule(func, hour=2, min=30, sec=0) # Will call the next day at 02:30.
 
     Args:
         callback (function): the callback function that will be called [1].

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -141,6 +141,25 @@ def realtime_to_gametime(secs=0, mins=0, hrs=0, days=0, weeks=0,
         return time_to_tuple(gtime, *units)
     return gtime
 
+def custom_gametime(absolute=False):
+    """
+    Return the game time as a tuple of units, as defined in settings.
+
+    Args:
+        absolute (bool, optional): return the relative or absolute time.
+
+    Returns:
+        The tuple describing the game time.  The length of the tuple
+        is related to the number of unique units defined in the
+        settings.  By default, the tuple would be (year, month,
+        week, day, hour, minute, second).
+
+    """
+    current = gametime(absolute=absolute)
+    units = sorted(set(UNITS.values()), reverse=True)
+    del units[-1]
+    return time_to_tuple(current, *units)
+
 def real_seconds_until(**kwargs):
     """
     Return the real seconds until game time.

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -245,13 +245,14 @@ class GametimeScript(DefaultScript):
         """The script is created."""
         self.key = "unknown scr"
         self.interval = 100
-        self.repeats = 0
+        self.start_delay = True
         self.persistent = True
 
     def at_start(self):
         """The script is started or restarted."""
-        if self.db.gametime:
-            self.ndb._task.interval = real_seconds_until(**self.db.gametime)
+        if self.db.need_reset:
+            self.db.need_reset = False
+            self.restart(interval=real_seconds_until(**self.db.gametime))
 
     def at_repeat(self):
         """Call the callback and reset interval."""
@@ -259,11 +260,17 @@ class GametimeScript(DefaultScript):
         if callback:
             callback()
 
-        self.interval = real_seconds_until(**self.db.gametime)
+        seconds = real_seconds_until(**self.db.gametime)
+        self.restart(interval=seconds)
 
     def at_server_reload(self):
-        """The script is started or restarted."""
-        self.interval = real_seconds_until(**self.db.gametime)
+        """The server is about to reload.  Put the script in need of reset."""
+        self.db.need_reset = True
+
+    def at_server_shutdown(self):
+        """The server is about to shutdown.  Put the script in need of reset."""
+        self.db.need_reset = True
+
 
 def dummy():
     from typeclasses.rooms import Room

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -242,8 +242,7 @@ def schedule(callback, repeat=False, **kwargs):
         be persistent.
 
     Returns:
-        The number of real seconds before the callback will be
-        executed the first time.
+        The created script (Script).
 
     """
     seconds = real_seconds_until(**kwargs)

--- a/evennia/contrib/convert_gametime.py
+++ b/evennia/contrib/convert_gametime.py
@@ -252,7 +252,8 @@ class GametimeScript(DefaultScript):
         """The script is started or restarted."""
         if self.db.need_reset:
             self.db.need_reset = False
-            self.restart(interval=real_seconds_until(**self.db.gametime))
+            seconds = real_seconds_until(**self.db.gametime)
+            self.restart(interval=seconds)
 
     def at_repeat(self):
         """Call the callback and reset interval."""
@@ -270,9 +271,3 @@ class GametimeScript(DefaultScript):
     def at_server_shutdown(self):
         """The server is about to shutdown.  Put the script in need of reset."""
         self.db.need_reset = True
-
-
-def dummy():
-    from typeclasses.rooms import Room
-    for room in Room.objects.all():
-        room.msg_contents("The script ticks...")

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -170,6 +170,10 @@ class DefaultScript(ScriptBase):
 
         """
 
+        if self.ndb._task and self.ndb._task.running:
+            # The task already exists, doesn't start it again
+            return
+
         self.ndb._task = ExtendedLoopingCall(self._step_task)
 
         if self.db._paused_time:

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -170,10 +170,6 @@ class DefaultScript(ScriptBase):
 
         """
 
-        if self.ndb._task and self.ndb._task.running:
-            # The task already exists, doesn't start it again
-            return
-
         self.ndb._task = ExtendedLoopingCall(self._step_task)
 
         if self.db._paused_time:

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -346,6 +346,7 @@ class Evennia(object):
         from evennia.objects.models import ObjectDB
         #from evennia.players.models import PlayerDB
         from evennia.server.models import ServerConfig
+        from evennia.utils import gametime as _GAMETIME_MODULE
 
         if mode == 'reload':
             # call restart hooks
@@ -393,6 +394,9 @@ class Evennia(object):
             self.shutdown_complete = True
             # kill the server
             reactor.callLater(1, reactor.stop)
+
+        # we make sure the proper gametime is saved as late as possible
+        ServerConfig.objects.conf("runtime", _GAMETIME_MODULE.runtime())
 
     # server start/stop hooks
 

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -7,7 +7,11 @@ total runtime of the server and the current uptime.
 """
 from __future__ import division
 import time
+from calendar import monthrange
+from datetime import datetime, timedelta
+
 from django.conf import settings
+from evennia import DefaultScript
 from evennia.server.models import ServerConfig
 
 # Speed-up factor of the in-game time compared
@@ -107,6 +111,106 @@ def gametime(absolute=False):
     gtime = epoch + (runtime() - GAME_TIME_OFFSET) * TIMEFACTOR
     return gtime
 
+def real_seconds_until(sec=None, min=None, hour=None, day=None,
+        month=None, year=None):
+    """
+    Return the real seconds until game time.
+
+    If the game time is 5:00, TIME_FACTOR is set to 2 and you ask
+    the number of seconds until it's 5:10, then this function should
+    return 300 (5 minutes).
+
+    Args:
+        sec (int or None): number of absolute seconds.
+        min (int or None): number of absolute minutes.
+        hour (int or None): number of absolute hours.
+        day (int or None): number of absolute days.
+        month (int or None): number of absolute months.
+        year (int or None): number of absolute years.
+
+    Example:
+        real_seconds_until(hour=5, min=10, sec=0)
+
+    Returns:
+        The number of real seconds before the given game time is up.
+
+    """
+    current = datetime.frmtimestamp(gametime(absolute=True))
+    s_sec = year if year is not None else current.second
+    s_min = min if min is not None else current.minute
+    s_hour = hour if hour is not None else current.hour
+    s_day = day if day is not None else current.day
+    s_month = month if month is not None else current.month
+    s_year = year if year is not None else current.year
+    projected = datetime(s_year, s_month, s_day, s_hour, s_min, s_sec)
+
+    if projected <= current:
+        # We increase one unit of time depending on parameters
+        days_in_month = monthrange(s_year, s_month)[1]
+        days_in_year = sum(monthrange(s_year, m + 1)[1] for m in range(12))
+        if month is not None:
+            projected += timedelta(days=days_in_year)
+        elif day is not None:
+            projected += timedelta(days=days_in_month)
+        elif hour is not None:
+            projected += timedelta(days=1)
+        elif min is not None:
+            projected += timedelta(seconds=3600)
+        else:
+            projected += timedelta(seconds=60)
+
+    # Get the number of gametime seconds between these two dates
+    print "Asked", current, projected
+    seconds = (projected - current).total_seconds()
+    print "Found", seconds
+    return seconds / TIMEFACTOR
+
+def schedule(callback, repeat=False, sec=None, min=None, hour=None,
+        day=None, month=None, year=None):
+    """
+    Call the callback when the game time is up.
+
+    This function will setup a script that will be called when the
+    time corresponds to the game time.  If `repeat` is set to True,
+    the callback will be called again next time the game time matches
+    the given time.  The time is given in units as keyword arguments.
+    For instance:
+    >>> schedule(func, min=5, sec=0) # Will call next hour at :05.
+    >>> schedule(func, hour=2, min=30, sec=0) # Will call the next day at 02:30.
+
+    Args:
+        callback (function): the callback function that will be called [1].
+        repeat (bool, optional): should the callback be called regularly?
+        sec (int or None): number of absolute seconds.
+        min (int or None): number of absolute minutes.
+        hour (int or None): number of absolute hours.
+        day (int or None): number of absolute days.
+        month (int or None): number of absolute months.
+        year (int or None): number of absolute years.
+
+    [1] The callback must be a top-level function, since the script will
+        be persistent.
+
+    Returns:
+        The created script (Script).
+
+    """
+    seconds = real_seconds_until(sec=sec, min=min, hour=hour, day=day,
+            month=month, year=year)
+    script = create_script("evennia.utils.gametime.GametimeScript",
+            key="GametimeScript", desc="A gametime-sensitive script",
+            interval=seconds, start_delay=True,
+            repeats=-1 if repeat else 1)
+    script.db.callback = callback
+    script.db.gametime = {
+            "sec": sec,
+            "min": min,
+            "hour": hour,
+            "day": day,
+            "month": month,
+            "year": year,
+    }
+    return script
 
 def reset_gametime():
     """
@@ -117,3 +221,25 @@ def reset_gametime():
     global GAME_TIME_OFFSET
     GAME_TIME_OFFSET = runtime()
     ServerConfig.objects.conf("gametime_offset", GAME_TIME_OFFSET)
+
+
+# Scripts dealing in gametime (use `schedule`  to create it)
+class GametimeScript(DefaultScript):
+
+    """Gametime-sensitive script."""
+
+    def at_script_creation(self):
+        """The script is created."""
+        self.key = "unknown scr"
+        self.interval = 100
+        self.start_delay = True
+        self.persistent = True
+
+    def at_repeat(self):
+        """Call the callback and reset interval."""
+        callback = self.db.callback
+        if callback:
+            callback()
+
+        seconds = real_seconds_until(**self.db.gametime)
+        self.restart(interval=seconds)

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from evennia import DefaultScript
 from evennia.server.models import ServerConfig
+from evennia.utils.create import create_script
 
 # Speed-up factor of the in-game time compared
 # to real time.
@@ -135,8 +136,8 @@ def real_seconds_until(sec=None, min=None, hour=None, day=None,
         The number of real seconds before the given game time is up.
 
     """
-    current = datetime.frmtimestamp(gametime(absolute=True))
-    s_sec = year if year is not None else current.second
+    current = datetime.fromtimestamp(gametime(absolute=True))
+    s_sec = sec if sec is not None else current.second
     s_min = min if min is not None else current.minute
     s_hour = hour if hour is not None else current.hour
     s_day = day if day is not None else current.day
@@ -160,9 +161,7 @@ def real_seconds_until(sec=None, min=None, hour=None, day=None,
             projected += timedelta(seconds=60)
 
     # Get the number of gametime seconds between these two dates
-    print "Asked", current, projected
     seconds = (projected - current).total_seconds()
-    print "Found", seconds
     return seconds / TIMEFACTOR
 
 def schedule(callback, repeat=False, sec=None, min=None, hour=None,
@@ -197,8 +196,8 @@ def schedule(callback, repeat=False, sec=None, min=None, hour=None,
     """
     seconds = real_seconds_until(sec=sec, min=min, hour=hour, day=day,
             month=month, year=year)
-    script = create_script("evennia.utils.gametime.GametimeScript",
-            key="GametimeScript", desc="A gametime-sensitive script",
+    script = create_script("evennia.utils.gametime.TimeScript",
+            key="TimeScript", desc="A gametime-sensitive script",
             interval=seconds, start_delay=True,
             repeats=-1 if repeat else 1)
     script.db.callback = callback
@@ -224,7 +223,7 @@ def reset_gametime():
 
 
 # Scripts dealing in gametime (use `schedule`  to create it)
-class GametimeScript(DefaultScript):
+class TimeScript(DefaultScript):
 
     """Gametime-sensitive script."""
 

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -81,7 +81,8 @@ def game_epoch():
     Get the game epoch.
 
     """
-    return settings.TIME_GAME_EPOCH or server_epoch()
+    game_epoch = settings.TIME_GAME_EPOCH
+    return game_epoch if game_epoch is not None else server_epoch()
 
 
 def gametime(absolute=False):

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -89,14 +89,12 @@ def gametime(absolute=False):
     Get the total gametime of the server since first start (minus downtimes)
 
     Args:
-        format (bool, optional): Format into time representation.
         absolute (bool, optional): Get the absolute game time, including
             the epoch. This could be converted to an absolute in-game
             date.
 
     Returns:
-        time (float or tuple): The gametime or the same time split up
-            into time units.
+        time (float): The gametime as a virtual timestamp.
 
     Notes:
         If one is using a standard calendar, one could convert the unformatted


### PR DESCRIPTION
#### Short description

In the `convert_gametime` contrib are now functions/scripts to handle gametime scheduling.  The system is not working perfectly because I don't see how to change script delays at runtime.  If you can give me a hint here that would be great!

#### Motivation for adding to Evennia

The `time.delay` function or more complicated scripts don't interact very easily with user-defined gametime.  Since not all users work with a custom calendar, this new script is kept in the dedicated contrib.

The most useful function for what I have added in this module is `schedule()`.  It takes a game time (as units) and a callback.  It works like this:

    schedule(func, repeat=False, min=30, sec=0)
    # This will call func each hour at x:30:00 (gametime).

It works with custom calendars having defined other units as well.  The "every" unit is taken from the higher, not defined unit.  For instance, should you call `schedule` with `hour=3, min=0, sec=0``, the higher, not-mentioned unit is day.  Therefore, if you set `repeat` to `True`, the callback will be executed everyday at 3:00:00.  By default, `repeat` is set to `False`, so the callback is scheduled next time (using the same context, if it's already more than 3:00, it will pick the following day).

#### An error persists

More tests ought to be done, along with some unittest whenever I'll have the time to write them.  The biggest problem for the time being is that `interval` in scripts can't change at runtime (at least, it seems so).  My script created by `schedule()` checks the next gametime, in case of a reload or shutdown that would push it back and forth a few seconds each time.  It changes its `interval` in `at_repeat`, for instance, but this modification isn't acknowledged by the underlying loop.

To simplify testing, I've kept the `dummy()` callback function.  This will simply send a message to all rooms.  You can test the system like this:

    @py/edit
    from evennia.contrib.convert_gametime import *
    self.msg(str(schedule(dummy, repeat=True, sec=30)))

What this should do is set the `dummy()` callback for execution every minute at XX:30.  It works the first time.  But the next executions depend on the original intervals, and they are not updated.  If you call this while it's XX:25 in game, for instance, the script will run every 5 seconds (or less, due to TIME_FACTOR).  I'm not sure how to fix this... but the PR cannot be merged as is, I think.  If you can redirect me on the right method, I'll try to update it quickly.

Thanks!