### PR TITLE
Fix an issue with adding an empty column to an EvTable

### DIFF
--- a/evennia/utils/evtable.py
+++ b/evennia/utils/evtable.py
@@ -1421,8 +1421,21 @@ class EvTable(object):
         column = EvColumn(*args, **options)
         wtable = self.ncols
         htable = self.nrows
-        excess = len(column) - htable
 
+        header = kwargs.get("header", None)
+        if header:
+            column.add_rows(unicode(header), ypos=0, **options)
+            self.header = True
+        elif self.header:
+            # we have a header already. Offset
+            column.add_rows("", ypos=0, **options)
+
+        # Calculate whether the new column needs to expand to the
+        # current table size, or if the table needs to expand to
+        # the column size.
+        # This needs to happen after the header rows have already been
+        # added to the column in order for the size calculations to match.
+        excess = len(column) - htable
         if excess > 0:
             # we need to add new rows to table
             for col in self.table:
@@ -1435,13 +1448,6 @@ class EvTable(object):
             column.add_rows(*empty_rows, **options)
             self.nrows -= excess
 
-        header = kwargs.get("header", None)
-        if header:
-            column.add_rows(unicode(header), ypos=0, **options)
-            self.header = True
-        elif self.header:
-            # we have a header already. Offset
-            column.add_rows("", ypos=0, **options)
         if xpos is None or xpos > wtable - 1:
             # add to the end
             self.table.append(column)


### PR DESCRIPTION
There seems to be an issue with adding an empty column (i.e. a column
with empty data) to an EvTable that has already been set up.  It seems
that the column with empty data is added with one extra row than the
rest of the table, and when a new call to add_rows() is made to EvTable,
the data in the column that was added previously is offset by 1.

This change fixes that by calculating the size of the new column to take
into account the headers BEFORE making the calculation on whether to
expand the column to match the table's size or not.

#### Brief overview of PR changes/additions

This change just moves calculation of new column size until after the header has been taken into account.

#### Motivation for adding to Evennia

Fixes issue #1479 

#### Other info (issues closed, discussion etc)
