### PR TITLE
Change if statement in comms/models.py to fix #1570

### DIFF
--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -584,9 +584,7 @@ class SubscriptionHandler(object):
         for obj in self.all():
             from django.core.exceptions import ObjectDoesNotExist
             try:
-                if hasattr(obj, 'account'):
-                    if not obj.account:
-                        continue
+                if hasattr(obj, 'account') and obj.account:
                     obj = obj.account
                 if not obj.is_connected:
                     continue

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -519,6 +519,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
                     obj.at_msg_send(text=text, to_obj=self, **kwargs)
                 except Exception:
                     logger.log_trace()
+        kwargs["options"] = options
         try:
             if not self.at_msg_receive(text=text, **kwargs):
                 # if at_msg_receive returns false, we abort message to this object
@@ -526,7 +527,6 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         except Exception:
             logger.log_trace()
 
-        kwargs["options"] = options
 
         if text and not (isinstance(text, basestring) or isinstance(text, tuple)):
             # sanitize text before sending across the wire

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -207,6 +207,14 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
         return ObjectSessionHandler(self)
 
     @property
+    def is_connected(self):
+        # we get an error for objects subscribed to channels without this
+        if self.account: # seems sane to pass on the account
+            return self.account.is_connected
+        else:
+            return False
+
+    @property
     def has_account(self):
         """
         Convenience property for checking if an active account is


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Applies fix described in #1570 as well as adds/fixes a couple other conveniences for people attempting to subscribe objects to channels.

#### Motivation for adding to Evennia
Fixes #1570, better supports inter-object messages through channels

#### Other info (issues closed, discussion etc)
1. Applies fix described in #1570 in `comms/models.py`, changing an if statement so that objects without accounts can still be subscribed to a channel
2. Move options dict being added to kwargs in the DefaultObject `.msg` function to _prior_ to sending over to `at_msg_receive` hook - this allows us to see what channel sent the message in the `at_msg_receive` hook, as seems to have been intended.
3. Add `is_connected` property to DefaultObject, defaulting to `False` or the account's `is_connected` property, if available. This avoids an error message we would get otherwise.