### PR TITLE
CmdWall docstring and message correction

### DIFF
--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -544,7 +544,8 @@ class CmdWall(COMMAND_DEFAULT_CLASS):
     Usage:
       @wall <message>
 
-    Announces a message to all connected accounts.
+    Announces a message to all connected sessions
+    including all currently unlogged in.
     """
     key = "@wall"
     locks = "cmd:perm(wall) or perm(Admin)"
@@ -556,5 +557,5 @@ class CmdWall(COMMAND_DEFAULT_CLASS):
             self.caller.msg("Usage: @wall <message>")
             return
         message = "%s shouts \"%s\"" % (self.caller.name, self.args)
-        self.msg("Announcing to all connected accounts ...")
+        self.msg("Announcing to all connected sessions ...")
         SESSIONS.announce_all(message)

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -185,7 +185,7 @@ class TestAdmin(CommandTest):
         self.call(admin.CmdPerm(), "Char2 = Builder", "Permission 'Builder' given to Char2 (the Object/Character).")
 
     def test_wall(self):
-        self.call(admin.CmdWall(), "Test", "Announcing to all connected accounts ...")
+        self.call(admin.CmdWall(), "Test", "Announcing to all connected sessions ...")
 
     def test_ban(self):
         self.call(admin.CmdBan(), "Char", "NameBan char was added.")


### PR DESCRIPTION
### Brief overview of PR changes/additions
Notes that message will also be sent to unlogged in sessions, not just connected accounts.

### Motivation for adding to Evennia
Previous wording is slightly misleading, not mentioning unlogged in sessions will also receive the sent message.

### Other info (issues closed, discussion etc)
For master branch, if this is considered a fix.

If the intended behavior is send only to accounts (all logged in), then the unlogged in sessions need to be removed before sending.  Options could allow accounts, unlogged, or both to target specific sessions instead of all.
