### PR TITLE
Allow contrib.ingame_python.scripts.EventHandler.get_events to work w…

### DIFF
--- a/evennia/contrib/ingame_python/scripts.py
+++ b/evennia/contrib/ingame_python/scripts.py
@@ -10,7 +10,7 @@ import traceback
 
 from django.conf import settings
 from evennia import DefaultObject, DefaultScript, ChannelDB, ScriptDB
-from evennia import logger
+from evennia import logger, ObjectDB
 from evennia.utils.ansi import raw
 from evennia.utils.create import create_channel
 from evennia.utils.dbserialize import dbserialize
@@ -101,7 +101,7 @@ class EventHandler(DefaultScript):
         Return a dictionary of events on this object.
 
         Args:
-            obj (Object): the connected object.
+            obj (Object or typeclass): the connected object or typeclass.
 
         Returns:
             A dictionary of the object's events.
@@ -115,7 +115,11 @@ class EventHandler(DefaultScript):
         events = {}
         all_events = self.ndb.events
         classes = Queue()
-        classes.put(type(obj))
+        if isinstance(obj, ObjectDB):
+            classes.put(type(obj))
+        else:
+            classes.put(obj)
+
         invalid = []
         while not classes.empty():
             typeclass = classes.get()

--- a/evennia/contrib/ingame_python/scripts.py
+++ b/evennia/contrib/ingame_python/scripts.py
@@ -101,24 +101,28 @@ class EventHandler(DefaultScript):
         Return a dictionary of events on this object.
 
         Args:
-            obj (Object or typeclass): the connected object or typeclass.
+            obj (Object or typeclass): the connected object or a general typeclass.
 
         Returns:
             A dictionary of the object's events.
 
-        Note:
+        Notes:
             Events would define what the object can have as
             callbacks.  Note, however, that chained callbacks will not
             appear in events and are handled separately.
+
+            You can also request the events of a typeclass, not a
+            connected object.  This is useful to get the global list
+            of events for a typeclass that has no object yet.
 
         """
         events = {}
         all_events = self.ndb.events
         classes = Queue()
-        if isinstance(obj, ObjectDB):
-            classes.put(type(obj))
-        else:
+        if isinstance(obj, type):
             classes.put(obj)
+        else:
+            classes.put(type(obj))
 
         invalid = []
         while not classes.empty():


### PR DESCRIPTION
…ith typeclasses

#### Brief overview of PR changes/additions

The in-game Python global script can now work with objects and typeclasses.

#### Motivation for adding to Evennia

This allows to test the events of a typeclass without needing its objects.  This is useful to explore the system itself without relying on individual objects.