### PR TITLE
Contrib/slots handler

### DIFF
--- a/evennia/contrib/slots_handler/readme.md
+++ b/evennia/contrib/slots_handler/readme.md
@@ -1,0 +1,84 @@
+# Slots Handler
+It's pretty common for RPG systems to have mechanics where a character is limited to, or must choose, a specific number of items. This contrib is designed to be adaptable to handle as many permutations of this style of mechanic as possible.
+
+## How to use
+### Slotted object example
+The `@lazy_property` declaration below can be put on any typeclass parent. The functionality of `SlotsHandler` relies on the `AttributesHandler`, so any deviations from the standard typeclass system have to at least include that. This document will assume that you're using the name `slots` for the property.
+```python
+from evennia.objects.objects import DefaultObject
+
+class SlottedObject(DefaultObject):
+    "This is a test object for SlotsHandler."
+
+    @lazy_property
+    def slots(self):
+        return SlotsHandler(self)
+```
+### Slottable object example
+```python
+from evennia.objects.objects import DefaultObject
+
+class SlottableObject(DefaultObject):
+    "This is a test object for SlotsHandler."
+
+    def at_object_creation(self):
+        self.slots = {"addons": ["left"]}
+```
+### Concepts
+**Slots format:** In this contrib, all arguments and attributes labeled slots are intended to come in one of two formats:
+```python
+["magic items", "spells", "stunts"]
+```
+This represents a list of categories, and is used for targeting every slot in each of the named categories. There's no point in using this format for `add()`, but it can be used to delete a whole category, list specific categories, or attach/drop in broad strokes.
+```python
+{"spells": [2, "class bonus", "racial bonus"], "stunts": ["athletics", "weaponry"]}
+```
+This format is used to target specific slots. If numerical values are included, they will be treated in specific ways. For `add()` and `delete()`, the numerical values will be summed and an equal number of numbered slots will be added to or deleted from the category. For `attach()` and `drop()`, they will be summed and that number of slots will be used or freed up. For `check()`, the first *n* numbered slots will be returned.
+
+**Slot category:** SlotsHandler interprets the top-level keys of a dict, or the values of a list, to be categories. Categories are important as they factor into the storage name of the slot list, so if you don't want to separate your slots, give them a very general category such as `"slots"`.
+
+**Numbered vs named slots:** Slot keys must be integers or strings. Numbered slots are anonymous and mostly will not be referred to directly. Named slots are for cases where you want to refer to them directly.
+
+**Nesting:** The system is designed with simplicity in mind. You should not try to force individual slot attributes to be more than a basic `dict`. However, since we're storing objects in these slots, it's perfectly possible to store one slot attribute inside a slot in a different attribute. Your code just has to know to look for that, because `SlotsHandler` does not. The individual building blocks are simple, but they may be assembled in more complicated ways than they can achieve on their own.
+
+## SlottedObject.slots.add
+```
+add(self, slots)
+```
+> Create an array of slots, or add additional slots to an existing array.
+**Args:**
+* **slots (dict):** A dict of slots to add. Since you can't add empty categories, it would be pointless to pass a list to this function, and so it doesn't accept lists for input.
+
+## SlottedObject.slots.delete
+```
+# I feel like I need to change this syntax to conform with the dict model.
+delete(self, slots)
+```
+> Delete the named category or slots.
+**Args:**
+* **slots (list or dict):** Slot categories or individual slots to delete.
+
+## SlottedObject.slots.attach
+```
+# I feel like I need to change this syntax to conform with the dict model.
+attach(self, target, slots=None)
+```
+> Attempt to attach the target in all slots it consumes. Optionally, the target's slots may be overridden.
+**Args:**
+* **target (object):** The object being attached.
+* **slots (list or dict, optional):** Slot categories or individual slots to drop from.
+
+## SlottedObject.slots.drop
+```
+# I feel like I need to change this syntax to conform with the dict model.
+attach(self, target=None, slots=None)
+```
+> Attempt to drop the target from all slots it occupies. Optionally, you may choose to drop only specific slots. This function is messy in that it doesn't care if the slots exist or not, it just tries to drop everything it is given. This function will return a dict of any emptied slots, so it can act as a pop(), but if you don't catch that data, it WILL be lost.
+**Args:**
+* **target (object):** The object being dropped.
+* **slots (list or dict, optional):** Slot categories or individual slots to drop from.
+
+> Return a dict of slots representing where target is attached.
+
+**Args:**
+* **target (object):** The object being searched for.

