### PR TITLE
Add EvMenu support for ending on start node.

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -855,6 +855,8 @@ class EvMenu(object):
             self.helptext = _HELP_NO_OPTIONS if self.auto_quit else _HELP_NO_OPTIONS_NO_QUIT
 
         self.display_nodetext()
+        if not options:
+            self.close_menu()
 
     def close_menu(self):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, if the start node has options of None then any input causes a "Choose an option or try 'help'." message to display and then ending the menu. This is because EvMenu only supports ending the menu via the _input_parser. We add a check to the goto method which calls to display the starting node and thus allows the menu to exit seamlessly from a single node.

#### Motivation for adding to Evennia
This matter was discussed on length on IRC. Whilst it is agreed that EvMenu should not be used to display a single node where choices are not required of the player, I would suggest that EvMenu should have the option to deal with that eventuality seamlessly regardless. I can envision situation where the starting menu has the option of ending on the first node due to some condition, which if not present would otherwise lead to a sprawling narrative worthy of the EvMenu system.

#### Other info (issues closed, discussion etc)
