### PR TITLE
CONTRIB: Gendersub help fix

### DIFF
--- a/evennia/contrib/gendersub.py
+++ b/evennia/contrib/gendersub.py
@@ -50,7 +50,7 @@ _GENDER_PRONOUN_MAP = {"male": {"s": "he",
                                      "p": "their",
                                      "a": "theirs"}
                                      }
-_RE_GENDER_PRONOUN = re.compile(r'(\|s|\|S|\|o|\|O|\|p|\|P|\|a|\|A)')
+_RE_GENDER_PRONOUN = re.compile(r'(?<!\|)\|(?!\|)[sSoOpPaA]')
 
 # in-game command for setting the gender
 
@@ -59,7 +59,7 @@ class SetGender(Command):
     Sets gender on yourself
 
     Usage:
-      @gender male|female|neutral|ambiguous
+      @gender male||female||neutral||ambiguous
 
     """
     key = "@gender"
@@ -73,7 +73,7 @@ class SetGender(Command):
         caller = self.caller
         arg = self.args.strip().lower()
         if not arg in ("male", "female", "neutral", "ambiguous"):
-            caller.msg("Usage: @gender male|female|neutral|ambiguous")
+            caller.msg("Usage: @gender male||female||neutral||ambiguous")
             return
         caller.db.gender = arg
         caller.msg("Your gender was set to %s." % arg)

--- a/evennia/contrib/gendersub.py
+++ b/evennia/contrib/gendersub.py
@@ -134,5 +134,8 @@ class GenderCharacter(DefaultCharacter):
 
         """
         # pre-process the text before continuing
-        text = _RE_GENDER_PRONOUN.sub(self._get_pronoun, text)
+        try:
+            text = _RE_GENDER_PRONOUN.sub(self._get_pronoun, text)
+        except TypeError:
+            pass
         super(GenderCharacter, self).msg(text, from_obj=from_obj, session=session, **kwargs)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Made the gendersub contrib package work with messages that don't include gender information, such as those coming from the help system.  Made gender substitution respect escape sequences
#### Motivation for adding to Evennia
When the gendersub contrib package is activated, it is impossible to access the help system.
Also, when that package is used, it was not respecting escaped pipes, causing undesired substitution to occur.
#### Other info (issues closed, discussion etc)
This issue was not tracked.  Regex was changed to include negative-lookaround substitution.