### PR TITLE
Extended get_input to accept *args & **kwargs

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -894,9 +894,11 @@ class CmdGetInput(Command):
 
             caller.ndb._getinput._session = self.session
             prompt = caller.ndb._getinput._prompt
+            args = caller.ndb._getinput._args
+            kwargs = caller.ndb._getinput._kwargs
             result = self.raw_string.strip()  # we strip the ending line break caused by sending
 
-            ok = not callback(caller, prompt, result)
+            ok = not callback(caller, prompt, result, *args, **kwargs)
             if ok:
                 # only clear the state if the callback does not return
                 # anything
@@ -930,7 +932,7 @@ class _Prompt(object):
     pass
 
 
-def get_input(caller, prompt, callback, session=None):
+def get_input(caller, prompt, callback, session=None, *args, **kwargs):
     """
     This is a helper function for easily request input from
     the caller.
@@ -981,6 +983,8 @@ def get_input(caller, prompt, callback, session=None):
     caller.ndb._getinput._callback = callback
     caller.ndb._getinput._prompt = prompt
     caller.ndb._getinput._session = session
+    caller.ndb._getinput._args = args
+    caller.ndb._getinput._kwargs = kwargs
     caller.cmdset.add(InputCmdSet)
     caller.msg(prompt, session=session)
 

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -957,6 +957,13 @@ def get_input(caller, prompt, callback, session=None, *args, **kwargs):
             greater than 2. The session is then updated by the
             command and is available (for example in callbacks)
             through `caller.ndb.getinput._session`.
+        *args, **kwargs (optional): Extra arguments will be 
+            passed to the fall back function as a list 'args' 
+            and all keyword arguments as a dictionary 'kwargs'.
+            To utilise *args and **kwargs, a value for the
+            session argument must be provided (None by default)
+            and the callback function must take *args and 
+            **kwargs as arguments.
 
     Raises:
         RuntimeError: If the given callback is not callable.
@@ -975,6 +982,12 @@ def get_input(caller, prompt, callback, session=None, *args, **kwargs):
         may not be easy to get if caller is a player in higher
         multisession modes), then it is available in the
         callback through `caller.ndb._getinput._session`.
+        
+        Chaining get_input functions will result in the caller
+        stacking ever more instances of InputCmdSets. Whilst 
+        they will all be cleared on concluding the get_input 
+        chain, EvMenu should be considered for anything beyond 
+        a single question.
 
     """
     if not callable(callback):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Calling get_input with args and kwargs passes them to the callback function. Does not affect previous use so no changed required to existing code.

#### Motivation for adding to Evennia
Allows more complicated, self contained, use of get_input.

#### Other info (issues closed, discussion etc)
