### PR TITLE
Fix Admin page for Channel objects

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -417,7 +417,7 @@ class CmdCBoot(COMMAND_DEFAULT_CLASS):
             string = "You don't control this channel."
             self.msg(string)
             return
-        if account not in channel.db_subscriptions.all():
+        if not channel.subscriptions.has(account):
             string = "Account %s is not connected to channel %s." % (account.key, channel.key)
             self.msg(string)
             return

--- a/evennia/comms/admin.py
+++ b/evennia/comms/admin.py
@@ -58,7 +58,7 @@ class ChannelAdmin(admin.ModelAdmin):
     save_on_top = True
     list_select_related = True
     fieldsets = (
-        (None, {'fields': (('db_key',), 'db_lock_storage', 'db_subscriptions')}),
+        (None, {'fields': (('db_key',), 'db_lock_storage', 'db_account_subscriptions', 'db_object_subscriptions')}),
     )
 
     def subscriptions(self, obj):
@@ -69,7 +69,7 @@ class ChannelAdmin(admin.ModelAdmin):
             obj (Channel): The channel to get subs from.
 
         """
-        return ", ".join([str(sub) for sub in obj.db_subscriptions.all()])
+        return ", ".join([str(sub) for sub in obj.subscriptions.all()])
 
     def save_model(self, request, obj, form, change):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In Evennia 0.7, the admin page for the Channel objects still referred to `db_subscriptions`, which caused a server error.

#### Motivation for adding to Evennia
Fixes 500 error on admin page for channels

#### Other info (issues closed, discussion etc)
Built against master - since it's a bugfix.