### PR TITLE
Fix locationless spawned objects

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2718,7 +2718,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
             self.caller.msg("The prototype must be a prototype key or a Python dictionary.")
             return
 
-        if "noloc" in self.switches and not "location" not in prototype:
+        if "noloc" not in self.switches and "location" not in prototype:
             prototype["location"] = self.caller.location
 
         for obj in spawn(prototype):

--- a/evennia/utils/spawner.py
+++ b/evennia/utils/spawner.py
@@ -100,7 +100,7 @@ _CREATE_OBJECT_KWARGS = ("key", "location", "home", "destination")
 
 
 def _handle_dbref(inp):
-    dbid_to_obj(inp, ObjectDB)
+    return dbid_to_obj(inp, ObjectDB)
 
 
 def _validate_prototype(key, prototype, protparents, visited):


### PR DESCRIPTION
Spawned objects were not getting locations assigned to them.  By default
the locations should be assigned to the caller's location.

#### Brief overview of PR changes/additions

Fixes some conditional checks in the spawn builder to add locations to the
spawned item if not using "noloc" switch and "location" is not part of the
prototype.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)

Potential fix for issue #1455 
