### PR TITLE
Fix #1234: use a mock datetime class to force UTC

### DIFF
--- a/evennia/contrib/tests.py
+++ b/evennia/contrib/tests.py
@@ -4,6 +4,7 @@ Testing suite for contrib folder
 
 """
 
+import datetime
 from evennia.commands.default.tests import CommandTest
 from evennia.utils.test_resources import EvenniaTest
 from mock import Mock, patch
@@ -173,6 +174,16 @@ from evennia.contrib import extended_room
 from evennia import gametime
 from evennia.objects.objects import DefaultRoom
 
+class ForceUTCDatetime(datetime.datetime):
+
+    """Force UTC datetime."""
+
+    @classmethod
+    def fromtimestamp(cls, timestamp):
+        """Force fromtimestamp to run with naive datetimes."""
+        return datetime.datetime.utcfromtimestamp(timestamp)
+
+@patch('evennia.contrib.extended_room.datetime.datetime', ForceUTCDatetime)
 class TestExtendedRoom(CommandTest):
     room_typeclass = extended_room.ExtendedRoom
     DETAIL_DESC = "A test detail."


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Inside of the tests run by `ExtendedRoom`, there's a class that overrides `datetime`, specifically its `fromtimestamp` method.  It's only active during the tests of `ExtendedRoom`.


Tests pass corectly on my system now.