### PR TITLE
Add setting for global CmdHelp's help_more flag

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -198,7 +198,8 @@ class CmdHelp(Command):
         # retrieve all available commands and database topics
         all_cmds = [cmd for cmd in cmdset if self.check_show_help(cmd, caller)]
         all_topics = [topic for topic in HelpEntry.objects.all() if topic.access(caller, 'view', default=True)]
-        all_categories = list(set([cmd.help_category.lower() for cmd in all_cmds] + [topic.help_category.lower() for topic in all_topics]))
+        all_categories = list(set([cmd.help_category.lower() for cmd in all_cmds] + [topic.help_category.lower()
+                                                                                     for topic in all_topics]))
 
         if query in ("list", "all"):
             # we want to list all available help entries, grouped by category
@@ -222,7 +223,8 @@ class CmdHelp(Command):
         if suggestion_maxnum > 0:
             vocabulary = [cmd.key for cmd in all_cmds if cmd] + [topic.key for topic in all_topics] + all_categories
             [vocabulary.extend(cmd.aliases) for cmd in all_cmds]
-            suggestions = [sugg for sugg in string_suggestions(query, set(vocabulary), cutoff=suggestion_cutoff, maxnum=suggestion_maxnum)
+            suggestions = [sugg for sugg in string_suggestions(query, set(vocabulary), cutoff=suggestion_cutoff,
+                                                               maxnum=suggestion_maxnum)
                            if sugg != query]
             if not suggestions:
                 suggestions = [sugg for sugg in vocabulary if sugg != query and sugg.startswith(query)]
@@ -231,9 +233,9 @@ class CmdHelp(Command):
         match = [cmd for cmd in all_cmds if cmd == query]
         if len(match) == 1:
             formatted = self.format_help_entry(match[0].key,
-                     match[0].get_help(caller, cmdset),
-                     aliases=match[0].aliases,
-                     suggested=suggestions)
+                                               match[0].get_help(caller, cmdset),
+                                               aliases=match[0].aliases,
+                                               suggested=suggestions)
             self.msg_help(formatted)
             return
 
@@ -241,16 +243,17 @@ class CmdHelp(Command):
         match = list(HelpEntry.objects.find_topicmatch(query, exact=True))
         if len(match) == 1:
             formatted = self.format_help_entry(match[0].key,
-                     match[0].entrytext,
-                     aliases=match[0].aliases.all(),
-                     suggested=suggestions)
+                                               match[0].entrytext,
+                                               aliases=match[0].aliases.all(),
+                                               suggested=suggestions)
             self.msg_help(formatted)
             return
 
         # try to see if a category name was entered
         if query in all_categories:
-            self.msg_help(self.format_help_list({query:[cmd.key for cmd in all_cmds if cmd.help_category==query]},
-                                                {query:[topic.key for topic in all_topics if topic.help_category==query]}))
+            self.msg_help(self.format_help_list({query: [cmd.key for cmd in all_cmds if cmd.help_category == query]},
+                                                {query: [topic.key for topic in all_topics
+                                                         if topic.help_category == query]}))
             return
 
         # no exact matches found. Just give suggestions.
@@ -264,6 +267,7 @@ def _loadhelp(caller):
     else:
         return ""
 
+
 def _savehelp(caller, buffer):
     entry = caller.db._editing_help
     caller.msg("Saved help entry.")
@@ -274,6 +278,7 @@ def _savehelp(caller, buffer):
 def _quithelp(caller):
     caller.msg("Closing the editor.")
     del caller.db._editing_help
