### PR TITLE
Add a confirmation to the default @destroy command

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -13,6 +13,7 @@ main test suite started with
 """
 
 import re
+import types
 
 from django.conf import settings
 from mock import Mock
@@ -73,8 +74,12 @@ class CommandTest(EvenniaTest):
             receiver.msg = Mock()
             cmdobj.at_pre_cmd()
             cmdobj.parse()
-            cmdobj.func()
+            ret = cmdobj.func()
+            if isinstance(ret, types.GeneratorType):
+                ret.next()
             cmdobj.at_post_cmd()
+        except StopIteration:
+            pass
         except InterruptCommand:
             pass
         finally:
@@ -250,7 +255,10 @@ class TestBuilding(CommandTest):
         self.call(building.CmdDesc(), "Obj2=TestDesc", "The description was set on Obj2(#5).")
 
     def test_wipe(self):
+        confirm = building.CmdDestroy.confirm
+        building.CmdDestroy.confirm = False
         self.call(building.CmdDestroy(), "Obj", "Obj was destroyed.")
+        building.CmdDestroy.confirm = confirm
 
     def test_dig(self):
         self.call(building.CmdDig(), "TestRoom1=testroom;tr,back;b", "Created room TestRoom1")
@@ -330,7 +338,10 @@ class TestBatchProcess(CommandTest):
         # cannot test batchcode here, it must run inside the server process
         self.call(batchprocess.CmdBatchCommands(), "example_batch_cmds", "Running Batchcommand processor  Automatic mode for example_batch_cmds")
         # we make sure to delete the button again here to stop the running reactor
+        confirm = building.CmdDestroy.confirm
+        building.CmdDestroy.confirm = False
         self.call(building.CmdDestroy(), "button", "button was destroyed.")
+        building.CmdDestroy.confirm = confirm
 
 
 class CmdInterrupt(Command):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The default `@destroy` command now displays a confirmation before deleting.  This behavior can be bypassed in several ways.

- Using the `@destroy/force` switch, no confirmation is displayed.
- Modifying the `confirm` class variable in the `CmdDestroy` class, no confirmation will ever be displayed.

#### Motivation for adding to Evennia

Destroying objects has to be efficient, but lots of damage can be done by a change in letter.  The default behavior is a bit more secure: it will display a confirmation message (with the list of keys and IDs) before destroying.  The user has to enter `y` or `yes` in order to continue.  If the user is really sure about what she does, the `/force` switch has been added to the command.  If an admin wishes to go back to the previous behavior (no confirmation), a simple class variable on the command can be changed.

Since default commands are meant to present default code to use in the commands, this is a great opportunity to have a default command using `yield` to require user input.

#### Testing

Testing this feature is difficult.  The tests written on `@destroy` have been slightly altered in order to bypass confirmation.  It means that the confirmation itself is not tested.  It might be worth adding tests to see if the confirmation effectively works, but I do not know how to write them.

Additionally, I have added some lines to the `CommandTest.call` which didn't support testing commands with `yield` statements.

#### Other info (issues closed, discussion etc)

None