### PR TITLE
Adding at_give() hook to the default object

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -355,6 +355,8 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
         caller.msg("You give %s to %s." % (to_give.key, target.key))
         to_give.move_to(target, quiet=True)
         target.msg("%s gives you %s." % (caller.key, to_give.key))
+        # Call the object script's at_give() method.
+        obj.at_give(caller, target)
 
 
 class CmdDesc(COMMAND_DEFAULT_CLASS):

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1415,6 +1415,22 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
 
         """
         pass
+      
+    def at_give(self, giver, getter):
+        """
+        Called by the default `give` command when this object has been
+        given.
+
+        Args:
+            giver (Object): The object giving this object.
+            getter (Object): The object getting this object.
+
+        Notes:
+            This hook cannot stop the give from happening. Use
+            permissions for that.
+
+        """
+        pass
 
     def at_drop(self, dropper):
         """
@@ -1425,7 +1441,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             dropper (Object): The object which just dropped this object.
 
         Notes:
-            This hook cannot stop the pickup from happening. Use
+            This hook cannot stop the drop from happening. Use
             permissions from that.
 
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds an at_give() hook to the default object, which is called by the default give command and passes the giving and receiving objects as arguments.

#### Motivation for adding to Evennia
I'm working on a simple contrib for wearable objects, and wanted clothing objects that are worn to have their 'worn' status automatically removed when dropped or given away - there's a built-in hook for the former, but not the latter.
