### PR TITLE
Only parse as switches when directly after mux command

### DIFF
--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -99,7 +99,7 @@ class MuxCommand(Command):
 
         # split out switches
         switches = []
-        if args and len(args) > 1 and args[0] == "/":
+        if args and len(args) > 1 and raw[0] == "/":
             # we have a switch, or a set of switches. These end with a space.
             switches = args[1:].split(None, 1)
             if len(switches) > 1:


### PR DESCRIPTION
### Brief overview of PR changes/additions
Only parse as switches when directly after mux command, to enforce the syntax
 **command[ possibly several words][/switch[/switch..]] arg1[,arg2,...] [[=|,] arg[,..]]**

### Motivation for adding to Evennia
Allows mux switch character (`/`) to be used as the first character of an argument when whitespace is provided between the command and the argument, but parsed normally when whitespace does not separate the command and intended switch.

### Other info (issues closed, discussion etc)
Example:
`say /Tomorrow/, not today!`
should not take the first word as a switch, because it is separated from the command, not flush against it.

`say/ooc /ooc is the switch to speak out of character.`
will parse `ooc` as a switch, but the second `/ooc` is parsed as part of the argument as expected.