### PR TITLE
Add a setting to change telnet default encoding

### DIFF
--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -50,7 +50,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         self.handshakes = 8  # suppress-go-ahead, naws, ttype, mccp, mssp, msdp, gmcp, mxp
         self.init_session(self.protocol_name, client_address, self.factory.sessionhandler)
         # change encoding to ENCODINGS[0] which reflects Telnet default encoding
-        self.protocol_flags["ENCODING"] = settings.ENCODINGS[0]
+        self.protocol_flags["ENCODING"] = settings.ENCODINGS[0] if settings.ENCODINGS else 'utf-8'
 
         # suppress go-ahead
         self.sga = suppress_ga.SuppressGA(self)

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -24,7 +24,6 @@ _RE_LEND = re.compile(r"\n$|\r$|\r\n$|\r\x00$|", re.MULTILINE)
 _RE_LINEBREAK = re.compile(r"\n\r|\r\n|\n|\r", re.DOTALL + re.MULTILINE)
 _RE_SCREENREADER_REGEX = re.compile(r"%s" % settings.SCREENREADER_REGEX_STRIP, re.DOTALL + re.MULTILINE)
 _IDLE_COMMAND = settings.IDLE_COMMAND + "\n"
-_TELNET_ENCODING = settings.ENCODINGS[0]
 
 class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
     """
@@ -49,8 +48,9 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         # this number is counted down for every handshake that completes.
         # when it reaches 0 the portal/server syncs their data
         self.handshakes = 8  # suppress-go-ahead, naws, ttype, mccp, mssp, msdp, gmcp, mxp
-        self.init_session(self.protocol_name, client_address, self.factory.sessionhandler,
-                override_flags={"ENCODING": _TELNET_ENCODING})
+        self.init_session(self.protocol_name, client_address, self.factory.sessionhandler)
+        # change encoding to ENCODINGS[0] which reflects Telnet default encoding
+        self.protocol_flags["ENCODING"] = settings.ENCODINGS[0]
 
         # suppress go-ahead
         self.sga = suppress_ga.SuppressGA(self)

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -24,7 +24,7 @@ _RE_LEND = re.compile(r"\n$|\r$|\r\n$|\r\x00$|", re.MULTILINE)
 _RE_LINEBREAK = re.compile(r"\n\r|\r\n|\n|\r", re.DOTALL + re.MULTILINE)
 _RE_SCREENREADER_REGEX = re.compile(r"%s" % settings.SCREENREADER_REGEX_STRIP, re.DOTALL + re.MULTILINE)
 _IDLE_COMMAND = settings.IDLE_COMMAND + "\n"
-
+_TELNET_ENCODING = settings.TELNET_ENCODING
 
 class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
     """
@@ -49,7 +49,8 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         # this number is counted down for every handshake that completes.
         # when it reaches 0 the portal/server syncs their data
         self.handshakes = 8  # suppress-go-ahead, naws, ttype, mccp, mssp, msdp, gmcp, mxp
-        self.init_session(self.protocol_name, client_address, self.factory.sessionhandler)
+        self.init_session(self.protocol_name, client_address, self.factory.sessionhandler,
+                override_flags={"ENCODING": _TELNET_ENCODING})
 
         # suppress go-ahead
         self.sga = suppress_ga.SuppressGA(self)

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -24,7 +24,7 @@ _RE_LEND = re.compile(r"\n$|\r$|\r\n$|\r\x00$|", re.MULTILINE)
 _RE_LINEBREAK = re.compile(r"\n\r|\r\n|\n|\r", re.DOTALL + re.MULTILINE)
 _RE_SCREENREADER_REGEX = re.compile(r"%s" % settings.SCREENREADER_REGEX_STRIP, re.DOTALL + re.MULTILINE)
 _IDLE_COMMAND = settings.IDLE_COMMAND + "\n"
-_TELNET_ENCODING = settings.TELNET_ENCODING
+_TELNET_ENCODING = settings.ENCODINGS[0]
 
 class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
     """

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -41,7 +41,7 @@ class Session(object):
                       'conn_time', 'cmd_last', 'cmd_last_visible', 'cmd_total',
                       'protocol_flags', 'server_data', "cmdset_storage_string")
 
-    def init_session(self, protocol_key, address, sessionhandler):
+    def init_session(self, protocol_key, address, sessionhandler, override_flags=None):
         """
         Initialize the Session. This should be called by the protocol when
         a new session is established.
