### PR TITLE
Change IAC + GA to key off of MUDPROMPT @option

### DIFF
--- a/evennia/commands/default/player.py
+++ b/evennia/commands/default/player.py
@@ -560,6 +560,7 @@ class CmdOption(COMMAND_DEFAULT_CLASS):
                       "CLIENTNAME": utils.to_str,
                       "ENCODING": validate_encoding,
                       "MCCP": validate_bool,
+                      "MUDPROMPT": validate_bool,
                       "MXP": validate_bool,
                       "NOCOLOR": validate_bool,
                       "NOPKEEPALIVE": validate_bool,

--- a/evennia/server/inputfuncs.py
+++ b/evennia/server/inputfuncs.py
@@ -193,7 +193,8 @@ def client_options(session, *args, **kwargs):
                            "UTF-8", "SCREENREADER", "ENCODING",
                            "MCCP", "SCREENHEIGHT",
                            "SCREENWIDTH", "INPUTDEBUG",
-                           "RAW", "NOCOLOR"))
+                           "RAW", "NOCOLOR",
+                           "MUDPROMPT"))
         session.msg(client_options=options)
         return
 

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -221,7 +221,9 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         # escape IAC in line mode, and correctly add \r\n
         line += self.delimiter
         line = line.replace(IAC, IAC + IAC).replace('\n', '\r\n')
-        return self.transport.write(mccp_compress(self, line + IAC + GA))
+        if self.protocol_flags.get("MUDPROMPT", False):
+            line = line + IAC + GA
+        return self.transport.write(mccp_compress(self, line))
 
     # Session hooks
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Like it says on the tin; add a MUDPROMPT @option and key the IAC + GA on the end of output blobs off of that @option. :)

#### Motivation for adding to Evennia
Several clients interpret IAC + GA as a linefeed, in order to support MUDs that always end a line with them.  This causes Evennia to spew empty lines everywhere if IAC + GA is always on.  Giving the option to toggle it seems a good solution.
