### PR TITLE
Put older syntax for the exec statement and fix can_say and say events

### DIFF
--- a/evennia/contrib/ingame_python/scripts.py
+++ b/evennia/contrib/ingame_python/scripts.py
@@ -454,7 +454,7 @@ class EventHandler(DefaultScript):
                 continue
 
             try:
-                exec(callback["code"], locals, locals)
+                exec callback["code"] in {}, locals
             except InterruptEvent:
                 return False
             except Exception:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR fixes issue #1388 (changing the syntax of the `exec` statement to support older Python versions) and fix the `can_say` and `say` events.

#### Motivation for adding to Evennia

- Fixing the issue #1388 (although it's already closed).
- Fixing the `say` commands to allow `can_say` and `say` events to still be called.

#### Other info (issues closed, discussion etc)
