### PR TITLE
Correct the IRC reset mapping to use 0x0F (15)

### DIFF
--- a/evennia/server/portal/irc.py
+++ b/evennia/server/portal/irc.py
@@ -18,7 +18,7 @@ from evennia.utils import logger, utils, ansi
 
 IRC_BOLD = "\002"
 IRC_COLOR = "\003"
-IRC_RESET = "\017"
+IRC_RESET = "\015"
 IRC_ITALIC = "\026"
 IRC_NORMAL = "99"
 IRC_UNDERLINE = "37"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Mapping mIRC's reset character 0x0F to /015 instead of /017, which is incorrect.

#### Motivation for adding to Evennia
Without the correct mapping, Evenna passes along the raw mIRC reset character (0x0F) without properly converting it to Evennia markup.

Using the correct mapping causes expected text line to be terminated with Evenna's reset markup, then correctly converted to other Evennia protocol clients, such as Telnet.

#### Other info (issues closed, discussion etc)
