### PR TITLE
Remove duplicate entries from CmdServerLoad

### DIFF
--- a/evennia/utils/idmapper/models.py
+++ b/evennia/utils/idmapper/models.py
@@ -572,7 +572,7 @@ def cache_size(mb=True):
             if not subclasses:
                 num = len(submodel.get_all_cached_instances())
                 numtotal[0] += num
-                classdict[submodel.__name__] = num
+                classdict[submodel.__dbclass__.__name__] = num
             else:
                 get_recurse(subclasses)
     get_recurse(SharedMemoryModel.__subclasses__())


### PR DESCRIPTION
#### Brief overview of PR changes/additions
CmdServerLoad uses idmapper's `cache_size` function, but that builds a list of classes by name, rather than using their `__dbmodel__` attribute to distinguish them. As a result, there was a duplicate entry for each typeclass with identical values: for example, it would show each of your ObjectDB typeclasses that were currently represented in memory with a number corresponding to the number of ObjectDB instances next to each typeclass, which was misleading. So I just added them by their `__dbmodel__` to the class dict for a better representation.


#### Motivation for adding to Evennia
Have cache_size return a classdict of the `__dbmodel__` class names to be more accurate and readable. It wasn't a big deal, but it was hard to read when you have a lot of different typeclasses.

#### Other info (issues closed, discussion etc)
N/A
