### PR TITLE
Add useful hooks for the say and whisper commands

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -452,13 +452,15 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
             return
 
         speech = self.rhs
+        # Call a hook to change the speech before whispering
+        speech = caller.at_before_whisper(receiver, speech)
 
-        # Feedback for the object doing the talking.
-        caller.msg('You whisper to %s, "%s|n"' % (receiver.key, speech))
+        # If the speech is empty, abort the command
+        if not speech:
+            return
 
-        # Build the string to emit to receiver.
-        emit_string = '%s whispers, "%s|n"' % (caller.name, speech)
-        receiver.msg(emit_string, from_obj=caller)
+        # Call the at_after_whisper hook for feedback
+        caller.at_after_whisper(receiver, speech)
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -409,16 +409,15 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
 
         speech = self.args
 
-        # calling the speech hook on the location
-        speech = caller.location.at_say(caller, speech)
+        # Calling the at_before_say hook on the character
+        speech = caller.at_before_say(speech)
 
-        # Feedback for the object doing the talking.
-        caller.msg('You say, "%s|n"' % speech)
+        # If speech is empty, stop here
+        if not speech:
+            return
 
-        # Build the string to emit to neighbors.
-        emit_string = '%s says, "%s|n"' % (caller.name, speech)
-        caller.location.msg_contents(emit_string, exclude=caller, from_obj=caller)
-
+        # Call the at_after_say hook on the character
+        caller.at_after_say(speech)
 
 class CmdWhisper(COMMAND_DEFAULT_CLASS):
     """

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -128,7 +128,7 @@ class TestGeneral(CommandTest):
         self.call(general.CmdSay(), "Testing", "You say, \"Testing\"")
 
     def test_whisper(self):
-        self.call(general.CmdWhisper(), "Obj = Testing", "You whisper to Obj, \"Testing\"")
+        self.call(general.CmdWhisper(), "Obj = Testing", "You whisper to Obj, \"Testing\"", caller=self.char2)
 
     def test_access(self):
         self.call(general.CmdAccess(), "", "Permission Hierarchy (climbing):")

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1513,25 +1513,6 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         self.location.msg_contents(msg_location, exclude=(self, ),
                 mapping=mapping)
 
-    def at_say(self, speaker, message):
-        """
-        DEPRECATED.
-        Called on this object if an object inside this object speaks.
-        The string returned from this method is the final form of the
-        speech.
-
-        Args:
-            speaker (Object): The object speaking.
-            message (str): The words spoken.
-
-        Notes:
-            You should not need to add things like 'you say: ' or
-            similar here, that should be handled by the say command before
-            this.
-
-        """
-        return message
-
     def at_before_whisper(self, receiver, speech):
         """
         Before the object whispers something to receiver.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The say and whisper commands now have hooks to control and display messages, which makes updating the behavior of these commands quite simple without overriding them.

#### Motivation for adding to Evennia

The say command already used a hook: this hook, `object.at_say`, was called before the say and was used to change the content of the message to be displayed.  However, it didn't allow to display the content in another format.  Moreover, it used `%s` symbols instead of relying on mappings, which meant it didn't use `get_display_name` on objects.

There's now two different hooks for the say command:

- `object.at_before_say`: it can be used much like `object.location.at_say` (notice that this change invalids the latter `at_say` hook).  It can be used to modify the text to be said in the location.  It can also prevent the say by returning a None value.
- `object.at_after_say`: this hook is responsible for displaying the said message in the location.  The say command doesn't do anything but calling these hooks, which means changing the format of the say command is quite easy without re-writing the say command.  This second hook allows for simple overriding of messages to display, mapping (with `get_display_name`) and simple extensions by users' sub-classing.

The whisper command adds these two hooks on objects too, since it didn't use any hook at all.

#### A warning on compatibility

This PR breaks compatibility of the `at_say` hook.  The hook isn't used anymore.  Beforehand, it was used on the location (that is, more likely than not, on the room of the character speaking).  This, however, didn't seem to allow the greatest flexibility, and the `at_before_say` hook, like the `at_after_say` one, are put on the object speaking, not on its location.

Therefore, there's a deprecated warning in the `at_say` hook.  I'm not sure whether it should be removed or simply re-mapped to `at_before_say`.  If the latter, then it can be somewhat misleading to users, because they don't do the exact same thing, but it depends on Evennia's policy on hook compatibility.