### PR TITLE
Create fallback for default cmdsets that fail to load

### DIFF
--- a/evennia/commands/cmdsethandler.py
+++ b/evennia/commands/cmdsethandler.py
@@ -355,9 +355,12 @@ class CmdSetHandler(object):
                                 # If a cmdset fails to load, check if we have a fallback path to use
                                 fallback_path = settings.CMDSET_FALLBACKS.get(path, None)
                                 if fallback_path:
+                                    logger.log_err("Error encountered for cmdset at path %s. Replacing with: %s" % (
+                                        path, fallback_path))
                                     cmdset = self._import_cmdset(fallback_path)
                                 # If no cmdset is returned from the fallback, we can't go further
                                 if not cmdset:
+                                    logger.log_err("Fallback path '%s' failed to generate a cmdset." % fallback_path)
                                     continue
                             cmdset.permanent = cmdset.key != '_CMDSET_ERROR'
                             self.cmdset_stack.append(cmdset)

--- a/evennia/commands/cmdsethandler.py
+++ b/evennia/commands/cmdsethandler.py
@@ -351,6 +351,14 @@ class CmdSetHandler(object):
                     elif path:
                         cmdset = self._import_cmdset(path)
                         if cmdset:
+                            if cmdset.key == '_CMDSET_ERROR':
+                                # If a cmdset fails to load, check if we have a fallback path to use
+                                fallback_path = settings.CMDSET_FALLBACKS.get(path, None)
+                                if fallback_path:
+                                    cmdset = self._import_cmdset(fallback_path)
+                                # If no cmdset is returned from the fallback, we can't go further
+                                if not cmdset:
+                                    continue
                             cmdset.permanent = cmdset.key != '_CMDSET_ERROR'
                             self.cmdset_stack.append(cmdset)
 

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -348,6 +348,12 @@ CMDSET_CHARACTER = "commands.default_cmdsets.CharacterCmdSet"
 CMDSET_PLAYER = "commands.default_cmdsets.PlayerCmdSet"
 # Location to search for cmdsets if full path not given
 CMDSET_PATHS = ["commands", "evennia", "contribs"]
+# Fallbacks for cmdset paths that fail to load. Note that if you change the path for your default cmdsets,
+# you will also need to copy CMDSET_FALLBACKS after your change in your settings file for it to detect the change.
+CMDSET_FALLBACKS = {CMDSET_CHARACTER: 'evennia.commands.default.cmdset_character.CharacterCmdSet',
+                    CMDSET_PLAYER: 'evennia.commands.default.cmdset_player.PlayerCmdSet',
+                    CMDSET_SESSION: 'evennia.commands.default.cmdset_session.SessionCmdSet',
+                    CMDSET_UNLOGGEDIN: 'evennia.commands.default.cmdset_unloggedin.UnloggedinCmdSet'}
 # Parent class for all default commands. Changing this class will
 # modify all default commands, so do so carefully.
 COMMAND_DEFAULT_CLASS = "evennia.commands.default.muxcommand.MuxCommand"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Checks the path of any cmdset that fails to load against a dict in settings that can provide a fallback to try instead, making syntax errors in code much more forgiving.


#### Motivation for adding to Evennia
In Evennia chat, @DamnedScholar brought up that cmdset failure isn't very forgiving - any syntax error in an imported file is likely to wreck the entire process and leave them in a state where they can't even `@reload` the server. While I discussed the workarounds, such as catching exceptions in import statements, this isn't particularly newbie friendly. An automatic fallback of the default cmdsets seemed like a good solution to me.

#### Other info (issues closed, discussion etc)
N/A
