### PR TITLE
Prevent AttributeError in multimatch commands when command.obj is None

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -429,7 +429,7 @@ class Command(with_metaclass(CommandMeta, object)):
             object, conventionally with a preceding space.
 
         """
-        if hasattr(self, 'obj') and self.obj != caller:
+        if hasattr(self, 'obj') and self.obj and self.obj != caller:
             return " (%s)" % self.obj.get_display_name(caller).strip()
         return ""
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, get_extra_info will raise an AttributeError if self.obj is defined in the command, but is currently None. This prevents the AttributeError and returns an empty string correctly.

#### Motivation for adding to Evennia
Prevent following traceback:
```
Traceback (most recent call last):
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]   File "/home/tehom/arx/evennia/evennia/commands/cmdhandler.py", line 597, in cmdhandler
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]     sysarg = yield _SEARCH_AT_RESULT([match[2] for match in matches], caller, query=matches[0][0])
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]   File "/home/tehom/arx/evennia/evennia/utils/utils.py", line 1769, in at_search_result
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]     info=result.get_extra_info(caller))
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]   File "/home/tehom/arx/evennia/evennia/commands/command.py", line 433, in get_extra_info
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::]     return " (%s)" % self.obj.get_display_name(caller).strip()
2017-06-01T02:13:04-0400 [AMPProtocol,0,127.0.0.1] [::] AttributeError: 'NoneType' object has no attribute 'get_display_name'
```

#### Other info (issues closed, discussion etc)
N/A
