### PR TITLE
Add notification support to a few older browsers and Safari

### DIFF
--- a/evennia/web/webclient/static/webclient/js/webclient_gui.js
+++ b/evennia/web/webclient/static/webclient/js/webclient_gui.js
@@ -374,7 +374,10 @@ function onNewLine(text, originator) {
     document.title = "(" + unread + ") " + originalTitle;
     if ("Notification" in window){
       if (("notification_popup" in options) && (options["notification_popup"])) {
-          Notification.requestPermission().then(function(result) {
+          // There is a Promise-based API for this, but it’s not supported
+          // in Safari and some older browsers:
+          // https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission#Browser_compatibility
+          Notification.requestPermission(function(result) {
               if(result === "granted") {
               var title = originalTitle === "" ? "Evennia" : originalTitle;
               var options = {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This makes the webclient use the callback-based `Notification.requestPermission(callback)` API instead of the `Promise`-based `Notification.requestPermission().then(callback)` API. The older API is supported in all browsers that support notifications, while the `Promise`-based API is only supported in Chrome 46+, Firefox 47+, and Opera 40+.

#### Motivation for adding to Evennia

Right now, this throws an error in older browsers and Safari, preventing notifications from being displayed.

#### Other info (issues closed, discussion etc)

Extracted from https://github.com/evennia/ainneve/pull/97.