### PR TITLE
objects.py at_say method update adds flexibility, maintains backward compatiblility.

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -416,8 +416,9 @@ class CmdSay(COMMAND_DEFAULT_CLASS):
         if not speech:
             return
 
-        # Call the at_after_say hook on the character
-        caller.at_say(speech)
+        # Call the at_after_say hook on the character, setting
+        # msg_self True to send default message to caller
+        caller.at_say(speech, msg_self=True)
 
 
 class CmdWhisper(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -458,7 +458,8 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
             return
 
         # Call the at_after_whisper hook for feedback
-        caller.at_say(speech, receiver=receiver, whisper=True)
+        msg_self = None if receiver is caller else True
+        caller.at_say(speech, msg_self=msg_self, receiver=receiver, whisper=True)
 
 
 class CmdPose(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -133,7 +133,7 @@ class TestGeneral(CommandTest):
         self.call(general.CmdSay(), "Testing", "You say, \"Testing\"")
 
     def test_whisper(self):
-        self.call(general.CmdWhisper(), "Obj = Testing", "You whisper to Obj, \"Testing\"", caller=self.char2)
+        self.call(general.CmdWhisper(), "Obj = Testing", "You whisper \"Testing\" to Obj.", caller=self.char2)
 
     def test_access(self):
         self.call(general.CmdAccess(), "", "Permission Hierarchy (climbing):")

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1623,7 +1623,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             msg_type = "whisper"
         if msg_type == "whisper":
             # whisper mode
-            msg_self = msg_self or 'You whisper "{speech}" to {receiver}.'
+            msg_self = 'You whisper "{speech}" to {receiver}.' if msg_self is True else msg_self
             msg_receiver = msg_receiver or '{object} whispers: "{speech}"'
             msg_location = None
         else:

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1577,8 +1577,8 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         """
         return message
 
-    def at_say(self, message, msg_self=True, msg_location=None,
-               receiver=None, msg_receiver=None, msg_type="say", mapping=None, **kwargs):
+    def at_say(self, message, msg_self, msg_location=None, receiver=None,
+               msg_receiver=None, msg_type="say", mapping=None, **kwargs):
         """
         Display the actual say (or whisper) of self.
 


### PR DESCRIPTION
### Brief overview of PR changes/additions
Returns use of the the "type" kwarg to the tuple msg output, allowing messages of different types, but having at_say default to "say" type, as before.

Defaults to using msg_self ("You say, ) format, but allows _not_ excluding the speaker from msg_location messages.  Keeps the hard-coded defaults, including whisper, but whisper mode is engaged with a kwarg _or_ msg_type for flexibility/ compatibility.

### Motivation for adding to Evennia
Game code relying on Evennia 0.6 behavior of sending type kwarg in tuple msg output won't break, but keeps the nice mappings and default says/whisper (albeit in a slightly modified format) that @v-legoff added.

### Other info (issues closed, discussion etc)
devel branch

Does this change break anything _differently_, and will it fit the expected and more uncommon use cases?