### PR TITLE
Rename card-block to card-body on Login and Logout Pages

### DIFF
--- a/evennia/web/website/templates/website/registration/logged_out.html
+++ b/evennia/web/website/templates/website/registration/logged_out.html
@@ -10,7 +10,7 @@
 <div class="row">
   <div class="col">
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         <h1 class="card-title">Logged Out</h1>
         <p>You have been logged out.</p>
         <p>Redirecting in 2 seconds...</p>

--- a/evennia/web/website/templates/website/registration/login.html
+++ b/evennia/web/website/templates/website/registration/login.html
@@ -11,7 +11,7 @@ Login
 <div class="row">
   <div class="col">
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         <h1 class="card-title">Login</h1>
         <hr />
         {% if user.is_authenticated %}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The login and logout pages of Evennia's website have the wrong css classes - card-block instead of card-body. This causes a lack of spacing around them.

#### Other info (issues closed, discussion etc)
Renames these classes - looks a little nicer than it did before.
