### PR TITLE
Add kwargs for hooks to move_to

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -614,7 +614,8 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             obj.msg(text=(outmessage, outkwargs), from_obj=from_obj, **kwargs)
 
     def move_to(self, destination, quiet=False,
-                emit_to_obj=None, use_destination=True, to_none=False, move_hooks=True):
+                emit_to_obj=None, use_destination=True, to_none=False, move_hooks=True,
+                msg=None, mapping=None):
         """
         Moves this object to a new location.
 
@@ -634,6 +635,8 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             move_hooks (bool): If False, turn off the calling of move-related hooks
                 (at_before/after_move etc) with quiet=True, this is as quiet a move
                 as can be done.
+            msg (str, optional): a replacement message.
+            mapping (dict, optional): additional mapping objects.
 
         Returns:
             result (bool): True/False depending on if there were problems with the move.
@@ -700,7 +703,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if not quiet:
             # tell the old room we are leaving
             try:
-                self.announce_move_from(destination)
+                self.announce_move_from(destination, msg=msg, mapping=mapping)
             except Exception as err:
                 logerr(errtxt % "at_announce_move()", err)
                 return False
@@ -715,7 +718,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if not quiet:
             # Tell the new room we are there.
             try:
-                self.announce_move_to(source_location)
+                self.announce_move_to(source_location, msg=msg, mapping=mapping)
             except Exception as err:
                 logerr(errtxt % "announce_move_to()", err)
                 return False

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -615,7 +615,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
 
     def move_to(self, destination, quiet=False,
                 emit_to_obj=None, use_destination=True, to_none=False, move_hooks=True,
-                msg=None, mapping=None):
+                **kwargs):
         """
         Moves this object to a new location.
 
@@ -635,8 +635,9 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             move_hooks (bool): If False, turn off the calling of move-related hooks
                 (at_before/after_move etc) with quiet=True, this is as quiet a move
                 as can be done.
-            msg (str, optional): a replacement message.
-            mapping (dict, optional): additional mapping objects.
+
+        Kwargs:
+          Passed on to announce_move_to and announce_move_from hooks.
 
         Returns:
             result (bool): True/False depending on if there were problems with the move.
@@ -703,7 +704,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if not quiet:
             # tell the old room we are leaving
             try:
-                self.announce_move_from(destination, msg=msg, mapping=mapping)
+                self.announce_move_from(destination, **kwargs)
             except Exception as err:
                 logerr(errtxt % "at_announce_move()", err)
                 return False
@@ -718,7 +719,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         if not quiet:
             # Tell the new room we are there.
             try:
-                self.announce_move_to(source_location, msg=msg, mapping=mapping)
+                self.announce_move_to(source_location, **kwargs)
             except Exception as err:
                 logerr(errtxt % "announce_move_to()", err)
                 return False


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`announce_move_from` and `announce_move_to` allow you to pass mappings and other useful kwargs to them in order to override their behavior, but `move_to` itself does not take these arguments and does not pass them to the hooks. I just added them to `move_to` arguments and pass them along to the hooks.

#### Motivation for adding to Evennia
Allow `announce_move_to` and `announce_move_from` hooks to take advantage of their mapping and msg arguments.

#### Other info (issues closed, discussion etc)
N/A
