### PR TITLE
CONTRIB: mail.py: check if ooc or puppeting before finding player object during get_all_mail

### DIFF
--- a/evennia/contrib/mail.py
+++ b/evennia/contrib/mail.py
@@ -252,5 +252,5 @@ class CmdMail(default_cmds.MuxCommand):
                 self.caller.msg(unicode(table))
                 self.caller.msg(_HEAD_CHAR * _WIDTH)
             else:
-                self.caller.msg("Sorry, you don't have any messages.  What a pathetic loser!")
+                self.caller.msg("There are no messages in your inbox.")
 

--- a/evennia/contrib/mail.py
+++ b/evennia/contrib/mail.py
@@ -88,7 +88,11 @@ class CmdMail(default_cmds.MuxCommand):
         """
         # mail_messages = Msg.objects.get_by_tag(category="mail")
         # messages = []
-        messages = Msg.objects.get_by_tag(category="mail", raw_queryset=True).filter(db_receivers_players=self.caller)
+        try:
+            player = self.caller.player
+        except AttributeError:
+            player = self.caller
+        messages = Msg.objects.get_by_tag(category="mail", raw_queryset=True).filter(db_receivers_players=player)
         return messages
 
     def send_mail(self, recipients, subject, message, caller):

--- a/evennia/contrib/tests.py
+++ b/evennia/contrib/tests.py
@@ -540,7 +540,7 @@ from evennia.contrib import mail
 class TestMail(CommandTest):
     def test_mail(self):
         self.call(mail.CmdMail(), "2", "'2' is not a valid mail id.", caller=self.player)
-        self.call(mail.CmdMail(), "", "Sorry, you don't have any messages.", caller=self.player)
+        self.call(mail.CmdMail(), "", "There are no messages in your inbox.", caller=self.player)
         self.call(mail.CmdMail(), "Char=Message 1", "You have received a new @mail from Char|You sent your message.", caller=self.char1)
         self.call(mail.CmdMail(), "Char=Message 2", "You sent your message.", caller=self.char2)
         self.call(mail.CmdMail(), "TestPlayer2=Message 2",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Checks to see if OOC or Puppeting during get_all_mail
#### Motivation for adding to Evennia
Trying to use the mail system fails when OOC
#### Other info (issues closed, discussion etc)
This fixes the test failure and the bug introduced in PR #1262 