### PR TITLE
Add newline after multimatch string error message

### DIFF
--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -1786,8 +1786,12 @@ def at_search_result(matches, caller, query="", quiet=False, **kwargs):
         error = kwargs.get("nofound_string") or _("Could not find '%s'." % query)
         matches = None
     elif len(matches) > 1:
-        error = kwargs.get("multimatch_string") or \
-            _("More than one match for '%s' (please narrow target):\n" % query)
+        multimatch_string = kwargs.get("multimatch_string")
+        if multimatch_string:
+            error = "%s\n" % multimatch_string
+        else:
+            error = _("More than one match for '%s' (please narrow target):\n" % query)
+
         for num, result in enumerate(matches):
             # we need to consider Commands, where .aliases is a list
             aliases = result.aliases.all() if hasattr(result.aliases, "all") else result.aliases


### PR DESCRIPTION
Other utility functions, such as caller.msg(), don't require adding
newline because newlines are added implicitly.  This change modifies the
multimatch string parameter to also not require newline, but add one
implicitly.

#### Brief overview of PR changes/additions

Modifies the utils "at_search_result()" function to append a newline to "multimatch_string" if it is part of the kwargs.

#### Motivation for adding to Evennia

Performing a command on object when there is ambiguity on which object to select, outputs a message  indicating there are multiple such objects. The problem is the formatting is a bit off, where the first object is on the same line as the error message.

For example, if I have two "swords" in my inventory, and I do "drop sword", I get this error message:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/441039/31855566-4dc9c42a-b673-11e7-9210-a3712e626a3f.png">

It seems like the "multimatch_error" string doesn't append a newline.  I don't know if this is on purpose, but I found this odd since other functions such as "msg()" automatically append newlines to the string.

After my fix, this is the expected output

<img width="252" alt="image" src="https://user-images.githubusercontent.com/441039/31855556-14da175a-b673-11e7-8535-26ff8a3c1f1c.png">


#### Other info (issues closed, discussion etc)

If intention is not to have a newline in multimatch_string, then please ignore this commit.