+
 
 class CmdSetHelp(COMMAND_DEFAULT_CLASS):
     """
@@ -307,7 +312,7 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
     help_category = "Building"
 
     def func(self):
-        "Implement the function"
+        """Implement the function"""
 
         switches = self.switches
         lhslist = self.lhslist
@@ -329,7 +334,7 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
         # check if we have an old entry with the same name
         try:
             for querystr in topicstrlist:
-                old_entry = HelpEntry.objects.find_topicmatch(querystr) # also search by alias
+                old_entry = HelpEntry.objects.find_topicmatch(querystr)  # also search by alias
                 if old_entry:
                     old_entry = list(old_entry)[0]
                     break
@@ -352,12 +357,12 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
             else:
                 helpentry = create.create_help_entry(topicstr,
                                                      self.rhs, category=category,
-                                                     locks=lockstring,aliases=aliases)
+                                                     locks=lockstring, aliases=aliases)
             self.caller.db._editing_help = helpentry
 
             EvEditor(self.caller, loadfunc=_loadhelp, savefunc=_savehelp,
-                    quitfunc=_quithelp, key="topic {}".format(topicstr),
-                    persistent=True)
+                     quitfunc=_quithelp, key="topic {}".format(topicstr),
+                     persistent=True)
             return
 
         if 'append' in switches or "merge" in switches or "extend" in switches:
@@ -401,21 +406,21 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
                 self.msg("Overwrote the old topic '%s'%s." % (topicstr, aliastxt))
             else:
                 self.msg("Topic '%s'%s already exists. Use /replace to overwrite "
-                        "or /append or /merge to add text to it." % (topicstr, aliastxt))
+                         "or /append or /merge to add text to it." % (topicstr, aliastxt))
         else:
             # no old entry. Create a new one.
             new_entry = create.create_help_entry(topicstr,
                                                  self.rhs, category=category,
-                                                 locks=lockstring,aliases=aliases)
+                                                 locks=lockstring, aliases=aliases)
             if new_entry:
                 self.msg("Topic '%s'%s was successfully created." % (topicstr, aliastxt))
                 if 'edit' in switches:
                     # open the line editor to edit the helptext
                     self.caller.db._editing_help = new_entry
                     EvEditor(self.caller, loadfunc=_loadhelp,
-                            savefunc=_savehelp, quitfunc=_quithelp,
-                            key="topic {}".format(new_entry.key),
-                            persistent=True)
+                             savefunc=_savehelp, quitfunc=_quithelp,
+                             key="topic {}".format(new_entry.key),
+                             persistent=True)
                     return
             else:
                 self.msg("Error when creating topic '%s'%s! Contact an admin." % (topicstr, aliastxt))

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -16,6 +16,7 @@ from evennia.utils.eveditor import EvEditor
 from evennia.utils.utils import string_suggestions, class_from_module
 
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
+HELP_MORE = settings.HELP_MORE
 
 # limit symbol import for API
 __all__ = ("CmdHelp", "CmdSetHelp")
@@ -45,9 +46,9 @@ class CmdHelp(Command):
     return_cmdset = True
 
     # Help messages are wrapped in an EvMore call (unless using the webclient
-    # with separate help popups) If you want to avoid this, simply set the
-    # 'help_more' flag to False.
-    help_more = True
+    # with separate help popups) If you want to avoid this, simply add
+    # 'HELP_MORE = False' in your settings/conf/settings.py
+    help_more = HELP_MORE
 
     # suggestion cutoff, between 0 and 1 (1 => perfect match)
     suggestion_cutoff = 0.6

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -494,8 +494,12 @@ PERMISSION_PLAYER_DEFAULT = "Players"
 # Default sizes for client window (in number of characters), if client
 # is not supplying this on its own
 CLIENT_DEFAULT_WIDTH = 78
-CLIENT_DEFAULT_HEIGHT = 45 # telnet standard is 24 but does anyone use such
-                           # low-res displays anymore?
+# telnet standard height is 24; does anyone use such low-res displays anymore?
+CLIENT_DEFAULT_HEIGHT = 45
+# Help output from CmdHELP are wrapped in an EvMore call
+# (excluding webclient with separate help popups). If continuous scroll
+# is preferred, change 'HELP_MORE' to False. EvMORE uses CLIENT_DEFAULT_HEIGHT
+HELP_MORE = True
 
 ######################################################################
 # Guest accounts

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -100,7 +100,7 @@ EVENNIA_ADMIN = True
 EVENNIA_DIR = os.path.dirname(os.path.abspath(__file__))
 # Path to the game directory (containing the server/conf/settings.py file)
 # This is dynamically created- there is generally no need to change this!
-if sys.argv[1] == 'test' if len(sys.argv)>1 else False:
+if sys.argv[1] == 'test' if len(sys.argv) > 1 else False:
     # unittesting mode
     GAME_DIR = os.getcwd()
 else:
@@ -206,14 +206,14 @@ MAX_CONNECTION_RATE = 2
 # from the client! To turn the limiter off, set to <= 0.
 MAX_COMMAND_RATE = 80
 # The warning to echo back to users if they send commands too fast
-COMMAND_RATE_WARNING ="You entered commands too fast. Wait a moment and try again."
+COMMAND_RATE_WARNING = "You entered commands too fast. Wait a moment and try again."
 # Determine how large of a string can be sent to the server in number
 # of characters. If they attempt to enter a string over this character
 # limit, we stop them and send a message. To make unlimited, set to
 # 0 or less.
 MAX_CHAR_LIMIT = 6000
 # The warning to echo back to users if they enter a very large string
-MAX_CHAR_LIMIT_WARNING="You entered a string that was too long. Please break it up into multiple parts."
+MAX_CHAR_LIMIT_WARNING = "You entered a string that was too long. Please break it up into multiple parts."
 # If this is true, errors and tracebacks from the engine will be
 # echoed as text in-game as well as to the log. This can speed up
 # debugging. OBS: Showing full tracebacks to regular users could be a
@@ -483,7 +483,7 @@ MAX_NR_CHARACTERS = 1
 # The access hierarchy, in climbing order. A higher permission in the
 # hierarchy includes access of all levels below it. Used by the perm()/pperm()
 # lock functions.
-PERMISSION_HIERARCHY = ["Guests", # note-only used if GUEST_ENABLED=True
+PERMISSION_HIERARCHY = ["Guests",  # note-only used if GUEST_ENABLED=True
                         "Players",
                         "PlayerHelpers",
                         "Builders",
@@ -537,17 +537,17 @@ GUEST_LIST = ["Guest" + str(s+1) for s in range(9)]
 # general "mud info" channel. Other channels beyond that
 # are up to the admin to design and call appropriately.
 DEFAULT_CHANNELS = [
-                  # public channel
-                  {"key": "Public",
-                  "aliases": ('ooc', 'pub'),
-                  "desc": "Public discussion",
-                  "locks": "control:perm(Wizards);listen:all();send:all()"},
-                  # connection/mud info
-                  {"key": "MudInfo",
-                   "aliases": "",
-                   "desc": "Connection log",
-                   "locks": "control:perm(Immortals);listen:perm(Wizards);send:false()"}
-                  ]
+                    # public channel
+                    {"key": "Public",
+                     "aliases": ('ooc', 'pub'),
+                     "desc": "Public discussion",
+                     "locks": "control:perm(Wizards);listen:all();send:all()"},
+                    #  connection/mud info
+                    {"key": "MudInfo",
+                     "aliases": "",
+                     "desc": "Connection log",
+                     "locks": "control:perm(Immortals);listen:perm(Wizards);send:false()"}
+                   ]
 # Extra optional channel for receiving connection messages ("<player> has (dis)connected").
 # While the MudInfo channel will also receieve this, this channel is meant for non-staffers.
 CHANNEL_CONNECTINFO = None
@@ -573,8 +573,8 @@ IRC_ENABLED = False
 # active. OBS: RSS support requires the python-feedparser package to
 # be installed (through package manager or from the website
 # http://code.google.com/p/feedparser/)
-RSS_ENABLED=False
-RSS_UPDATE_INTERVAL = 60*10 # 10 minutes
+RSS_ENABLED = False
+RSS_UPDATE_INTERVAL = 60*10  # 10 minutes
 
 ######################################################################
 # Django web features
@@ -590,7 +590,7 @@ DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 # Emails are sent to these people if the above DEBUG value is False. If you'd
 # rather prefer nobody receives emails, leave this commented out or empty.
-ADMINS = () #'Your Name', 'your_email@domain.com'),)
+ADMINS = ()  # 'Your Name', 'your_email@domain.com'),)
 # These guys get broken link notifications when SEND_BROKEN_LINK_EMAILS is True.
 MANAGERS = ADMINS
 # Absolute path to the directory that holds file uploads from web apps.
@@ -651,13 +651,13 @@ WEBSITE_TEMPLATE = 'website'
 WEBCLIENT_TEMPLATE = 'webclient'
 # The default options used by the webclient
 WEBCLIENT_OPTIONS = {
-        "gagprompt": True, # Gags prompt from the output window and keep them
-                           # together with the input bar
-        "helppopup": True, # Shows help files in a new popup window
-        "notification_popup": False, # Shows notifications of new messages as
-                                     # popup windows
-        "notification_sound": False # Plays a sound for notifications of new
-                                    # messages
+        "gagprompt": True,  # Gags prompt from the output window and keep them
+                            # together with the input bar
+        "helppopup": True,  # Shows help files in a new popup window
+        "notification_popup": False,  # Shows notifications of new messages as
+                                      # popup windows
+        "notification_sound": False   # Plays a sound for notifications of new
+                                      # messages
     }
 
 # We setup the location of the website template as well as the admin site.

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -496,7 +496,7 @@ PERMISSION_PLAYER_DEFAULT = "Players"
 CLIENT_DEFAULT_WIDTH = 78
 # telnet standard height is 24; does anyone use such low-res displays anymore?
 CLIENT_DEFAULT_HEIGHT = 45
-# Help output from CmdHELP are wrapped in an EvMore call
+# Help output from CmdHelp are wrapped in an EvMore call
 # (excluding webclient with separate help popups). If continuous scroll
 # is preferred, change 'HELP_MORE' to False. EvMORE uses CLIENT_DEFAULT_HEIGHT
 HELP_MORE = True


### PR DESCRIPTION
### Brief overview of PR changes/additions
Adds setting for global CmdHelp's help_more flag, defaulted to True (as before)

### Motivation for adding to Evennia
Allows toggling help_more flag as a server option within `CmdHelp` without need to overwrite/replace it.

### Other info (issues closed, discussion etc)
Setting `HELP_MORE` placed near `CLIENT_DEFAULT_WIDTH` and `CLIENT_DEFAULT_HEIGHT`

Although it's easy to alter by overwriting in game, less code change is involved by making it a server option, and other coders have expressed interest in toggling this directly.