### PR TITLE
Fix search and timeout with large database

### DIFF
--- a/evennia/comms/admin.py
+++ b/evennia/comms/admin.py
@@ -53,10 +53,11 @@ class ChannelAdmin(admin.ModelAdmin):
     list_display = ('id', 'db_key', 'db_lock_storage', "subscriptions")
     list_display_links = ("id", 'db_key')
     ordering = ["db_key"]
-    search_fields = ['id', 'db_key', 'db_aliases']
+    search_fields = ['id', 'db_key', 'db_tags__db_key']
     save_as = True
     save_on_top = True
     list_select_related = True
+    raw_id_fields = ('db_object_subscriptions', 'db_account_subscriptions',)
     fieldsets = (
         (None, {'fields': (('db_key',), 'db_lock_storage', 'db_account_subscriptions', 'db_object_subscriptions')}),
     )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In the admin window, searches wouldn't work for Channels because it was trying to search db_aliases, which didn't exist, rather than db_tags. Viewing any channel would try to go for a few minutes before returning a database lock error if you had large numbers of objects in the database due to not having raw_id fields set, so added those.

#### Motivation for adding to Evennia
Prevent errors from being raised in channel admin.

#### Other info (issues closed, discussion etc)
N/A
