### PR TITLE
Fix the `characters` property on players having multiple characters

### DIFF
--- a/evennia/players/models.py
+++ b/evennia/players/models.py
@@ -106,10 +106,10 @@ class PlayerDB(TypedObject, AbstractUser):
 
     # alias to the objs property
     def __characters_get(self):
-        return self.objs
+        return self.db._playable_characters
 
     def __characters_set(self, value):
-        self.objs = value
+        self.db._playable_characters = value
 
     def __characters_del(self):
         raise Exception("Cannot delete name")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR is supposed to fix the bug one can get from querying the `characters` property on a player.

#### Motivation for adding to Evennia

The `characters` property was not working, an AttributeError was raised.

This PR seems to fix the issue, although it doesn't seem to be tested right now.