--- a/evennia/contrib/slots_handler/readme.md
+++ b/evennia/contrib/slots_handler/readme.md
@@ -46,6 +46,7 @@ This format is used to target specific slots. If numerical values are included, 
 add(self, slots)
 ```
 > Create an array of slots, or add additional slots to an existing array.
+
 **Args:**
 * **slots (dict):** A dict of slots to add. Since you can't add empty categories, it would be pointless to pass a list to this function, and so it doesn't accept lists for input.
 
@@ -54,6 +55,8 @@ add(self, slots)
 delete(self, slots)
 ```
 > Delete the named category or slots.
+> WARNING: If you have anything attached in slots when they are removed, the slots' contents will also be removed. This function will return a dict of any removed slots and their contents, so it can act as a pop(), but if you don't catch that data, it WILL be lost.
+
 **Args:**
 * **slots (list or dict):** Slot categories or individual slots to delete.
 
@@ -62,6 +65,7 @@ delete(self, slots)
 attach(self, target, slots=None)
 ```
 > Attempt to attach the target in all slots it consumes. Optionally, the target's slots may be overridden.
+
 **Args:**
 * **target (object):** The object being attached.
 * **slots (list or dict, optional):** Slot categories or individual slots to drop from.
@@ -71,6 +75,7 @@ attach(self, target, slots=None)
 drop(self, target=None, slots=None)
 ```
 > Attempt to drop the target from all slots it occupies. Optionally, you may choose to drop only specific slots. This function is messy in that it doesn't care if the slots exist or not, it just tries to drop everything it is given. This function will return a dict of any emptied slots, so it can act as a pop(), but if you don't catch that data, it WILL be lost.
+
 **Args:**
 * **target (object):** The object being dropped.
 * **slots (list or dict, optional):** Slot categories or individual slots to drop from.
@@ -80,6 +85,7 @@ drop(self, target=None, slots=None)
 replace(self, target, slots=None)
 ```
 > Works exactly like `.slots.attach`, but first invokes `.slots.drop` on all requested slots. The results of both commands are returned as a tuple in the form `(drop, attach)`.
+
 **Args:**
 * **target (object):** The object being attached.
 * **slots (list or dict, optional):** Slot categories or individual slots to drop from.

--- a/evennia/contrib/slots_handler/readme.md
+++ b/evennia/contrib/slots_handler/readme.md
@@ -1,7 +1,19 @@
 # Slots Handler
+DamnedScholar 2017
+
 It's pretty common for RPG systems to have mechanics where a character is limited to, or must choose, a specific number of items. This contrib is designed to be adaptable to handle as many permutations of this style of mechanic as possible.
 
 ## How to use
+### Simple walkthrough
+This walkthrough will help you get started with `SlotsHandler` right away. First, create an object. For the sake of simplicity, we're using a newly created object, but the slots can exist on anything as long as it has a typeclass.
+```
+@py from evennia.utils import create;self.ndb.spells = create.create_object(typeclass="evennia.contrib.slots_handler.slots.SlottedObject", location=self, key="spellbook")
+```
+This gives you an object in your inventory, and a temporary shortcut to it: `self.ndb.spells` (which will disappear when the server restarts). You now need to configure the kinds and number of slots:
+```python
+@py self.ndb.spells.slots.add({"ready": [2, "bonus"], "known": [4, "fire", "air"]})
+```
+
 ### Slotted object example
 The `@lazy_property` declaration below can be put on any typeclass parent. The functionality of `SlotsHandler` relies on the `AttributesHandler`, so any deviations from the standard typeclass system have to at least include that. This document will assume that you're using the name `slots` for the property.
 ```python
