### PR TITLE
Default email domain to example.com per RFC2606

### DIFF
--- a/evennia/utils/create.py
+++ b/evennia/utils/create.py
@@ -369,7 +369,7 @@ def create_player(key, email, password,
         key (str): The player's name. This should be unique.
         email (str): Email on valid addr@addr.domain form. This is
             technically required but if set to `None`, an email of
-            `dummy@dummy.com` will be used as a placeholder.
+            `dummy@example.com` will be used as a placeholder.
         password (str): Password in cleartext.
 
     Kwargs:
@@ -404,7 +404,7 @@ def create_player(key, email, password,
     # correctly when each object is recovered).
 
     if not email:
-        email = "dummy@dummy.com"
+        email = "dummy@example.com"
     if _PlayerDB.objects.filter(username__iexact=key):
         raise ValueError("A Player with the name '%s' already exists." % key)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the default email addressed assigned to an account from "dummy@dummy.com" to "dummy@example.com"
#### Motivation for adding to Evennia
dummy.com is an actual domain that can receive email.  IETF RFC 2606 reserves the special domain "example.com" specifically for this use case
#### Other info (issues closed, discussion etc)
this was not a tracked issue