### PR TITLE
Add more clear error message to _SaverMutable

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -153,6 +153,12 @@ class _SaverMutable(object):
         if self._parent:
             self._parent._save_tree()
         elif self._db_obj:
+            if not self._db_obj.pk:
+                cls_name = self.__class__.__name__
+                non_saver_name = cls_name.lstrip("_Saver")
+                err_msg = "%s %s has had its root Attribute deleted." % (cls_name, self)
+                err_msg += " It must be cast to a %s before it can be modified further." % non_saver_name
+                raise ValueError(err_msg)
             self._db_obj.value = self
         else:
             logger.log_err("_SaverMutable %s has no root Attribute to save to." % self)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a more clear error message for the edge case of someone removing an Attribute and then modifying the mutable that was stored there.

#### Motivation for adding to Evennia

To prevent confusion in anyone as easily confused as I am.

#### Other info (issues closed, discussion etc)

Resolves #1400
