### PR TITLE
Add automatic escaping of the settings docstring for Windows' sake

### DIFF
--- a/evennia/game_template/server/conf/settings.py
+++ b/evennia/game_template/server/conf/settings.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Evennia settings file.
 
 The available options are found in the default settings file found


### PR DESCRIPTION
#### Brief overview of PR changes/additions

In Python 3, docstrings can contain arbitrary values escaped with `\`.  The current setting file (created by default in `mygame/server/conf/settings.py`) also contains the absolute path.  On Windows, this path has `\` in it.  As it is, it raises a `SyntaxError` on reading the docstring.

#### Motivation for adding to Evennia

Fixing this little conflict was trivial and simple.  However there might be some discussion on how to do that:

1. I chose to place a simple `r` in front of the docstring itself to escape the `\` it might contain.
2. We could also require the path be escaped.

I don't suppose it's worth a long debate and that's the only file which gave me this issue, so I don't think a general policy would be required but...

#### Other info (issues closed, discussion etc)

  * Evennia on Py3k (note, again, I work on Python 3.6, Python 3.5 doesn't work with Evennia on Windows and apparently not on other platforms for some reason)
