### PR TITLE
use bold for |h (highlight)

### DIFF
--- a/evennia/server/portal/irc.py
+++ b/evennia/server/portal/irc.py
@@ -93,6 +93,7 @@ IRC_COLOR_MAP = dict([
     (r'|_', " "),         # space
     (r'|*', ""),          # invert
     (r'|^', ""),          # blinking text
+    (r'|h', IRC_BOLD),    # highlight, use bold instead
 
     (r'|r', IRC_COLOR + IRC_RED),
     (r'|g', IRC_COLOR + IRC_GREEN),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Uses IRC \002 (bold) for highlight

#### Motivation for adding to Evennia
Fixes #1367 

#### Other info (issues closed, discussion etc)
You may want to just strip |h instead of using IRC Bold, it's up to style choice.
