### PR TITLE
Fix weird lag issue with db_model (Resolves #1173)

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -219,7 +219,7 @@ class AttributeHandler(object):
     def _fullcache(self):
         """Cache all attributes of this object"""
         query = {"%s__id" % self._model: self._objid,
-                 "attribute__db_model": self._model,
+                 "attribute__db_model__iexact": self._model,
                  "attribute__db_attrtype": self._attrtype}
         attrs = [conn.attribute for conn in getattr(self.obj, self._m2m_fieldname).through.objects.filter(**query)]
         self._cache = dict(("%s-%s" % (to_str(attr.db_key).lower(),
@@ -273,7 +273,7 @@ class AttributeHandler(object):
                     return []  # no such attribute: return an empty list
             else:
                 query = {"%s__id" % self._model: self._objid,
-                         "attribute__db_model": self._model,
+                         "attribute__db_model__iexact": self._model,
                          "attribute__db_attrtype": self._attrtype,
                          "attribute__db_key__iexact": key.lower(),
                          "attribute__db_category__iexact": category.lower() if category else None}
@@ -298,7 +298,7 @@ class AttributeHandler(object):
             else:
                 # we have to query to make this category up-date in the cache
                 query = {"%s__id" % self._model: self._objid,
-                         "attribute__db_model": self._model,
+                         "attribute__db_model__iexact": self._model,
                          "attribute__db_attrtype": self._attrtype,
                          "attribute__db_category__iexact": category.lower() if category else None}
                 attrs = [conn.attribute for conn


### PR DESCRIPTION
#### Brief overview of PR changes/additions
So while playing around with the incredibly weird bug that only seemed to affect me (issue #1173 ), where db_model added to a query with db_attrtype and/or db_category would produce game-stopping lag, I randomly read somewhere about LIKE statements possibly interfering with the performance of an index in some types of databases, and saw django's notes about the __iexact/exact flags using LIKE. So just as a random experiment, I tried adding __iexact to db_model, and the lag issue resolved instantly. Now, this surely seems like a bizarre bug somewhere, and I have zero idea **why** this should work, but here we are.

#### Motivation for adding to Evennia
Fix crippling lag issue that cropped up in one instance of an SQLite database. Still don't know root cause.

#### Other info (issues closed, discussion etc)
Resolves #1173 
