### PR TITLE
Update Object.announce_move_* to take advantage of mapping

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1159,10 +1159,10 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         You can override this method and call its parent with a
         message to simply change the default message.  In the string,
         you can use the following as mappings (between braces):
-            character: the character who is moving.
-            exit: the exit from which the character is moving (if found).
-            origin: the location of the character before the move.
-            destination: the location of the character after moving.
+            object: the object which is moving.
+            exit: the exit from which the object is moving (if found).
+            origin: the location of the object before the move.
+            destination: the location of the object after moving.
 
         """
         if not self.location:
@@ -1170,7 +1170,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if msg:
             string = msg
         else:
-            string = "{character} is leaving {origin}, heading for {destination}."
+            string = "{object} is leaving {origin}, heading for {destination}."
 
         location = self.location
         exits = [o for o in location.contents if o.location is location and o.destination is destination]
@@ -1178,7 +1178,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             mapping = {}
 
         mapping.update({
-                "character": self,
+                "object": self,
                 "exit": exits[0] if exits else "somwhere",
                 "origin": location or "nowhere",
                 "destination": destination or "nowhere",
@@ -1199,10 +1199,10 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         You can override this method and call its parent with a
         message to simply change the default message.  In the string,
         you can use the following as mappings (between braces):
-            character: the character who is moving.
-            exit: the exit from which the character is moving (if found).
-            origin: the location of the character before the move.
-            destination: the location of the character after moving.
+            object: the object which is moving.
+            exit: the exit from which the object is moving (if found).
+            origin: the location of the object before the move.
+            destination: the location of the object after moving.
 
         """
 
@@ -1217,9 +1217,9 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             if msg:
                 string = msg
             else:
-                string = "{character} arrives to {destination} from {origin}."
+                string = "{object} arrives to {destination} from {origin}."
         else:
-            string = "{character} arrives to {destination}."
+            string = "{object} arrives to {destination}."
 
         origin = source_location
         destination = self.location