@@ -22,7 +34,7 @@ class SlottableObject(DefaultObject):
     "This is a test object for SlotsHandler."
 
     def at_object_creation(self):
-        self.slots = {"addons": ["left"]}
+        self.db.slots = {"addons": ["left"]}
 ```
 ### Concepts
 **Slots format:** In this contrib, all arguments and attributes labeled slots are intended to come in one of two formats:

--- a/evennia/contrib/slots_handler/readme.md
+++ b/evennia/contrib/slots_handler/readme.md
@@ -51,7 +51,6 @@ add(self, slots)
 
 ## SlottedObject.slots.delete
 ```
-# I feel like I need to change this syntax to conform with the dict model.
 delete(self, slots)
 ```
 > Delete the named category or slots.
@@ -60,7 +59,6 @@ delete(self, slots)
 
 ## SlottedObject.slots.attach
 ```
-# I feel like I need to change this syntax to conform with the dict model.
 attach(self, target, slots=None)
 ```
 > Attempt to attach the target in all slots it consumes. Optionally, the target's slots may be overridden.
@@ -70,14 +68,26 @@ attach(self, target, slots=None)
 
 ## SlottedObject.slots.drop
 ```
-# I feel like I need to change this syntax to conform with the dict model.
-attach(self, target=None, slots=None)
+drop(self, target=None, slots=None)
 ```
 > Attempt to drop the target from all slots it occupies. Optionally, you may choose to drop only specific slots. This function is messy in that it doesn't care if the slots exist or not, it just tries to drop everything it is given. This function will return a dict of any emptied slots, so it can act as a pop(), but if you don't catch that data, it WILL be lost.
 **Args:**
 * **target (object):** The object being dropped.
 * **slots (list or dict, optional):** Slot categories or individual slots to drop from.
 
+## SlottedObject.slots.replace
+```
+replace(self, target, slots=None)
+```
+> Works exactly like `.slots.attach`, but first invokes `.slots.drop` on all requested slots. The results of both commands are returned as a tuple in the form `(drop, attach)`.
+**Args:**
+* **target (object):** The object being attached.
+* **slots (list or dict, optional):** Slot categories or individual slots to drop from.
+
+## SlottedObject.slots.where
+```
+where(self, target=None)
+```
 > Return a dict of slots representing where target is attached.
 
 **Args:**

--- a/evennia/contrib/slots_handler/readme.md
+++ b/evennia/contrib/slots_handler/readme.md
@@ -41,6 +41,16 @@ This format is used to target specific slots. If numerical values are included, 
 
 **Nesting:** The system is designed with simplicity in mind. You should not try to force individual slot attributes to be more than a basic `dict`. However, since we're storing objects in these slots, it's perfectly possible to store one slot attribute inside a slot in a different attribute. Your code just has to know to look for that, because `SlotsHandler` does not. The individual building blocks are simple, but they may be assembled in more complicated ways than they can achieve on their own.
 
+### How do I use it?
+The first way is just to record how many of a thing a character has. One object can be stored in multiple slots for systems where one mechanic might fill more than one requirement. The handler doesn't support querying for specific slots, because I feel like `.all()` is sufficient for those purposes. To retrieve a specific slot, it's easy enough to use syntax like the following:
+```python
+spells = obj.slots.all()['spells']
+weapon = obj.slots.all()['equipped']['weapon']
+```
+
+### What's next?
+While I consider `SlotsHandler` complete as-is, there is room for sample commands that interact with the handler and a set of classes that a new user can plug into their game to instantly see how it works without altering their own typeclasses.
+
 ## SlottedObject.slots.add
 ```
 add(self, slots)

