### PR TITLE
make help command's matching respect CMD_IGNORE_PREFIXES

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -17,6 +17,7 @@ from evennia.utils.utils import string_suggestions, class_from_module
 
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 HELP_MORE = settings.HELP_MORE
+CMD_IGNORE_PREFIXES = settings.CMD_IGNORE_PREFIXES
 
 # limit symbol import for API
 __all__ = ("CmdHelp", "CmdSetHelp")
@@ -231,6 +232,15 @@ class CmdHelp(Command):
 
         # try an exact command auto-help match
         match = [cmd for cmd in all_cmds if cmd == query]
+
+        if not match:
+            # try an inexact match with prefixes stripped from query and cmds
+            _query = query[1:] if query[0] in CMD_IGNORE_PREFIXES else query
+
+            match = [cmd for cmd in all_cmds
+                    for m in cmd._matchset if m == _query or
+                    m[0] in CMD_IGNORE_PREFIXES and m[1:] == _query]
+
         if len(match) == 1:
             formatted = self.format_help_entry(match[0].key,
                                                match[0].get_help(caller, cmdset),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes `CmdHelp` to respect `CMD_IGNORE_PREFIXES` by stripping prefixes from both queries and command matchsets, allowing such lookups as `help +locks` and `help locks` to redirect to the `@locks` docstring and et cetera.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
Resolves #1466.
