### PR TITLE
Adjust docstring to resolve #1300 in shipped command.py

### DIFF
--- a/evennia/game_template/commands/command.py
+++ b/evennia/game_template/commands/command.py
@@ -21,17 +21,17 @@ class Command(BaseCommand):
 
     Each Command implements the following methods, called
     in this order (only func() is actually required):
-        - at_pre_command(): If this returns True, execution is aborted.
+        - at_pre_cmd(): If this returns True, execution is aborted.
         - parse(): Should perform any extra parsing needed on self.args
             and store the result on self.
         - func(): Performs the actual work.
-        - at_post_command(): Extra actions, often things done after
+        - at_post_cmd(): Extra actions, often things done after
             every command, like prompts.
 
     """
     pass
 
-#------------------------------------------------------------
+# -------------------------------------------------------------
 #
 # The default commands inherit from
 #
@@ -46,139 +46,140 @@ class Command(BaseCommand):
 # the functionality implemented in the parse() method, so be
 # careful with what you change.
 #
-#------------------------------------------------------------
+# -------------------------------------------------------------
 
-#from evennia.utils import utils
-#class MuxCommand(Command):
-#    """
-#    This sets up the basis for a MUX command. The idea
-#    is that most other Mux-related commands should just
-#    inherit from this and don't have to implement much
-#    parsing of their own unless they do something particularly
-#    advanced.
+# from evennia.utils import utils
 #
-#    Note that the class's __doc__ string (this text) is
-#    used by Evennia to create the automatic help entry for
-#    the command, so make sure to document consistently here.
-#    """
-#    def has_perm(self, srcobj):
-#        """
-#        This is called by the cmdhandler to determine
-#        if srcobj is allowed to execute this command.
-#        We just show it here for completeness - we
-#        are satisfied using the default check in Command.
-#        """
-#        return super(MuxCommand, self).has_perm(srcobj)
 #
-#    def at_pre_cmd(self):
-#        """
-#        This hook is called before self.parse() on all commands
-#        """
-#        pass
+# class MuxCommand(Command):
+#     """
+#     This sets up the basis for a MUX command. The idea
+#     is that most other Mux-related commands should just
+#     inherit from this and don't have to implement much
+#     parsing of their own unless they do something particularly
+#     advanced.
 #
-#    def at_post_cmd(self):
-#        """
-#        This hook is called after the command has finished executing
-#        (after self.func()).
-#        """
-#        pass
+#     Note that the class's __doc__ string (this text) is
+#     used by Evennia to create the automatic help entry for
+#     the command, so make sure to document consistently here.
+#     """
+#     def has_perm(self, srcobj):
+#         """
+#         This is called by the cmdhandler to determine
+#         if srcobj is allowed to execute this command.
+#         We just show it here for completeness - we
+#         are satisfied using the default check in Command.
+#         """
+#         return super(MuxCommand, self).has_perm(srcobj)
 #
-#    def parse(self):
-#        """
-#        This method is called by the cmdhandler once the command name
-#        has been identified. It creates a new set of member variables
-#        that can be later accessed from self.func() (see below)
+#     def at_pre_cmd(self):
+#         """
+#         This hook is called before self.parse() on all commands
+#         """
+#         pass
 #
-#        The following variables are available for our use when entering this
-#        method (from the command definition, and assigned on the fly by the
-#        cmdhandler):
-#           self.key - the name of this command ('look')
-#           self.aliases - the aliases of this cmd ('l')
-#           self.permissions - permission string for this command
-#           self.help_category - overall category of command
+#     def at_post_cmd(self):
+#         """
+#         This hook is called after the command has finished executing
+#         (after self.func()).
+#         """
+#         pass
 #