--- a/evennia/contrib/slots_handler/slots.py
+++ b/evennia/contrib/slots_handler/slots.py
@@ -1,0 +1,282 @@
+class SlotsHandler:
+    """
+    Handler for the slots system. This handler is designed to be attached to
+    objects with a particular @lazy-property name, so it will be referred to as
+    `.slots`, though individual games can set that however they like.
+
+    Place on character or other typeclassed object:
+    ```
+    @lazy_property
+    def slots(self):
+        return SlotsHandler(self)
+    ```
+
+    The purpose of this handler is to sit on a "holder" typeclassed object and
+    manage slots for "held" objects. The first thing that should happen is
+    using `self.slots.add()` on the holder object to identify the available
+    options. `.slots.delete()` can be used to delete or pop old slots.
+
+    By default, a held object can have slots stored on it (the handler will
+    check `.db.slots`, `.ndb.slots`, and `.slots` in that order), and
+    `self.slots.attach()` will attempt to attach it on all of those slots (it
+    should fail if it can't attach on every slot). `self.slots.drop()` will
+    remove the target from any of the slots given it. Both of these methods
+    have the option to be given a custom `slots` argument, which will override
+    the slots on the held object.
+
+    Using the custom `slots` in `attach()` and `drop()` provides some
+    customization facility in that you can store *any* object in a slot, not
+    just an object that has been set up for it.
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+        self._objid = obj.id
+
+    def is_name_valid(self, test):
+        "Internal function to check if the name is right."
+        try:
+            exec(test + " = 1")
+        except SyntaxError:
+            raise ValueError("You have to limit slot category names to "
+                             "characters that are valid in variable names.")
+
+    def all(self):
+        "Return a dict of all slots."
+        d = self.obj.attributes.get(category="slots", return_obj=True)
+
+        r = [(s.key, s.value) for s in d]
+
+        return dict(r)
+
+    def add(self, name, num=0, *slots):
+        """
+        Create an array of slots, or add additional slots to an existing array.
+
+        Args:
+            name: The name of the array.
+            *slots: A set of lists, strings, and/or tuples defining slot names.
+            num: Any unnamed slots.
+        """
+
+        self.is_name_valid(name)
+        existing = self.obj.attributes.get(name, category="slots")
+        self.obj.msg("Existing attribute {}: {}".format(name, repr(existing)))
+        slot_list = []
+        for arg in slots:
+            if isinstance(arg, list):
+                slot_list += arg
+            elif isinstance(arg, str):
+                slot_list.append(arg)
+            elif isinstance(arg, tuple):
+                slot_list.append(list(arg))
+            else:
+                raise ValueError("Only lists, strings, and tuples accepted.")
+        # To find where the numbers should start, iterate through numerical
+        # keys and store the highest value.
+        highest = 0
+        if existing:
+            for slot in existing.keys():
+                if isinstance(slot, int) and slot > highest:
+                    highest = slot
+        for i in range(highest, highest + num):
+            slot_list.append(i+1)
+        slots = {slot: "" for slot in slot_list}
+
+        if not existing:
+            new = self.obj.attributes.add(name, slots, category="slots")
+
+            return True
+        else:
+            existing.update(slots)
+            return True
+
+    def delete(self, name, num=0, *slots):
+        """
+        This will delete slots from an existing array.
+        WARNING: If you have anything attached in slots when they are removed,
+        the slots' contents will also be removed. This function will return a
+        dict of any removed slots and their contents, so it can act as a pop(),
+        but if you don't catch that data, it WILL be lost.
+        """
+
+        self.is_name_valid(name)
+        existing = self.obj.attributes.get(name, category="slots")
+        if not existing: # If the named array isn't there, don't bother.
+            return False
+        slot_list = []
+        if not num and not slots:
+            self.obj.attributes.remove(name)
+        for arg in slots:
+            if isinstance(arg, list):
+                slot_list += arg
+            elif isinstance(arg, str):
+                slot_list.append(arg)
+            elif isinstance(arg, tuple):
+                slot_list.append(list(arg))
+            else:
+                raise ValueError
+        # To find where the numbers should start, iterate through numerical
+        # keys and store the highest value.
+        highest = 0
+        if existing:
+            for key in existing.keys():
+                if isinstance(key, int) and key > highest:
+                    highest = key
+        for i in range(highest, highest - num, -1):
+            slot_list.append(i)
+
+        deleted = {}
+
+        for slot in slot_list:
+            deleted.update({slot: existing.pop(slot)})
+
+        return deleted
+
+    def attach(self, target, slots=None):
+        "Attempt to attach the target in all slots it consumes. Optionally, the target's slots may be overridden."
+
+        if not slots:
+            slots = target.db.slots
+            if not slots:
+                slots = target.ndb.slots
+                if not slots:
+                    try:
+                        slots = target.slots
+                    except AttributeError:
+                        return StatMsg(False, "No slots detected.")
+
+        modified = {}
+
+        if not isinstance(slots, (dict, _SaverDict)):
+            return StatMsg(False, "You have to declare slots in the form "
+                           "`{key: [values]}`.")
+
+        for name in slots:
+            array = self.obj.attributes.get(name, category="slots")
+            if not array:
+                return StatMsg(False, "You need to add slots before you can "
+                               "attach anything.")
+
+            new = {}
+
+            # Get the number of open slots, then count to see if there are
+            # enough for the attachment.
+            numbered = [n for n in array.keys()
+                        if isinstance(n, int) and not array[n]]
+            requirement = [n for n in slots[name] if isinstance(n, int)] + [0]
+            requirement = sum(requirement)
+            if len(numbered) < requirement:
+                return StatMsg(False, "You're running out of numbered slots. "
+                               "You need to add or free up slots before you "
+                               "can attach this.")
+
+            if numbered:
+                new.update({numbered[i]: target
+                            for i in range(0, requirement)})
+
+            # Get the list of open named slots and check to see if all of the
+            # requested slots are members of them.
+            named = [n for n in array.keys()
+                     if isinstance(n, str) and not array[n]]
+            requirement = [n for n in slots[name] if isinstance(n, str)]
+            if requirement and not set(requirement).issubset(named):
+                return StatMsg(False, "You're running out of named slots. "
+                               "You need to add or free up slots before you "
+                               "can attach this.")
+
+            if named:
+                new.update({req: target
+                            for req in requirement})
+
+            array.update(new)
+            modified.update({name: new})
+
+        return modified
+
+    def drop(self, target, slots=None):
+        """
+        Attempt to drop the target from all slots it occupies, or the slots
+        provided. This function is messy in that it doesn't care if the
+        slots exist or not, it just tries to drop everything it is given. This
+        function will return a dict of any emptied slots, so it can act as a
+        pop(), but if you don't catch that data, it WILL be lost.
+        """
+        if slots and not isinstance(slots, dict):
+            return StatMsg(False, "You have to declare slots in the form "
+                           "`{key: [values]}`.")
+
+        modified = {}
+        arrays = self.obj.attributes.get(category="slots", return_obj=True)
+        if not isinstance(arrays, list):
+            arrays = [arrays]
+
+        # If no slots are declared, the object should be dropped from all slots
+        # without regard for which slots the object thinks that it should be
+        # occupying.
+        if not arrays:
+            return StatMsg(False, "You don't seem to have any slots to use.")
+        if not slots:
+            slots = [array.key for array in arrays]
+
+        # At this point, the attribute objects only get in the way, so we
+        # extract the values.
+        arrays = {array.key: array.value for array in arrays}
+
+        for name in slots:
+            new = {}
+            mod = []
+
+            if isinstance(slots, (list, tuple, set)):
+                # If the input is not a dict, it is interpreted as a list of
+                # category names and all slots are emptied of the target.
+                for slot, contents in arrays[name].items():
+                    if contents is target:
+                        new.update({slot: ''})
+                        mod.append(slot)
+            elif isinstance(slots, dict):
+                # If the input is a dict, only named slots will be emptied.
+                # Numbered slots should be specified as a single number.
+                i = 0
+                numbered = [k for k in slots[name] if isinstance(k, int)]
+                numbered = [i + 1 for k in numbered for i in range(i, k)]
+                named = [k for k in slots[name] if isinstance(k, str)]
+                for slot in named:
+                    if arrays[name][slot] is target:
+                        new.update({slot: ''})
+                        mod.append(slot)
+                for i in range(0, len(numbered)):
+                    for check in arrays[name]:
+                        if isinstance(check, int) and arrays[name][check] is target:
+                            new.update({check: ''})
+                            mod.append(check)
+
+            else:
+                return StatMsg(False, "The slots requested are not in an "
+                               "appropriate type (a list, tuple, or set "
+                               "of attribute names, or a dict of category "
+                               "and slot names).")
+
+            comp = len(mod)
+            # mod = [s for s in mod if not isinstance(s, int)]
+            # mod[0:0] = [comp - len(mod) if comp - len(mod) > 0]
+
+            arrays[name].update(new)
+            modified.update({name: mod})
+
+        return {k: v for k, v in modified.items() if v}
+
+    def where(self, target):
+        "Return a dict of slots representing where target is attached."
+
+        arrays = self.obj.attributes.get(category="slots", return_obj=True)
+        if not isinstance(arrays, list):
+            arrays = [arrays]
+        arrays = {array.key: array.value for array in arrays}
+
+        # Filter out all empty entries.
+        r = {name: [s for s, c in slots.items() if c is target]
+             for name, slots in arrays.items()}
+        r = {name: contents for name, contents in r.items() if contents}
+
+        return r

--- a/evennia/contrib/slots_handler/test_slots.py
+++ b/evennia/contrib/slots_handler/test_slots.py
@@ -8,7 +8,7 @@ from evennia.utils.utils import lazy_property
 from sr5.utils import *
 
 
-class SlottedObject(DefaultObject):
+class ContribSHSlottedObject(DefaultObject):
     """
     This is a test object for SlotsHandler tests. All typeclassed objects
     *should* play nicely with SlotsHandler.
