### PR TITLE
docs: add missing word

### DIFF
--- a/evennia/contrib/rpsystem.py
+++ b/evennia/contrib/rpsystem.py
@@ -627,7 +627,7 @@ class SdescHandler(object):
     def get(self):
         """
         Simple getter. The sdesc should never be allowed to
-        be empty, but it is we must fall back to the key.
+        be empty, but if it is we must fall back to the key.
 
         """
         return self.sdesc or self.obj.key


### PR DESCRIPTION
#### Brief overview of PR changes/additions

In the `evennia/evennia/contrib/rpsystem.py` file, the documentation for the `get` function of the `SdescHandler` class was missing the word `if`.

#### Motivation for adding to Evennia

Clarification of docs for future readers.

#### Other info (issues closed, discussion etc)