-#           self.caller - the object calling this command
-#           self.cmdstring - the actual command name used to call this
-#                            (this allows you to know which alias was used,
-#                             for example)
-#           self.args - the raw input; everything following self.cmdstring.
-#           self.cmdset - the cmdset from which this command was picked. Not
-#                         often used (useful for commands like 'help' or to
-#                         list all available commands etc)
-#           self.obj - the object on which this command was defined. It is often
-#                         the same as self.caller.
+#     def parse(self):
+#         """
+#         This method is called by the cmdhandler once the command name
+#         has been identified. It creates a new set of member variables
+#         that can be later accessed from self.func() (see below)
 #
-#        A MUX command has the following possible syntax:
+#         The following variables are available for our use when entering this
+#         method (from the command definition, and assigned on the fly by the
+#         cmdhandler):
+#            self.key - the name of this command ('look')
+#            self.aliases - the aliases of this cmd ('l')
+#            self.permissions - permission string for this command
+#            self.help_category - overall category of command
 #
-#          name[ with several words][/switch[/switch..]] arg1[,arg2,...] [[=|,] arg[,..]]
+#            self.caller - the object calling this command
+#            self.cmdstring - the actual command name used to call this
+#                             (this allows you to know which alias was used,
+#                              for example)
+#            self.args - the raw input; everything following self.cmdstring.
+#            self.cmdset - the cmdset from which this command was picked. Not
+#                          often used (useful for commands like 'help' or to
+#                          list all available commands etc)
+#            self.obj - the object on which this command was defined. It is often
+#                          the same as self.caller.
 #
-#        The 'name[ with several words]' part is already dealt with by the
-#        cmdhandler at this point, and stored in self.cmdname (we don't use
-#        it here). The rest of the command is stored in self.args, which can
-#        start with the switch indicator /.
+#         A MUX command has the following possible syntax:
 #
-#        This parser breaks self.args into its constituents and stores them in the
-#        following variables:
-#          self.switches = [list of /switches (without the /)]
-#          self.raw = This is the raw argument input, including switches
-#          self.args = This is re-defined to be everything *except* the switches
-#          self.lhs = Everything to the left of = (lhs:'left-hand side'). If
-#                     no = is found, this is identical to self.args.
-#          self.rhs: Everything to the right of = (rhs:'right-hand side').
-#                    If no '=' is found, this is None.
-#          self.lhslist - [self.lhs split into a list by comma]
-#          self.rhslist - [list of self.rhs split into a list by comma]
-#          self.arglist = [list of space-separated args (stripped, including '=' if it exists)]
+#           name[ with several words][/switch[/switch..]] arg1[,arg2,...] [[=|,] arg[,..]]
 #
-#          All args and list members are stripped of excess whitespace around the
-#          strings, but case is preserved.
-#        """
-#        raw = self.args
-#        args = raw.strip()
+#         The 'name[ with several words]' part is already dealt with by the
+#         cmdhandler at this point, and stored in self.cmdname (we don't use
+#         it here). The rest of the command is stored in self.args, which can
+#         start with the switch indicator /.
 #
-#        # split out switches
-#        switches = []
-#        if args and len(args) > 1 and args[0] == "/":
-#            # we have a switch, or a set of switches. These end with a space.
-#            switches = args[1:].split(None, 1)
-#            if len(switches) > 1:
-#                switches, args = switches
-#                switches = switches.split('/')
-#            else:
-#                args = ""
-#                switches = switches[0].split('/')
-#        arglist = [arg.strip() for arg in args.split()]
+#         This parser breaks self.args into its constituents and stores them in the
+#         following variables:
+#           self.switches = [list of /switches (without the /)]
+#           self.raw = This is the raw argument input, including switches
+#           self.args = This is re-defined to be everything *except* the switches
+#           self.lhs = Everything to the left of = (lhs:'left-hand side'). If
+#                      no = is found, this is identical to self.args.
+#           self.rhs: Everything to the right of = (rhs:'right-hand side').
+#                     If no '=' is found, this is None.
+#           self.lhslist - [self.lhs split into a list by comma]
+#           self.rhslist - [list of self.rhs split into a list by comma]
+#           self.arglist = [list of space-separated args (stripped, including '=' if it exists)]
 #
