### PR TITLE
`@locate` alias of CmdFind shows location of find

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -297,7 +297,7 @@ class Command(with_metaclass(CommandMeta, object)):
         Args:
             srcobj (Object): Object trying to gain permission
             access_type (str, optional): The lock type to check.
-            default (bool, optional): The fallbacl result if no lock
+            default (bool, optional): The fallback result if no lock
                 of matching `access_type` is found on this Command.
 
         """

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2315,7 +2315,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
             else:
                 result = result[0]
                 string += "\n|g   %s - %s|n" % (result.get_display_name(caller), result.path)
-                if self.cmdstring == "@locate" and not is_account and result.location:
+                if "locate" in self.cmdstring and not is_account and result.location:
                     string += "  Location: {}".format(result.location.get_display_name(caller))
         else:
             # Not an account/dbref search but a wider search; build a queryset.
@@ -2352,7 +2352,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
                 else:
                     string = "|wOne Match|n(#%i-#%i%s):" % (low, high, restrictions)
                     string += "\n   |g%s - %s|n" % (results[0].get_display_name(caller), results[0].path)
-                    if self.cmdstring == "@locate" and nresults == 1 and results[0].location:
+                    if "locate" in self.cmdstring and nresults == 1 and results[0].location:
                         string += "  Location: {}".format(results[0].location.get_display_name(caller))
             else:
                 string = "|wMatch|n(#%i-#%i%s):" % (low, high, restrictions)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2238,12 +2238,14 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
     Usage:
       @find[/switches] <name or dbref or *account> [= dbrefmin[-dbrefmax]]
+      @locate - this is a shorthand for using the /loc switch.
 
     Switches:
       room - only look for rooms (location=None)
       exit - only look for exits (destination!=None)
       char - only look for characters (BASE_CHARACTER_TYPECLASS)
       exact- only exact matches are returned.
+      loc  - display object location if exists and match has one result
 
     Searches the database for an object of a particular name or exact #dbref.
     Use *accountname to search for an account. The switches allows for
@@ -2265,6 +2267,9 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
         if not self.args:
             caller.msg("Usage: @find <string> [= low [-high]]")
             return
+
+        if "locate" in self.cmdstring:  # Use option /loc as a default for @locate command alias
+            switches.append('loc')
 
         searchstring = self.lhs
         low, high = 1, ObjectDB.objects.all().order_by("-id")[0].id
@@ -2315,8 +2320,8 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
             else:
                 result = result[0]
                 string += "\n|g   %s - %s|n" % (result.get_display_name(caller), result.path)
-                if "locate" in self.cmdstring and not is_account and result.location:
-                    string += "  Location: {}".format(result.location.get_display_name(caller))
+                if "loc" in self.switches and not is_account and result.location:
+                    string += " (|wlocation|n: |g{}|n)".format(result.location.get_display_name(caller))
         else:
             # Not an account/dbref search but a wider search; build a queryset.
             # Searchs for key and aliases
@@ -2352,8 +2357,8 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
                 else:
                     string = "|wOne Match|n(#%i-#%i%s):" % (low, high, restrictions)
                     string += "\n   |g%s - %s|n" % (results[0].get_display_name(caller), results[0].path)
-                    if "locate" in self.cmdstring and nresults == 1 and results[0].location:
-                        string += "  Location: {}".format(results[0].location.get_display_name(caller))
+                    if "loc" in self.switches and nresults == 1 and results[0].location:
+                        string += " (|wlocation|n: |g{}|n)".format(results[0].location.get_display_name(caller))
             else:
                 string = "|wMatch|n(#%i-#%i%s):" % (low, high, restrictions)
                 string += "\n   |RNo matches found for '%s'|n" % searchstring

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2315,6 +2315,8 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
             else:
                 result = result[0]
                 string += "\n|g   %s - %s|n" % (result.get_display_name(caller), result.path)
+                if self.cmdstring == "@locate" and not is_account and result.location:
+                    string += "  Location: {}".format(result.location.get_display_name(caller))
         else:
             # Not an account/dbref search but a wider search; build a queryset.
             # Searchs for key and aliases
@@ -2350,6 +2352,8 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
                 else:
                     string = "|wOne Match|n(#%i-#%i%s):" % (low, high, restrictions)
                     string += "\n   |g%s - %s|n" % (results[0].get_display_name(caller), results[0].path)
+                    if self.cmdstring == "@locate" and nresults == 1 and results[0].location:
+                        string += "  Location: {}".format(results[0].location.get_display_name(caller))
             else:
                 string = "|wMatch|n(#%i-#%i%s):" % (low, high, restrictions)
                 string += "\n   |RNo matches found for '%s'|n" % searchstring

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -439,7 +439,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
     Usage:
       whisper <character> = <message>
-      whisper <char1>, <char2> = <message?
+      whisper <char1>, <char2> = <message>
 
     Talk privately to one or more characters in your current location, without
     others in the room being informed.

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -293,6 +293,12 @@ class TestBuilding(CommandTest):
 
     def test_find(self):
         self.call(building.CmdFind(), "Room2", "One Match")
+        expect = "One Match(#1#7, loc):\n   " +\
+                 "Char2(#7)  evennia.objects.objects.DefaultCharacter (location: Room(#1))"
+        self.call(building.CmdFind(), "Char2", expect, cmdstring="locate")
+        self.call(building.CmdFind(), "Char2", expect, cmdstring="@locate")
+        self.call(building.CmdFind(), "/loc Char2", expect, cmdstring="find")
+        self.call(building.CmdFind(), "Char2", "One Match", cmdstring="@find")
 
     def test_script(self):
         self.call(building.CmdScript(), "Obj = scripts.Script", "Script scripts.Script successfully added")

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -470,7 +470,7 @@ BASE_SCRIPT_TYPECLASS = "typeclasses.scripts.Script"
 DEFAULT_HOME = "#2"
 # The start position for new characters. Default is Limbo (#2).
 #  MULTISESSION_MODE = 0, 1 - used by default unloggedin create command
-#  MULTISESSION_MODE = 2,3 - used by default character_create command
+#  MULTISESSION_MODE = 2, 3 - used by default character_create command
 START_LOCATION = "#2"
 # Lookups of Attributes, Tags, Nicks, Aliases can be aggressively
 # cached to avoid repeated database hits. This often gives noticeable
@@ -545,8 +545,8 @@ INLINEFUNC_MODULES = ["evennia.utils.inlinefuncs",
 #  3 - like mode 2, except multiple sessions can puppet one character, each
 #      session getting the same data.
 MULTISESSION_MODE = 0
-# The maximum number of characters allowed for MULTISESSION_MODE 2,3. This is
-# checked by the default ooc char-creation command. Forced to 1 for
+# The maximum number of characters allowed for MULTISESSION_MODE 2, 3.
+# This is checked by the default ooc char-creation command. Forced to 1 for
 # MULTISESSION_MODE 0 and 1.
 MAX_NR_CHARACTERS = 1
 # The access hierarchy, in climbing order. A higher permission in the


### PR DESCRIPTION
## Brief overview of PR changes/additions
If using `@locate` alias and only one object is found and the found object has a location, display that information.

Also, typo fix in CmdWhisper help docstring and access method in Command class

## Motivation for adding to Evennia
If one wants to know the location of an object, instead of doing a `@find` then an `@examine`, one can just `@locate` the object, provided the search identifier locates a unique object that has a non-None location.

## Other info (issues closed, discussion etc)

For develop branch, though the feature (and typo fix) can easily be back-ported.
Should a unit test be written for this minor addition?