### PR TITLE
LogFile class for rotating channel logs

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -126,9 +126,9 @@ LOCKWARNING_LOG_FILE = os.path.join(LOG_DIR, 'lockwarnings.log')
 # loose log info.
 CYCLE_LOGFILES = True
 # Number of lines to append to rotating channel logs when they rotate
-NUM_LOG_TAIL_LINES = 20
+CHANNEL_LOG_NUM_TAIL_LINES = 20
 # Max size of channel log files before they rotate
-LOG_ROTATE_SIZE = 1000000
+CHANNEL_LOG_ROTATE_SIZE = 1000000
 # Local time zone for this installation. All choices can be found here:
 # http://www.postgresql.org/docs/8.0/interactive/datetime-keywords.html#DATETIME-TIMEZONE-SET-TABLE
 TIME_ZONE = 'UTC'

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -125,6 +125,10 @@ LOCKWARNING_LOG_FILE = os.path.join(LOG_DIR, 'lockwarnings.log')
 # file sizes down. Turn off to get ever growing log files and never
 # loose log info.
 CYCLE_LOGFILES = True
+# Number of lines to append to rotating channel logs when they rotate
+NUM_LOG_TAIL_LINES = 20
+# Max size of channel log files before they rotate
+LOG_ROTATE_SIZE = 1000000
 # Local time zone for this installation. All choices can be found here:
 # http://www.postgresql.org/docs/8.0/interactive/datetime-keywords.html#DATETIME-TIMEZONE-SET-TABLE
 TIME_ZONE = 'UTC'

--- a/evennia/utils/logger.py
+++ b/evennia/utils/logger.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from traceback import format_exc
 from twisted.python import log, logfile
 from twisted.internet.threads import deferToThread
-from django.conf import settings
 
 
 _LOGDIR = None
@@ -161,6 +160,7 @@ class EvenniaLogFile(logfile.LogFile):
     lines of the previous log to the start of the new log, in order
     to preserve a continuous chat history for channel log files.
     """
+    from django.conf import settings
     num_lines_to_append = settings.CHANNEL_LOG_NUM_TAIL_LINES
 
     def rotate(self):
@@ -209,6 +209,7 @@ def _open_log_file(filename):
     handle.  Will create a new file in the log dir if one didn't
     exist.
     """
+    from django.conf import settings
     global _LOG_FILE_HANDLES, _LOGDIR
     if not _LOGDIR:
         _LOGDIR = settings.LOG_DIR

--- a/evennia/utils/logger.py
+++ b/evennia/utils/logger.py
@@ -159,12 +159,10 @@ class EvenniaLogFile(logfile.LogFile):
 
     def rotate(self):
         append_tail = self.num_lines_to_append > 0
-        print "append_tail is %s" % append_tail
         if not append_tail:
             logfile.LogFile.rotate(self)
             return
         lines = tail_log_file(self.path, 0, self.num_lines_to_append)
-        print "lines is %s" % lines
         logfile.LogFile.rotate(self)
         for line in lines:
             self.write(line)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I added a logfile class based on Twisted's rotating logfiles to use for the filehandles for channel logs. I overrode its `rotate()` method in order to write the tail end of the previous log file to the new one after rotation, so that people don't see the channel history vanish whenever it rotates. Size of rotation and how many lines to rotate are both customizable with settings.

#### Motivation for adding to Evennia
To allow for channel logs to rotate rather than ominously growing unbounded in the background, growing ever more powerful, biding their time to strike. Resolves #1253 

#### Other info (issues closed, discussion etc)
I tested this a bit, but since my familiarity with twisted's logging consists of an afternoon of staring at their logging API and tinkering, I'm hoping that I didn't miss anything horrific.