@@ -52,6 +52,7 @@ class Session(object):
             address (str): Client address.
             sessionhandler (SessionHandler): Reference to the
                 main sessionhandler instance.
+        override_flags (optional, dict): a dictionary of protocol flags to override.
 
         """
         # This is currently 'telnet', 'ssh', 'ssl' or 'web'
@@ -87,6 +88,10 @@ class Session(object):
                                "INPUTDEBUG": False,
                                "RAW": False,
                                "NOCOLOR": False}
+
+        if override_flags:
+            self.protocol_flags.update(override_flags)
+
         self.server_data = {}
 
         # map of input data to session methods

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -7,7 +7,6 @@ from builtins import object
 
 import time
 
-
 #------------------------------------------------------------
 # Server Session
 #------------------------------------------------------------
@@ -41,7 +40,7 @@ class Session(object):
                       'conn_time', 'cmd_last', 'cmd_last_visible', 'cmd_total',
                       'protocol_flags', 'server_data', "cmdset_storage_string")
 
-    def init_session(self, protocol_key, address, sessionhandler, override_flags=None):
+    def init_session(self, protocol_key, address, sessionhandler):
         """
         Initialize the Session. This should be called by the protocol when
         a new session is established.
@@ -52,7 +51,6 @@ class Session(object):
             address (str): Client address.
             sessionhandler (SessionHandler): Reference to the
                 main sessionhandler instance.
-        override_flags (optional, dict): a dictionary of protocol flags to override.
 
         """
         # This is currently 'telnet', 'ssh', 'ssl' or 'web'
@@ -88,10 +86,6 @@ class Session(object):
                                "INPUTDEBUG": False,
                                "RAW": False,
                                "NOCOLOR": False}
-
-        if override_flags:
-            self.protocol_flags.update(override_flags)
-
         self.server_data = {}
 
         # map of input data to session methods

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -166,6 +166,12 @@ IDLE_TIMEOUT = -1
 # command-name is given here; this is because the webclient needs a default
 # to send to avoid proxy timeouts.
 IDLE_COMMAND = "idle"
+# The encoding (character set) specific to Telnet. This will not influence
+# other encoding settings: namely, the webclient, the website, the
+# database encoding will remain (utf-8 by default).  This setting only
+# affects the telnet encoding and will be overridden by user settings
+# (through one of their client's supported protocol or their account options).
+TELNET_ENCODING = "utf-8"
 # The set of encodings tried. An Account object may set an attribute "encoding" on
 # itself to match the client used. If not set, or wrong encoding is
 # given, this list is tried, in order, aborting on the first match.

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -166,17 +166,12 @@ IDLE_TIMEOUT = -1
 # command-name is given here; this is because the webclient needs a default
 # to send to avoid proxy timeouts.
 IDLE_COMMAND = "idle"
-# The encoding (character set) specific to Telnet. This will not influence
-# other encoding settings: namely, the webclient, the website, the
-# database encoding will remain (utf-8 by default).  This setting only
-# affects the telnet encoding and will be overridden by user settings
-# (through one of their client's supported protocol or their account options).
-TELNET_ENCODING = "utf-8"
 # The set of encodings tried. An Account object may set an attribute "encoding" on
 # itself to match the client used. If not set, or wrong encoding is
 # given, this list is tried, in order, aborting on the first match.
 # Add sets for languages/regions your accounts are likely to use.
 # (see http://en.wikipedia.org/wiki/Character_encoding)
+# Telnet default encoding, unless specified by the client, will be ENCODINGS[0].
 ENCODINGS = ["utf-8", "latin-1", "ISO-8859-1"]
 # Regular expression applied to all output to a given session in order
 # to strip away characters (usually various forms of decorations) for the benefit


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This adds a new setting in the default settings.  One can change Telnet default encoding to something other than utf-8.

There's a little issue though (see below).

#### Motivation for adding to Evennia

Some countries are used to a certain encoding, and that's not necessarily utf-8.  Here in France Windows often comes with a latin-1 encoded system and natively supports it, while utf-8 may not be as widely supported.  Changing the default encoding, only for telnet, while allowing full customization per user, would be good in principle.

#### Current issue

As it is, the code is pretty straightforward.  However, if you use `@options/save` to change your encoding and save it in the account, then the encoding is dropped the next time you connect or reload the server.  I am not positive why this happens.  The overridden flag still appears in the account attributes, but it's not applied for some reason.

#### Other info (issues closed, discussion etc)

* Evennia develop
