### PR TITLE
[Event system] Check that the script has valid non-attributes before …

### DIFF
--- a/evennia/contrib/events/utils.py
+++ b/evennia/contrib/events/utils.py
@@ -57,6 +57,7 @@ def register_events(path_or_typeclass):
     try:
         storage = ScriptDB.objects.get(db_key="event_handler")
         assert storage.is_active
+        assert storage.ndb.events is not None
     except (ScriptDB.DoesNotExist, AssertionError):
         storage = EVENTS
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When the server was "violently" shutdown, the script wasn't restarted properly, but it was still accessible from the database.  This made registering events a bit unstable.

#### Other info (issues closed, discussion etc)

- [Fix of issue #1343](https://github.com/evennia/evennia/issues/1343#issuecomment-307897564)
