### PR TITLE
Fix error when viewing help while OOC and not puppeting while using webclient

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -60,7 +60,7 @@ class CmdHelp(Command):
 
             if self.session.protocol_key in ("websocket", "ajax/comet"):
                 try:
-                    options = self.caller.player.db._saved_webclient_options
+                    options = self.player.db._saved_webclient_options
                     if options and options["helppopup"]:
                         usemore = False
                 except KeyError:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Check whether the caller has the "player" attribute when viewing help in the webclient.  Webclient feature "help in popup" requires checking the db usually found on a Player object.  However, when not puppeting, it was still assuming the caller was a character and tried to access the callers "player" field.  .  Only KeyError exceptions were caught from the try block, thus resulting in an unhandled exception.
#### Motivation for adding to Evennia
It is impossible to access the help system while OOC using the webclient.
This issue was introduced when the pop-up help window was added to the webclient.
#### Other info (issues closed, discussion etc)
This issue was not open in the tracker
Resubmissionof #1265  from different branch