### PR TITLE
Fix at_sync update call to have right number of arguments.

### DIFF
--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -134,7 +134,7 @@ class Session(object):
 
         """
         if self.account:
-            self.protocol_flags.update(self.account.attributes.get("_saved_protocol_flags"), {})
+            self.protocol_flags.update(self.account.attributes.get("_saved_protocol_flags") or {})
 
     # access hooks
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Whoops! There was more than one typo in #1555 . The `.attributes.get()` had the default empty dict outside it as a second argument to update, which only accepts one argument. So upon reload every at_sync would fail.

#### Motivation for adding to Evennia
Quick fix to at_sync.

#### Other info (issues closed, discussion etc)
Additional fix to #1555 
