### PR TITLE
Fix AttributeError when webserver isn't enabled.

### DIFF
--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -174,8 +174,11 @@ class Evennia(object):
         # (see https://github.com/evennia/evennia/issues/1128)
         def _wrap_sigint_handler(*args):
             from twisted.internet.defer import Deferred
-            d = self.web_root.empty_threadpool()
-            d.addCallback(lambda _: self.shutdown(_reactor_stopping=True))
+            if WEBSERVER_ENABLED:
+                d = self.web_root.empty_threadpool()
+                d.addCallback(lambda _: self.shutdown(_reactor_stopping=True))
+            else:
+                d = Deferred(lambda _: self.shutdown(_reactor_stopping=True))
             d.addCallback(lambda _: reactor.stop())
             reactor.callLater(1, d.callback, None)
         reactor.sigInt = _wrap_sigint_handler


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just a quick fix to make it check if `WEBSERVER_ENABLED` during shutdown, so it doesn't get an AttributeError.

#### Motivation for adding to Evennia
Small fix for people who don't have the webserver enabled.

#### Other info (issues closed, discussion etc)
N/A