### PR TITLE
Remove the over-incrementing task ID

### DIFF
--- a/evennia/contrib/events/scripts.py
+++ b/evennia/contrib/events/scripts.py
@@ -45,7 +45,6 @@ class EventHandler(DefaultScript):
         self.db.locked = []
 
         # Tasks
-        self.db.task_id = 0
         self.db.tasks = {}
 
     def at_start(self):
@@ -559,8 +558,12 @@ class EventHandler(DefaultScript):
         """
         now = datetime.now()
         delta = timedelta(seconds=seconds)
-        task_id = self.db.task_id
-        self.db.task_id += 1
+
+        # Choose a free task_id
+        used_ids = list(self.db.tasks.keys())
+        task_id = 1
+        while task_id in used_ids:
+            task_id += 1
 
         # Collect and freeze current locals
         locals = {}

--- a/evennia/contrib/events/tests.py
+++ b/evennia/contrib/events/tests.py
@@ -58,7 +58,6 @@ class TestEventHandler(EvenniaTest):
         self.assertEqual(self.handler.db.to_valid, [])
         self.assertEqual(self.handler.db.locked, [])
         self.assertEqual(self.handler.db.tasks, {})
-        self.assertEqual(self.handler.db.task_id, 0)
         self.assertIsNotNone(self.handler.ndb.events)
 
     def test_add_validation(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The event task ID was always increasing, which would create long IDs if the system was often used.

#### Motivation for adding to Evennia

With a system that creates lots of chained events, the task ID would have gone up pretty quickly.  Now, IDs can be re-used.  This doesn't create conflicts, as ID are free when the task is executed anyway.