### PR TITLE
Add a @spawn unit test

### DIFF
--- a/evennia/utils/test_prototypes.py
+++ b/evennia/utils/test_prototypes.py
@@ -1,0 +1,20 @@
+"""
+test_prototypes
+
+This is meant to be used with Evennia unittest framework
+to provide some named prototypes for use with various tests
+(for example commands that accept named prototypes, not just
+prototype dictionaries)
+"""
+
+GOBLIN = {
+    "key" : "Goblin", \
+    "typeclass" : "DefaultCharacter", \
+    "desc" : "A goblin."
+}
+
+BALL = {
+    "key" : "Ball", \
+    "typeclass" : "DefaultObject", \
+    "desc" : "A ball."
+}

--- a/evennia/utils/test_resources.py
+++ b/evennia/utils/test_resources.py
@@ -34,6 +34,8 @@ class EvenniaTest(TestCase):
         self.room1 = create.create_object(self.room_typeclass, key="Room", nohome=True)
         self.room1.db.desc = "room_desc"
         settings.DEFAULT_HOME = "#%i" % self.room1.id  # we must have a default home
+        # Set up fake prototype module for allowing tests to use named prototypes.
+        settings.PROTOTYPE_MODULES = "evennia.utils.test_prototypes"
         self.room2 = create.create_object(self.room_typeclass, key="Room2")
         self.exit = create.create_object(self.exit_typeclass, key='out', location=self.room1, destination=self.room2)
         self.obj1 = create.create_object(self.object_typeclass, key="Obj", location=self.room1, home=self.room1)


### PR DESCRIPTION
Tests the @spawn command and its variations.  The test is designed to
aslo check the properties of the spawned objects for some common/obvious
settings.

Test also adds a new prototypes file to be used with the Evennia unit
tester for any tests that require named prototypes.  The spawner test
requires testing named prototypes, so it is added in this change.

#### Brief overview of PR changes/additions

Mainly tests the @spawn command and its side-effects.

#### Motivation for adding to Evennia

Test should cover my recent fix for issue #1455

#### Other info (issues closed, discussion etc)

I've also added a change to add new prototype testing files.  I'm not sure if this should go along with this change, or separately.  I could definitely split it up into two separate changes - but since the @spawn testing required this named prototypes, I was hoping to check it in together.

This is for issue #1458