@@ -1231,7 +1231,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             mapping = {}
 
         mapping.update({
-                "character": self,
+                "object": self,
                 "exit": exits[0] if exits else "somewhere",
                 "origin": origin or "nowhere",
                 "destination": destination or "nowhere",

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1145,7 +1145,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         # return has_perm(self, destination, "can_move")
         return True
 
-    def announce_move_from(self, destination, msg=None):
+    def announce_move_from(self, destination, msg=None, mapping=None):
         """
         Called if the move is to be announced. This is
         called while we are still standing in the old
@@ -1154,6 +1154,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         Args:
             destination (Object): The place we are going to.
             msg (str, optional): a replacement message.
+            mapping (dict, optional): additional mapping objects.
 
         You can override this method and call its parent with a
         message to simply change the default message.  In the string,
@@ -1173,16 +1174,19 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
 
         location = self.location
         exits = [o for o in location.contents if o.location is location and o.destination is destination]
-        mapping = {
+        if not mapping:
+            mapping = {}
+
+        mapping.update({
                 "character": self,
                 "exit": exits[0] if exits else "somwhere",
                 "origin": location or "nowhere",
                 "destination": destination or "nowhere",
-        }
+        })
 
         location.msg_contents(string, exclude=(self, ), mapping=mapping)
 
-    def announce_move_to(self, source_location, msg=None):
+    def announce_move_to(self, source_location, msg=None, mapping=None):
         """
         Called after the move if the move was not quiet. At this point
         we are standing in the new location.
@@ -1190,6 +1194,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         Args:
             source_location (Object): The place we came from
             msg (str, optional): the replacement message if location.
+            mapping (dict, optional): additional mapping objects.
 
         You can override this method and call its parent with a
         message to simply change the default message.  In the string,
@@ -1222,12 +1227,15 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if origin:
             exits = [o for o in destination.contents if o.location is destination and o.destination is origin]
 
-        mapping = {
+        if not mapping:
+            mapping = {}
+
+        mapping.update({
                 "character": self,
                 "exit": exits[0] if exits else "somewhere",
                 "origin": origin or "nowhere",
                 "destination": destination or "nowhere",
-        }
+        })
 
         destination.msg_contents(string, exclude=(self, ), mapping=mapping)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1145,7 +1145,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         # return has_perm(self, destination, "can_move")
         return True
 
-    def announce_move_from(self, destination):
+    def announce_move_from(self, destination, msg=None):
         """
         Called if the move is to be announced. This is
         called while we are still standing in the old
@@ -1153,25 +1153,51 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
 
         Args:
             destination (Object): The place we are going to.
+            msg (str, optional): a replacement message.
+
+        You can override this method and call its parent with a
+        message to simply change the default message.  In the string,
+        you can use the following as mappings (between braces):
+            character: the character who is moving.
+            exit: the exit from which the character is moving (if found).
+            origin: the location of the character before the move.
+            destination: the location of the character after moving.
 
         """
         if not self.location:
             return
-        string = "%s is leaving %s, heading for %s."
-        location = self.location
-        for obj in self.location.contents:
-            if obj != self:
-                obj.msg(string % (self.get_display_name(obj),
-                                  location.get_display_name(obj) if location else "nowhere",
-                                  destination.get_display_name(obj)))
+        if msg:
+            string = msg
+        else:
+            string = "{character} is leaving {origin}, heading for {destination}."
 
-    def announce_move_to(self, source_location):
+        location = self.location
+        exits = [o for o in location.contents if o.location is location and o.destination is destination]
+        mapping = {
+                "character": self,
+                "exit": exits[0] if exits else "somwhere",
+                "origin": location or "nowhere",
+                "destination": destination or "nowhere",
+        }
+
+        location.msg_contents(string, exclude=(self, ), mapping=mapping)
+
+    def announce_move_to(self, source_location, msg=None):
         """
         Called after the move if the move was not quiet. At this point
         we are standing in the new location.
 
         Args:
             source_location (Object): The place we came from
+            msg (str, optional): the replacement message if location.
+
+        You can override this method and call its parent with a
+        message to simply change the default message.  In the string,
+        you can use the following as mappings (between braces):
+            character: the character who is moving.
+            exit: the exit from which the character is moving (if found).
+            origin: the location of the character before the move.
+            destination: the location of the character after moving.
 
         """
 
@@ -1182,13 +1208,28 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             self.location.msg(string)
             return
 
-        string = "%s arrives to %s%s."
-        location = self.location
-        for obj in self.location.contents:
-            if obj != self:
-                obj.msg(string % (self.get_display_name(obj),
-                                  location.get_display_name(obj) if location else "nowhere",
-                                  " from %s" % source_location.get_display_name(obj) if source_location else ""))
+        if source_location:
+            if msg:
+                string = msg
+            else:
+                string = "{character} arrives to {destination} from {origin}."
+        else:
+            string = "{character} arrives to {destination}."
+
+        origin = source_location
+        destination = self.location
+        exits = []
+        if origin:
+            exits = [o for o in destination.contents if o.location is destination and o.destination is origin]
+
+        mapping = {
+                "character": self,
+                "exit": exits[0] if exits else "somewhere",
+                "origin": origin or "nowhere",
+                "destination": destination or "nowhere",
+        }
+
+        destination.msg_contents(string, exclude=(self, ), mapping=mapping)
 
     def at_after_move(self, source_location):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Two additions in the `announce_move_from` and `announce_move_to` hooks:

- Support to override the default message without re-coding both methods.
- Support mappings in string.

#### Motivation for adding to Evennia

The `announce_move_from` or `announce_move_to` messages weren't easy to override without copy/pasting the initial code.  Moreover, it still used a system to send individual objects the message, rather than relying on `room.msg_contents` while specifying mapping.  Both characteristics made it a bit hard to update.

`location.msg_contents` (or `destination`) is now used with custom mapping.  It is possible to override these messages very simply:

```python
    def announce_move_from(self, destination):
        """..."""
        super(Character, self).announce_move_from(destination,
                msg="{character} leaves {exit}, toward {destination}.")
```

I have also added the `exit` mapping, which may be "somewhere" if the exit wasn't found.  `{character}`, `{origin}` and `{destination}` are self-explanatory.  Notice, however, that I didn't use `location` in the mapping, as I believe it's more clear to have mappings with `origin` and `destination` rather than `location` which isn't always straight-forward depending on the movement.  This is open to debate, of course.