### PR TITLE
resolve #1448, fix 'no help entry' not popping up in webclient

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -267,7 +267,7 @@ class CmdHelp(Command):
             return
 
         # no exact matches found. Just give suggestions.
-        self.msg(self.format_help_entry("", "No help entry found for '%s'" % query, None, suggested=suggestions))
+        self.msg((self.format_help_entry("", "No help entry found for '%s'" % query, None, suggested=suggestions), {"type": "help"}))
 
 
 def _loadhelp(caller):

--- a/evennia/web/webclient/static/webclient/css/webclient.css
+++ b/evennia/web/webclient/static/webclient/css/webclient.css
@@ -31,6 +31,8 @@ strong {font-weight: bold;}
 
 div {margin:0px;}
 
+.hidden { display: none; }
+
 /* Utility messages (green) */
 .sys { color: #0f0 }
 

--- a/evennia/web/webclient/static/webclient/js/webclient_gui.js
+++ b/evennia/web/webclient/static/webclient/js/webclient_gui.js
@@ -289,6 +289,7 @@ function onPrompt(args, kwargs) {
 
 // Called when the user logged in
 function onLoggedIn() {
+    $('#optionsbutton').removeClass('hidden');
     Evennia.msg("webclient_options", [], {});
 }
 
@@ -323,6 +324,8 @@ function onSilence(cmdname, args, kwargs) {}
 
 // Handle the server connection closing
 function onConnectionClose(conn_name, evt) {
+    $('#optionsbutton').addClass('hidden');
+    closePopup("#optionsdialog");
     onText(["The connection was closed or lost."], {'cls': 'err'});
 }
 

--- a/evennia/web/webclient/templates/webclient/webclient.html
+++ b/evennia/web/webclient/templates/webclient/webclient.html
@@ -11,7 +11,7 @@
 
 <div id="wrapper">
     <div id="toolbar">
-        <button id="optionsbutton" type="button">&#x2699;</button>
+        <button id="optionsbutton" type="button" class="hidden">&#x2699;</button>
     </div>
     <div id="messagewindow" role="log"></div>
     <div id="inputform">
@@ -48,4 +48,3 @@
 </div>
 
 {% endblock %}
-


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This change resolves #1448 by hiding the webclient options popup before log-in and after disconnection, in addition it will close the options dialog in the event of a disconnect, to keep things consistent. For optimal UI design, there is no reason to show the button to the user when it provides no functionality.

Included in this commit are two related bug fixes. The first fixes new accounts not having any saved webclient options despite the default settings. This is because nothing is saved to `account.db._saved_webclient_options` until the user makes a change on the other end. This explains why a server might have `helppopup` be a default setting, but it has no effect on the user's end until they toggle the checkmark off, then back on.

The second fix tags "no help entry found" messages from the built-in `help` command as help messages, which gets them popped up into the webclient as any other help file would.
