### PR TITLE
Adding a notice lock to hide room contents.

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1336,7 +1336,8 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             return ""
         # get and identify all objects
         visible = (con for con in self.contents if con != looker and
-                   con.access(looker, "view"))
+                   con.access(looker, "view") and
+                   con.access(looker, "notice", default=True))
         exits, users, things = [], [], []
         for con in visible:
             key = con.get_display_name(looker)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Able to easily hide objects in rooms but have them be fully interactable.
#### Motivation for adding to Evennia
Because it's cool.
#### Other info (issues closed, discussion etc)
Full context:
https://github.com/evennia/evennia/issues/1282
May introduce conflicts if user defines a lock called "notice" as well.