### PR TITLE
Remove list wrapper from value passed to Django

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1326,7 +1326,7 @@ def main():
                         arg, value = [p.strip() for p in arg.split("=", 1)]
                     else:
                         value = True
-                    kwargs[arg.lstrip("--")] = [value]
+                    kwargs[arg.lstrip("--")] = value
                 else:
                     args.append(arg)
         try:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove list wrapper from arguments passed to Django from evennia_launcher.py

#### Motivation for adding to Evennia
Fixes #1398, allows multi-database use of Evennia, as well as any other Django command requiring an argument to be passed with "--", for instance, "evennia migrate --database=myapp" or "evennia dbshell --database=myapp"

#### Other info (issues closed, discussion etc)
Closes #1398 
Tested - Does not seem to interfere, but @Griatch, you might want to check my reading - I couldn't find any reason to pass a list to Django.

Unittesting - I'm unsure if we unittest the evennia_launcher and I'm unsure of how to do so - perhaps a future thing to do.
