### PR TITLE
Fix another AttributeError in errback for #1207.

### DIFF
--- a/evennia/server/webserver.py
+++ b/evennia/server/webserver.py
@@ -125,7 +125,7 @@ class EvenniaReverseProxyResource(ReverseProxyResource):
         clientFactory.noisy = False
         self.reactor.connectTCP(self.host, self.port, clientFactory)
         # don't trigger traceback if connection is lost before request finish.
-        request.notifyFinish().addErrback(lambda f: f.cancel())
+        request.notifyFinish().addErrback(lambda f: logger.log_trace("%s\nCaught errback in webserver.py:75." % f))
         return NOT_DONE_YET
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I was looking over my portal log for any hints about the AMP Errors. No luck there, but I did see a traceback for an errback in `notifyFinish` that had an AttributeError.

#### Motivation for adding to Evennia
Resolves following traceback:
```
2017-06-05T00:17:35-0400 [twisted.internet.defer#critical] Unhandled error in Deferred:

Traceback (most recent call last):
  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/http.py", line 1951, in connectionLost
    request.connectionLost(reason)
  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/http.py", line 1337, in connectionLost
    d.errback(reason)
  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 434, in errback
    self._startRunCallbacks(fail)
  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 501, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 587, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/tehom/arx/evennia/evennia/server/webserver.py", line 128, in <lambda>
    request.notifyFinish().addErrback(lambda f: f.cancel())
exceptions.AttributeError: Failure instance has no attribute 'cancel'
2017-06-05T00:17:35-0400 [ProxyClient,client] Unhandled Error
	Traceback (most recent call last):
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/application/app.py", line 310, in runReactorWithLogging
	    reactor.run()
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1195, in run
	    self.mainLoop()
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/base.py", line 1207, in mainLoop
	    self.doIteration(t)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/epollreactor.py", line 396, in doPoll
	    log.callWithLogger(selectable, _drdw, selectable, fd, event)
	--- <exception caught here> ---
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/python/log.py", line 101, in callWithLogger
	    return callWithContext({"system": lp}, func, *args, **kw)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/python/log.py", line 84, in callWithContext
	    return context.call({ILogContext: newCtx}, func, *args, **kw)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
	    return self.currentContext().callWithContext(ctx, func, *args, **kw)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
	    return func(*args,**kw)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 610, in _doReadOrWrite
	    self._disconnectSelectable(selectable, why, inRead)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 252, in _disconnectSelectable
	    selectable.readConnectionLost(f)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 272, in readConnectionLost
	    self.connectionLost(reason)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 478, in connectionLost
	    self._commonConnection.connectionLost(self, reason)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/internet/tcp.py", line 292, in connectionLost
	    protocol.connectionLost(reason)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/http.py", line 486, in connectionLost
	    self.handleResponseEnd()
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/proxy.py", line 87, in handleResponseEnd
	    self.father.finish()
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/server.py", line 231, in finish
	    return http.Request.finish(self)
	  File "/home/tehom/arx/local/lib/python2.7/site-packages/twisted/web/http.py", line 863, in finish
	    "Request.finish called on a request after its connection was lost; "
	exceptions.RuntimeError: Request.finish called on a request after its connection was lost; use Request.notifyFinish to keep track of this.
```

#### Other info (issues closed, discussion etc)
N/A