### PR TITLE
Inclusion of type kwarg for common communications

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -414,8 +414,8 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to neighbors.
         emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents(emit_string, exclude=caller,
-                                     from_obj=caller, options={"type": "say"})
+        caller.location.msg_contents(text=(emit_string, {"type": "say"}), 
+                                     exclude=caller, from_obj=caller)
 
 
 class CmdWhisper(COMMAND_DEFAULT_CLASS):
@@ -457,7 +457,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to receiver.
         emit_string = '%s whispers, "%s|n"' % (caller.name, speech)
-        receiver.msg(emit_string, from_obj=caller, options={"type": "whisper"})
+        receiver.msg(text=(emit_string, {"type": "Whisper"}), from_obj=caller)
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):
@@ -500,8 +500,8 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents(msg, from_obj=self.caller,
-                                              options={"type": "pose"})
+            self.caller.location.msg_contents(text=(msg, {"type": "pose"}), 
+                                              from_obj=self.caller)
 
 
 class CmdAccess(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -414,7 +414,7 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to neighbors.
         emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents(emit_string, exclude=caller, from_obj=caller)
+        caller.location.msg_contents(emit_string, exclude=caller, from_obj=caller, type="say")
 
 
 class CmdWhisper(COMMAND_DEFAULT_CLASS):
@@ -456,7 +456,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to receiver.
         emit_string = '%s whispers, "%s|n"' % (caller.name, speech)
-        receiver.msg(emit_string, from_obj=caller)
+        receiver.msg(emit_string, from_obj=caller, type="whisper")
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):
@@ -499,7 +499,7 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents(msg, from_obj=self.caller)
+            self.caller.location.msg_contents(msg, from_obj=self.caller, type="pose")
 
 
 class CmdAccess(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -414,7 +414,7 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to neighbors.
         emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents((emit_string, {"type": "say"}), 
+        caller.location.msg_contents((emit_string, {"type": "Say"}), 
                                      exclude=caller, from_obj=caller)
 
 
@@ -500,7 +500,7 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents((msg, {"type": "pose"}), 
+            self.caller.location.msg_contents((msg, {"type": "Pose"}), 
                                               from_obj=self.caller)
 
 

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -414,7 +414,8 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to neighbors.
         emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents(emit_string, exclude=caller, from_obj=caller, type="say")
+        caller.location.msg_contents(emit_string, exclude=caller,
+                                     from_obj=caller, options={"type": "say"})
 
 
 class CmdWhisper(COMMAND_DEFAULT_CLASS):
@@ -456,7 +457,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to receiver.
         emit_string = '%s whispers, "%s|n"' % (caller.name, speech)
-        receiver.msg(emit_string, from_obj=caller, type="whisper")
+        receiver.msg(emit_string, from_obj=caller, options={"type": "whisper"})
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):
@@ -499,7 +500,8 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents(msg, from_obj=self.caller, type="pose")
+            self.caller.location.msg_contents(msg, from_obj=self.caller,
+                                              options={"type": "pose"})
 
 
 class CmdAccess(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -414,7 +414,7 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to neighbors.
         emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents(text=(emit_string, {"type": "say"}), 
+        caller.location.msg_contents((emit_string, {"type": "say"}), 
                                      exclude=caller, from_obj=caller)
 
 
@@ -457,7 +457,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
         # Build the string to emit to receiver.
         emit_string = '%s whispers, "%s|n"' % (caller.name, speech)
-        receiver.msg(text=(emit_string, {"type": "Whisper"}), from_obj=caller)
+        receiver.msg((emit_string, {"type": "Whisper"}), from_obj=caller)
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):
@@ -500,7 +500,7 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
             self.caller.msg(msg)
         else:
             msg = "%s%s" % (self.caller.name, self.args)
-            self.caller.location.msg_contents(text=(msg, {"type": "pose"}), 
+            self.caller.location.msg_contents((msg, {"type": "pose"}), 
                                               from_obj=self.caller)
 
 


### PR DESCRIPTION
Including a type entry in the option kwarg for the say, whisper and pose commands allows the receivers of those messages to treat them differently depending on type in code swiftly. IMO This is a wide enough concern that it goes beyond a game specific requirement. The inclusion will not disrupt any existing systems of Evennia.