### PR TITLE
Fixed a bug in which creating a SimpleDoor caused the next exit creat…

### DIFF
--- a/evennia/contrib/simpledoor.py
+++ b/evennia/contrib/simpledoor.py
@@ -101,20 +101,20 @@ class CmdOpen(default_cmds.CmdOpen):
         """
         Simple wrapper for the default CmdOpen.create_exit
         """
+        # create a new exit as normal
+        new_exit = super(CmdOpen, self).create_exit(exit_name, location, destination,
+                                                    exit_aliases=exit_aliases, typeclass=typeclass)
         if hasattr(self, "return_exit_already_created"):
             # we don't create a return exit if it was already created (because
             # we created a door)
             del self.return_exit_already_created
-            return None
-        # create a new exit as normal
-        new_exit = super(CmdOpen, self).create_exit(exit_name, location, destination,
-                                                    exit_aliases=exit_aliases, typeclass=typeclass)
+            return new_exit
         if inherits_from(new_exit, SimpleDoor):
             # a door - create its counterpart and make sure to turn off the default
             # return-exit creation of CmdOpen
             self.caller.msg("Note: A door-type exit was created - ignored eventual custom return-exit type.")
             self.return_exit_already_created = True
-            back_exit = super(CmdOpen, self).create_exit(exit_name, destination, location,
+            back_exit = self.create_exit(exit_name, destination, location,
                                                          exit_aliases=exit_aliases, typeclass=typeclass)
             new_exit.db.return_exit = back_exit
             back_exit.db.return_exit = new_exit


### PR DESCRIPTION
…ed to fail silently.

#### Brief overview of PR changes/additions
I discovered a bug in the existing SimpleDoor contrib. You can repro it as follows.
- Dig a new room.
- Create a simpledoor to the new room.
- Create a second new room.
- Create an exit to the second new room.
The second exit will never be created, and no output will be produced.

The bug is due to the "return_exit_already_created" flag never being removed. Prior to my fix, this flag would cause the subsequent exit to not be created at all, rather than preventing the second exit from causing an infinite recursion as intended. This recursion was instead prevented by simply making two basic exits and never calling the given class's create_exit method again. I've fixed this by changing the super().create_exit call to self.create_exit, as I believe was originally intended.

#### Motivation for adding to Evennia
It's a bug fix! Now people can use SimpleDoors without breaking their building process.

#### Other info (issues closed, discussion etc)
I didn't post an issue for this prior to the fix. I'm not sure if I should have.