@@ -19,7 +19,7 @@ class SlottedObject(DefaultObject):
         return SlotsHandler(self)
 
 
-class SlottableObjectOne(DefaultObject):
+class ContribSHSlottableObjectOne(DefaultObject):
     """
     This is a test object for SlotsHandler tests. All typeclassed objects
     *should* play nicely with SlotsHandler.
@@ -29,7 +29,7 @@ class SlottableObjectOne(DefaultObject):
         self.db.slots = {"addons": ["left"]}
 
 
-class SlottableObjectTwo(DefaultObject):
+class ContribSHSlottableObjectTwo(DefaultObject):
     """
     This is a test object for SlotsHandler tests. All typeclassed objects
     *should* play nicely with SlotsHandler.
@@ -39,7 +39,7 @@ class SlottableObjectTwo(DefaultObject):
         self.db.slots = {"addons": [1, "right"]}
 
 
-class SlottableObjectThree(DefaultObject):
+class ContribSHSlottableObjectThree(DefaultObject):
     """
     This is a test object for SlotsHandler tests. All typeclassed objects
     *should* play nicely with SlotsHandler.
@@ -54,13 +54,17 @@ class TestSlotsHandler(EvenniaTest):
 
     def setUp(self):
         super(TestSlotsHandler, self).setUp()
-        self.obj = create.create_object(SlottedObject, key="slotted",
+        self.obj = create.create_object(ContribSHSlottedObject,
+                                        key="slotted",
                                         location=self.room1, home=self.room1)
-        self.slo1 = create.create_object(SlottableObjectOne, key="item 1",
+        self.slo1 = create.create_object(ContribSHSlottableObjectOne,
+                                         key="item 1",
                                          location=self.obj, home=self.obj)
-        self.slo2 = create.create_object(SlottableObjectTwo, key="item 2",
+        self.slo2 = create.create_object(ContribSHSlottableObjectTwo,
+                                         key="item 2",
                                          location=self.obj, home=self.obj)
-        self.slo3 = create.create_object(SlottableObjectThree, key="item 3",
+        self.slo3 = create.create_object(ContribSHSlottableObjectThree,
+                                         key="item 3",
                                          location=self.obj, home=self.obj)
 
     def test_add(self):
@@ -139,10 +143,10 @@ class TestSlotsHandler(EvenniaTest):
         self.assertEqual(drop, expected)
 
         # Drop a specific object from specific slots.
-        drop = self.obj.slots.drop(self.slo2, {"addons": ["right"]})
-        self.assertEqual(drop, {"addons": {"right": self.slo2}})
+        attach = self.obj.slots.attach(self.slo2, {"addons": [2]})
+        drop = self.obj.slots.drop(self.slo2, {"addons": [1, "right"]})
         self.assertEqual(self.obj.slots.where(self.slo2),
-                         {"addons": [1]})
+                         {"addons": [1, 2]})
 
         # Try to drop an object with improper input.
         drop = self.obj.slots.drop(self.slo3, "not here")

--- a/evennia/contrib/slots_handler/test_slots.py
+++ b/evennia/contrib/slots_handler/test_slots.py
@@ -26,7 +26,7 @@ class SlottableObjectOne(DefaultObject):
     """
 
     def at_object_creation(self):
