### PR TITLE
Flexible at say

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1685,10 +1685,8 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             msg_type = 'whisper'
             msg_self = '{self} whisper to {all_receivers}, "{speech}"' if msg_self is True else msg_self
             msg_receivers = '{object} whispers: "{speech}"'
-            msg_location = None
         else:
             msg_self = '{self} say, "{speech}"' if msg_self is True else msg_self
-            msg_receivers = None
             msg_location = msg_location or '{object} says, "{speech}"'
 
         custom_mapping = kwargs.get('mapping', {})
@@ -1733,9 +1731,14 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
                                 "receiver": None,
                                 "speech": message}
             location_mapping.update(custom_mapping)
+            exclude = []
+            if msg_self:
+                exclude.append(self)
+            if receivers:
+                exclude.extend(receivers)
             self.location.msg_contents(text=(msg_location, {"type": msg_type}),
                                        from_obj=self,
-                                       exclude=(self, ) if msg_self else None,
+                                       exclude=exclude,
                                        mapping=location_mapping)
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
at_say hindered flexibility in ignoring parameters that could be passed to it. For example, you could not have speaking in a foreign language send different messages to some players and not others. Or send a different room message for a private message, such as 'Bob is seen whispering to Jane.'

#### Motivation for adding to Evennia
Make at_say more flexible.

#### Other info (issues closed, discussion etc)
Did separately from the bug fixes in #1525 since this is a feature/functionality change rather than fix.