-#        # check for arg1, arg2, ... = argA, argB, ... constructs
-#        lhs, rhs = args, None
-#        lhslist, rhslist = [arg.strip() for arg in args.split(',')], []
-#        if args and '=' in args:
-#            lhs, rhs = [arg.strip() for arg in args.split('=', 1)]
-#            lhslist = [arg.strip() for arg in lhs.split(',')]
-#            rhslist = [arg.strip() for arg in rhs.split(',')]
+#           All args and list members are stripped of excess whitespace around the
+#           strings, but case is preserved.
+#         """
+#         raw = self.args
+#         args = raw.strip()
 #
-#        # save to object properties:
-#        self.raw = raw
-#        self.switches = switches
-#        self.args = args.strip()
-#        self.arglist = arglist
-#        self.lhs = lhs
-#        self.lhslist = lhslist
-#        self.rhs = rhs
-#        self.rhslist = rhslist
+#         # split out switches
+#         switches = []
+#         if args and len(args) > 1 and args[0] == "/":
+#             # we have a switch, or a set of switches. These end with a space.
+#             switches = args[1:].split(None, 1)
+#             if len(switches) > 1:
+#                 switches, args = switches
+#                 switches = switches.split('/')
+#             else:
+#                 args = ""
+#                 switches = switches[0].split('/')
+#         arglist = [arg.strip() for arg in args.split()]
 #
-#        # if the class has the player_caller property set on itself, we make
-#        # sure that self.caller is always the player if possible. We also create
-#        # a special property "character" for the puppeted object, if any. This
-#        # is convenient for commands defined on the Player only.
-#        if hasattr(self, "player_caller") and self.player_caller:
-#            if utils.inherits_from(self.caller, "evennia.objects.objects.DefaultObject"):
-#                # caller is an Object/Character
-#                self.character = self.caller
-#                self.caller = self.caller.player
-#            elif utils.inherits_from(self.caller, "evennia.players.players.DefaultPlayer"):
-#                # caller was already a Player
-#                self.character = self.caller.get_puppet(self.session)
-#            else:
-#                self.character = None
+#         # check for arg1, arg2, ... = argA, argB, ... constructs
+#         lhs, rhs = args, None
+#         lhslist, rhslist = [arg.strip() for arg in args.split(',')], []
+#         if args and '=' in args:
+#             lhs, rhs = [arg.strip() for arg in args.split('=', 1)]
+#             lhslist = [arg.strip() for arg in lhs.split(',')]
+#             rhslist = [arg.strip() for arg in rhs.split(',')]
 #
+#         # save to object properties:
+#         self.raw = raw
+#         self.switches = switches
+#         self.args = args.strip()
+#         self.arglist = arglist
+#         self.lhs = lhs
+#         self.lhslist = lhslist
+#         self.rhs = rhs
+#         self.rhslist = rhslist
+#
+#         # if the class has the player_caller property set on itself, we make
+#         # sure that self.caller is always the player if possible. We also create
+#         # a special property "character" for the puppeted object, if any. This
+#         # is convenient for commands defined on the Player only.
+#         if hasattr(self, "player_caller") and self.player_caller:
+#             if utils.inherits_from(self.caller, "evennia.objects.objects.DefaultObject"):
+#                 # caller is an Object/Character
+#                 self.character = self.caller
+#                 self.caller = self.caller.player
+#             elif utils.inherits_from(self.caller, "evennia.players.players.DefaultPlayer"):
+#                 # caller was already a Player
+#                 self.character = self.caller.get_puppet(self.session)
+#             else:
+#                 self.character = None


### PR DESCRIPTION
### Brief overview of PR changes/additions
Adjust docstring to resolve #1300
Also realigns code indent to multiple of 4 after `# ` is removed to uncomment

### Motivation for adding to Evennia
Reference the correct names of BaseCommand methods in the docstring and realign line comments if/when uncommented.

### Other info (issues closed, discussion etc)
PyCharm line comments/uncomments by adding/removing `# `, so to have correct indentation, the single space was added to the line commented code.