### PR TITLE
Update websocket URL so proxy port can be utilized. Resolves #1421.

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -89,9 +89,9 @@ WEBSOCKET_CLIENT_PORT = 4005
 WEBSOCKET_CLIENT_INTERFACE = '0.0.0.0'
 # Actual URL for webclient component to reach the websocket. You only need
 # to set this if you know you need it, like using some sort of proxy setup.
-# If given it must be on the form "ws://hostname" (WEBSOCKET_CLIENT_PORT will
-# be automatically appended). If left at None, the client will itself
-# figure out this url based on the server's hostname.
+# If given it must be on the form "ws[s]://hostname[:port]". If left at None, 
+# the client will itself figure out this url based on the server's hostname.
+# e.g. ws://external.example.com or wss://external.example.com:443
 WEBSOCKET_CLIENT_URL = None
 # This determine's whether Evennia's custom admin page is used, or if the
 # standard Django admin is used.

--- a/evennia/web/webclient/templates/webclient/base.html
+++ b/evennia/web/webclient/templates/webclient/base.html
@@ -44,7 +44,7 @@ JQuery available.
         {% endif %}
 
         {% if websocket_url %}
-            var wsurl = "{{websocket_url}}:{{websocket_port}}";
+            var wsurl = "{{websocket_url}}";
         {% else %}
             var wsurl = "ws://" + this.location.hostname + ":{{websocket_port}}";
         {% endif %}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Patch for #1421. Allows a proxy port to be used in websocket url setting.

#### Motivation for adding to Evennia
`wss://` support.
