### PR TITLE
Fix SharedMemoryManager to respect foreignkeys for cached instances

### DIFF
--- a/evennia/utils/idmapper/manager.py
+++ b/evennia/utils/idmapper/manager.py
@@ -25,6 +25,12 @@ class SharedMemoryManager(Manager):
                 key = key[:-len('__exact')]
             if key in ('pk', self.model._meta.pk.attname):
                 inst = self.model.get_cached_instance(kwargs[items[0]])
+                try:
+                    # we got the item from cache, but if this is a fk, check it's ours
+                    if getattr(inst, str(self.field).split(".")[-1]) != self.instance:
+                        inst = None
+                except Exception:
+                    pass
         if inst is None:
             inst = super(SharedMemoryManager, self).get(*args, **kwargs)
         return inst


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The manager for the SharedMemoryManager would retrieve any cached instance by ID when used as a RelatedManager, whether the object was related to the instance doing the related query or not. Added a check to see if we have the appropriate field name set in the instance.

#### Motivation for adding to Evennia
Make `object.relatedmanager.get(id=num)` properly raise `DoesNotExist` if the id of the class instance is in our cache, but is not one of our related objects.

#### Other info (issues closed, discussion etc)
While this seems to be working so far, this is dabbling with stuff in django I don't have a very good grasp on, so I'm hoping this actually works properly.