### PR TITLE
Add tests for general_context

### DIFF
--- a/evennia/web/utils/general_context.py
+++ b/evennia/web/utils/general_context.py
@@ -10,17 +10,18 @@ from django.conf import settings
 from evennia.utils.utils import get_evennia_version
 
 # Determine the site name and server version
-
-try:
-    GAME_NAME = settings.SERVERNAME.strip()
-except AttributeError:
-    GAME_NAME = "Evennia"
-SERVER_VERSION = get_evennia_version()
-try:
-    GAME_SLOGAN = settings.GAME_SLOGAN.strip()
-except AttributeError:
-    GAME_SLOGAN = SERVER_VERSION
-
+def set_game_name_and_slogan():
+    global GAME_NAME, GAME_SLOGAN, SERVER_VERSION
+    try:
+        GAME_NAME = settings.SERVERNAME.strip()
+    except AttributeError:
+        GAME_NAME = "Evennia"
+    SERVER_VERSION = get_evennia_version()
+    try:
+        GAME_SLOGAN = settings.GAME_SLOGAN.strip()
+    except AttributeError:
+        GAME_SLOGAN = SERVER_VERSION
+set_game_name_and_slogan()
 
 # Setup lists of the most relevant apps so
 # the adminsite becomes more readable.
@@ -33,10 +34,13 @@ WEBSITE = ['Flatpages', 'News', 'Sites']
 
 
 # The main context processor function
-WEBCLIENT_ENABLED = settings.WEBCLIENT_ENABLED
-WEBSOCKET_CLIENT_ENABLED = settings.WEBSOCKET_CLIENT_ENABLED
-WEBSOCKET_PORT = settings.WEBSOCKET_CLIENT_PORT
-WEBSOCKET_URL = settings.WEBSOCKET_CLIENT_URL
+def set_webclient_settings():
+    global WEBCLIENT_ENABLED, WEBSOCKET_CLIENT_ENABLED, WEBSOCKET_PORT, WEBSOCKET_URL
+    WEBCLIENT_ENABLED = settings.WEBCLIENT_ENABLED
+    WEBSOCKET_CLIENT_ENABLED = settings.WEBSOCKET_CLIENT_ENABLED
+    WEBSOCKET_PORT = settings.WEBSOCKET_CLIENT_PORT
+    WEBSOCKET_URL = settings.WEBSOCKET_CLIENT_URL
+set_webclient_settings()
 
 
 def general_context(request):

--- a/evennia/web/utils/general_context.py
+++ b/evennia/web/utils/general_context.py
@@ -11,6 +11,13 @@ from evennia.utils.utils import get_evennia_version
 
 # Determine the site name and server version
 def set_game_name_and_slogan():
+    """
+    Sets global variables GAME_NAME and GAME_SLOGAN which are used by
+    general_context.
+
+    Notes:
+        This function is used for unit testing the values of the globals.
+    """
     global GAME_NAME, GAME_SLOGAN, SERVER_VERSION
     try:
         GAME_NAME = settings.SERVERNAME.strip()
@@ -33,8 +40,15 @@ CONNECTIONS = ['Irc']
 WEBSITE = ['Flatpages', 'News', 'Sites']
 
 
-# The main context processor function
+
 def set_webclient_settings():
+    """
+    As with set_game_name_and_slogan above, this sets global variables pertaining
+    to webclient settings.
+
+    Notes:
+        Used for unit testing.
+    """
     global WEBCLIENT_ENABLED, WEBSOCKET_CLIENT_ENABLED, WEBSOCKET_PORT, WEBSOCKET_URL
     WEBCLIENT_ENABLED = settings.WEBCLIENT_ENABLED
     WEBSOCKET_CLIENT_ENABLED = settings.WEBSOCKET_CLIENT_ENABLED
@@ -42,7 +56,7 @@ def set_webclient_settings():
     WEBSOCKET_URL = settings.WEBSOCKET_CLIENT_URL
 set_webclient_settings()
 
