### PR TITLE
Fixing a mistake.

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -716,6 +716,7 @@ INSTALLED_APPS = (
     'django.contrib.flatpages',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'sekizai',
     'evennia.utils.idmapper',
     'evennia.server',
     'evennia.typeclasses',


### PR DESCRIPTION
So, this is embarrassing. I had the `sekizai` app declared in my personal `settings.py` file and didn't even notice that I hadn't added it to `default_settings.py`, which breaks the web site. This fixes that problem.