### PR TITLE
nicks cmd fix

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -175,10 +175,9 @@ class CmdNick(COMMAND_DEFAULT_CLASS):
                         errstring += "Not a valid nick index."
                 else:
                     errstring += "Nick not found."
-
             if "delete" in switches or "del" in switches:
                 # clear the nick
-                if caller.nicks.has(old_nickstring, category=nicktype):
+                if old_nickstring and caller.nicks.has(old_nickstring, category=nicktype):
                     caller.nicks.remove(old_nickstring, category=nicktype)
                     string += "\nNick removed: '|w%s|n' -> |w%s|n." % (old_nickstring, old_replstring)
                 else:


### PR DESCRIPTION
The recent change to have None matches be cached broke the nicks/del command when executed on nicks that did not exist: the `has` check would be executed on a None key and return all cached results by category, which would be a list of None results and resolve to true.

#### Brief overview of PR changes/additions
Add check for nick existing.

#### Motivation for adding to Evennia
Minor bug fix to nick command.

#### Other info (issues closed, discussion etc)
N/A
