### PR TITLE
Add URL for BSD 3-Clause license

### DIFF
--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -613,7 +613,7 @@ class CmdAbout(COMMAND_DEFAULT_CLASS):
          |cEvennia|n %s|n
          MUD/MUX/MU* development system
 
-         |wLicence|n BSD 3-Clause Licence
+         |wLicence|n https://opensource.org/licenses/BSD-3-Clause
          |wWeb|n http://www.evennia.com
          |wIrc|n #evennia on FreeNode
          |wForum|n http://www.evennia.com/discussions

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -607,7 +607,7 @@ class CmdAbout(COMMAND_DEFAULT_CLASS):
     help_category = "System"
 
     def func(self):
-        """Show the version"""
+        """Display information about server or target"""
 
         string = """
          |cEvennia|n %s|n


### PR DESCRIPTION
Suggested to me by a user, since the URL names the license type, it serves as a direct replacement for the text.

#### Brief overview of PR changes/additions
Updates the text in the license field of the `@about` command.

#### Motivation for adding to Evennia
Provides link to resource of license type

#### Other info (issues closed, discussion etc)
