### PR TITLE
The ansi.raw utility now escapes vertical bars

### DIFF
--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -548,7 +548,7 @@ def raw(string):
         string (str): The raw, escaped string.
 
     """
-    return string.replace('{', '{{')
+    return string.replace('{', '{{').replace('|', '||')
 
 
 def group(lst, n):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The `raw` utility in `utils.ansi` now escapes vertical bars in addition to left braces.