### PR TITLE
Fix errors in django admin for Attributes

### DIFF
--- a/evennia/utils/picklefield.py
+++ b/evennia/utils/picklefield.py
@@ -120,9 +120,11 @@ def dbsafe_decode(value, compress_object=False):
 
 class PickledWidget(Textarea):
     def render(self, name, value, attrs=None):
+        """Display of the PickledField in django admin"""
         value = repr(value)
         try:
-            literal_eval(value)
+            # necessary to convert it back after repr(), otherwise validation errors will mutate it
+            value = literal_eval(value)
         except ValueError:
             return value
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Resolve issue with repeated `repr()` calls on validation errors, making the attributes unusuable. Handle edge case of sets not converting properly with literal_eval in python 2.x - believe it's fixed in 3.x.

#### Motivation for adding to Evennia
Make sure that changing attributes in django admin won't break anything.

#### Other info (issues closed, discussion etc)
Resolves #1521 