### PR TITLE
CmdLook use_dbref by Builders perm group #1251

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -60,16 +60,17 @@ class CmdLook(COMMAND_DEFAULT_CLASS):
         """
         Handle the looking.
         """
+        caller = self.caller
         if not self.args:
-            target = self.caller.location
+            target = caller.location
             if not target:
-                self.caller.msg("You have no location to look at!")
+                caller.msg("You have no location to look at!")
                 return
         else:
-            target = self.caller.search(self.args)
+            target = caller.search(self.args, use_dbref=caller.check_permstring("Builders"))
             if not target:
                 return
-        self.msg(self.caller.at_look(target))
+        self.msg(caller.at_look(target))
 
 
 class CmdNick(COMMAND_DEFAULT_CLASS):


### PR DESCRIPTION
### Brief overview of PR changes/additions
Only allow referencing targets to view by #dbid if viewer is in Builders permission group

### Motivation for adding to Evennia
Solves specific issue in #1251 with default CmdLook

### Other info (issues closed, discussion etc)
Does not resolve the general issue, which could be left to devs to call search with their specific check.

The reason I never made an issue of this is because devs can easily create their own custom replacements, which I did, but having the test in the default CmdLook (with this PR) provides an example of how it can be done.