-        self.slots = {"addons": ["left"]}
+        self.db.slots = {"addons": ["left"]}
 
 
 class SlottableObjectTwo(DefaultObject):
@@ -36,7 +36,7 @@ class SlottableObjectTwo(DefaultObject):
     """
 
     def at_object_creation(self):
-        self.slots = {"addons": [1, "right"]}
+        self.db.slots = {"addons": [1, "right"]}
 
 
 class SlottableObjectThree(DefaultObject):
@@ -46,7 +46,7 @@ class SlottableObjectThree(DefaultObject):
     """
 
     def at_object_creation(self):
-        self.slots = {"addons": ["left"]}
+        self.db.slots = {"addons": ["left"]}
 
 
 class TestSlotsHandler(EvenniaTest):

--- a/evennia/contrib/slots_handler/test_slots.py
+++ b/evennia/contrib/slots_handler/test_slots.py
@@ -1,0 +1,139 @@
+from evennia.utils.test_resources import EvenniaTest
+from evennia.objects.objects import DefaultObject
+from evennia.server.serversession import ServerSession
+from evennia.server.sessionhandler import SESSIONS
+from evennia.utils import create
+from evennia.utils.idmapper.models import flush_cache
+from evennia.utils.utils import lazy_property
+from sr5.utils import *
+
+class SlottedObject(DefaultObject):
+    """
+    This is a test object for SlotsHandler tests. All typeclassed objects
+    *should* play nicely with SlotsHandler.
+    """
+
+    @lazy_property
+    def slots(self):
+        return SlotsHandler(self)
+
+class SlottableObjectOne(DefaultObject):
+    """
+    This is a test object for SlotsHandler tests. All typeclassed objects
+    *should* play nicely with SlotsHandler.
+    """
+
+    def at_object_creation(self):
+        self.slots = {"addons": ["left"]}
+
+class SlottableObjectTwo(DefaultObject):
+    """
+    This is a test object for SlotsHandler tests. All typeclassed objects
+    *should* play nicely with SlotsHandler.
+    """
+
+    def at_object_creation(self):
+        self.slots = {"addons": [1, "right"]}
+
+class SlottableObjectThree(DefaultObject):
+    """
+    This is a test object for SlotsHandler tests. All typeclassed objects
+    *should* play nicely with SlotsHandler.
+    """
+
+    def at_object_creation(self):
+        self.slots = {"addons": ["left"]}
+
+class TestSlotsHandler(EvenniaTest):
+    "Test the class SlotsHandler."
+
+    def setUp(self):
+        super(TestSlotsHandler, self).setUp()
+        self.obj = create.create_object(SlottedObject, key="slotted",
+                                        location=self.room1, home=self.room1)
+        self.slo1 = create.create_object(SlottableObjectOne, key="item 1",
+                                         location=self.obj, home=self.obj)
+        self.slo2 = create.create_object(SlottableObjectTwo, key="item 2",
+                                         location=self.obj, home=self.obj)
+        self.slo3 = create.create_object(SlottableObjectThree, key="item 3",
+                                         location=self.obj, home=self.obj)
+
+    def test_add(self):
+        add = self.obj.slots.add("addons", 0, ["left", "right"])
+        self.assertTrue(add)
+
+        with self.assertRaises(ValueError):
+            add = self.obj.slots.add("add-ons", 0, ["left", "right"])
+
+        self.obj.slots.add("addons", 2)
+        self.assertEqual(self.obj.attributes.get("addons", category="slots"),
+                         {1: "", 2: "", "left": "", "right": ""})
+
+    def test_delete(self):
+        add = self.obj.slots.add("addons", 2, ["left", "right"])
+
+        delete = self.obj.slots.delete("addons", 1, ["right"])
+        self.assertIsInstance(delete, dict)
+        self.assertEqual(self.obj.attributes.get("addons", category="slots"),
+                         {1: "", "left": ""})
+
+    def test_attach(self):
+        # When no slots have been added first.
+        attach = self.obj.slots.attach(self.slo1)
+        self.assertIsInstance(attach, StatMsg)
+
+        # Add the slots.
+        add = self.obj.slots.add("addons", 2, ["left", "right"])
+
+        # Successful attachment.
+        attach = self.obj.slots.attach(self.slo1)
+        expected = {"addons": {"left": self.slo1}}
+        self.assertEqual(attach, expected)
+
+        # Successful attachment in multiple slots.
+        attach = self.obj.slots.attach(self.slo2)
+        expected = {"addons": {1: self.slo2, "right": self.slo2}}
+        self.assertEqual(attach, expected)
+
+        # Failed attachment because the slot is occupied.
+        attach = self.obj.slots.attach(self.slo3)
+        self.assertIsInstance(attach, StatMsg)
+
+        # Successful attachment while overriding slots.
+        attach = self.obj.slots.attach(self.slo3, {"addons": [1]})
+        expected = {"addons": {2: self.slo3}}
+        self.assertEqual(attach, expected)
+
+    def test_drop(self):
+        self.test_attach()
+
+        drop = self.obj.slots.drop(self.slo3)
+        expected = {"addons": [2]}
+        self.assertEqual(drop, expected)
+
+        drop = self.obj.slots.drop(self.slo2, {"addons": ["right"]})
+        expected = {"addons": ["right"]}
+        self.assertEqual(drop, expected)
+        self.assertEqual(self.obj.slots.where(self.slo2),
+                         {"addons": [1]})
+
+        drop = self.obj.slots.drop(self.slo3, "not here")
+        self.assertIsInstance(drop, StatMsg)
+
+    def test_where(self):
+        self.test_attach()
+
+        self.assertEqual(self.obj.slots.where(self.slo2),
+                         {"addons": [1, "right"]})
+
+        self.obj.slots.drop(self.slo2)
+        self.assertEqual(self.obj.slots.where(self.slo2),
+                         {})
+
+    def tearDown(self):
+        flush_cache()
+        self.obj.delete()
+        self.slo1.delete()
+        self.slo2.delete()
+        self.slo3.delete()
+        super(TestSlotsHandler, self).tearDown()


### PR DESCRIPTION
#### Brief overview of PR additions
This contrib introduces SlotsHandler, a system for registering an arbitrary number of slots on a typeclassed object. It's intended to be used as a storage system by game system commands, where any sort of Python object can be recorded in each slot. The basic use case of this is to provide a limiter for entities like magic items and spells, but it is as generic as possible, so it should be useful for a broad array of systems.

#### Motivation for adding to Evennia
The behavior required for slot-based mechanics isn't strongly supported, and this handler serves as a wrapper that performs management operations to allow for a developer to easily create/delete slots and fill/empty them.