### PR TITLE
Fix #1468 by checking if Notification is available

### DIFF
--- a/evennia/web/webclient/static/webclient/js/webclient_gui.js
+++ b/evennia/web/webclient/static/webclient/js/webclient_gui.js
@@ -369,28 +369,29 @@ function onNewLine(text, originator) {
     unread++;
     favico.badge(unread);
     document.title = "(" + unread + ") " + originalTitle;
+    if ("Notification" in window){
+      if (("notification_popup" in options) && (options["notification_popup"])) {
+          Notification.requestPermission().then(function(result) {
+              if(result === "granted") {
+              var title = originalTitle === "" ? "Evennia" : originalTitle;
+              var options = {
+                  body: text.replace(/(<([^>]+)>)/ig,""),
+                  icon: "/static/website/images/evennia_logo.png"
+              }
 
-    if (("notification_popup" in options) && (options["notification_popup"])) {
-        Notification.requestPermission().then(function(result) {
-            if(result === "granted") {
-            var title = originalTitle === "" ? "Evennia" : originalTitle;
-            var options = {
-                body: text.replace(/(<([^>]+)>)/ig,""),
-                icon: "/static/website/images/evennia_logo.png"
+              var n = new Notification(title, options);
+              n.onclick = function(e) {
+                  e.preventDefault();
+                   window.focus();
+                   this.close();
+              }
             }
-
-            var n = new Notification(title, options);
-            n.onclick = function(e) {
-                e.preventDefault();
-                 window.focus();
-                 this.close();
-            }
-          }
-        });
-    }
-    if (("notification_sound" in options) && (options["notification_sound"])) {
-        var audio = new Audio("/static/webclient/media/notification.wav");
-        audio.play();
+          });
+      }
+      if (("notification_sound" in options) && (options["notification_sound"])) {
+          var audio = new Audio("/static/webclient/media/notification.wav");
+          audio.play();
+      }
     }
   }
 }
@@ -427,7 +428,9 @@ function doStartDragDialog(event) {
 // Event when client finishes loading
 $(document).ready(function() {
 
-    Notification.requestPermission();
+    if ("Notification" in window) {
+      Notification.requestPermission();
+    }
 
     favico = new Favico({
       animation: 'none'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In `webclient_gui.js`, we attempt to call the Notification API without checking if it's available. If it's not available, we get a crash as described in #1468.

#### Motivation for adding to Evennia
Fixes #1468, also may add support for browsers/plugins that don't have the Notification object available for whatever reason.

#### Other info (issues closed, discussion etc)
Closes #1468