-
+# The main context processor function
 def general_context(request):
     """
     Returns common Evennia-related context stuff, which

--- a/evennia/web/utils/tests.py
+++ b/evennia/web/utils/tests.py
@@ -1,0 +1,59 @@
+from mock import Mock, patch
+
+from django.test import TestCase
+
+from . import general_context
+
+
+class TestGeneralContext(TestCase):
+    maxDiff = None
+
+    @patch('evennia.web.utils.general_context.GAME_NAME', "test_name")
+    @patch('evennia.web.utils.general_context.GAME_SLOGAN', "test_game_slogan")
+    @patch('evennia.web.utils.general_context.WEBSOCKET_CLIENT_ENABLED', "websocket_client_enabled_testvalue")
+    @patch('evennia.web.utils.general_context.WEBCLIENT_ENABLED', "webclient_enabled_testvalue")
+    @patch('evennia.web.utils.general_context.WEBSOCKET_PORT', "websocket_client_port_testvalue")
+    @patch('evennia.web.utils.general_context.WEBSOCKET_URL', "websocket_client_url_testvalue")
+    def test_general_context(self):
+        request = Mock()
+        self.assertEqual(general_context.general_context(request), {
+            'game_name': "test_name",
+            'game_slogan': "test_game_slogan",
+            'evennia_userapps': ['Accounts'],
+            'evennia_entityapps': ['Objects', 'Scripts', 'Comms', 'Help'],
+            'evennia_setupapps': ['Permissions', 'Config'],
+            'evennia_connectapps': ['Irc'],
+            'evennia_websiteapps': ['Flatpages', 'News', 'Sites'],
+            "webclient_enabled": "webclient_enabled_testvalue",
+            "websocket_enabled": "websocket_client_enabled_testvalue",
+            "websocket_port": "websocket_client_port_testvalue",
+            "websocket_url": "websocket_client_url_testvalue"
+        })
+
+    # spec being an empty list will initially raise AttributeError in set_game_name_and_slogan to test defaults
+    @patch('evennia.web.utils.general_context.settings', spec=[])
+    @patch('evennia.web.utils.general_context.get_evennia_version')
+    def test_set_game_name_and_slogan(self, mock_get_version, mock_settings):
+        mock_get_version.return_value = "version 1"
+        # test default/fallback values
+        general_context.set_game_name_and_slogan()
+        self.assertEqual(general_context.GAME_NAME, "Evennia")
+        self.assertEqual(general_context.GAME_SLOGAN, "version 1")
+        # test values when the settings are defined
+        mock_settings.SERVERNAME = "test_name"
+        mock_settings.GAME_SLOGAN = "test_game_slogan"
+        general_context.set_game_name_and_slogan()
+        self.assertEqual(general_context.GAME_NAME, "test_name")
+        self.assertEqual(general_context.GAME_SLOGAN, "test_game_slogan")
+
+    @patch('evennia.web.utils.general_context.settings')
+    def test_set_webclient_settings(self, mock_settings):
+        mock_settings.WEBCLIENT_ENABLED = "webclient"
+        mock_settings.WEBSOCKET_CLIENT_URL = "websocket_url"
+        mock_settings.WEBSOCKET_CLIENT_ENABLED = "websocket_client"
+        mock_settings.WEBSOCKET_CLIENT_PORT = "websocket_port"
+        general_context.set_webclient_settings()
+        self.assertEqual(general_context.WEBCLIENT_ENABLED, "webclient")
+        self.assertEqual(general_context.WEBSOCKET_URL, "websocket_url")
+        self.assertEqual(general_context.WEBSOCKET_CLIENT_ENABLED, "websocket_client")
+        self.assertEqual(general_context.WEBSOCKET_PORT, "websocket_port")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Another small bit of unit testing, this one for the general_context for the webpage. I struggled a bit with the testing of the global variables that were assigned - while I could mock them, this wouldn't cover testing their actual assignment. So I decided to move them into functions that would be immediately called in the module so that those could have their own separate test methods. If you like the approach, it might be something I'd do when writing unit tests for other modules that use global variables.

#### Motivation for adding to Evennia
Add more test coverage.

#### Other info (issues closed, discussion etc)
Yet another #1458 