### PR TITLE
Optional features for MuxCommand, added to default Evennia commands

### DIFF
--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -467,7 +467,7 @@ class CmdOption(COMMAND_DEFAULT_CLASS):
     """
     key = "@option"
     aliases = "@options"
-    options = ("save", "clear")
+    switch_options = ("save", "clear")
     locks = "cmd:all()"
 
     # this is used by the parent
@@ -651,7 +651,7 @@ class CmdQuit(COMMAND_DEFAULT_CLASS):
     game. Use the /all switch to disconnect from all sessions.
     """
     key = "@quit"
-    options = ("all",)
+    switch_options = ("all",)
     locks = "cmd:all()"
 
     # this is used by the parent

--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -455,7 +455,7 @@ class CmdOption(COMMAND_DEFAULT_CLASS):
     Usage:
       @option[/save] [name = value]
 
-    Switch:
+    Switches:
       save - Save the current option settings for future logins.
       clear - Clear the saved options.
 
@@ -467,6 +467,7 @@ class CmdOption(COMMAND_DEFAULT_CLASS):
     """
     key = "@option"
     aliases = "@options"
+    options = ("save", "clear")
     locks = "cmd:all()"
 
     # this is used by the parent
@@ -650,6 +651,7 @@ class CmdQuit(COMMAND_DEFAULT_CLASS):
     game. Use the /all switch to disconnect from all sessions.
     """
     key = "@quit"
+    options = ("all",)
     locks = "cmd:all()"
 
     # this is used by the parent

--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -36,7 +36,7 @@ class CmdBoot(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@boot"
-    options = ("quiet", "sid")
+    switch_options = ("quiet", "sid")
     locks = "cmd:perm(boot) or perm(Admin)"
     help_category = "Admin"
 
@@ -266,7 +266,7 @@ class CmdDelAccount(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@delaccount"
-    options = ("delobj",)
+    switch_options = ("delobj",)
     locks = "cmd:perm(delaccount) or perm(Developer)"
     help_category = "Admin"
 
@@ -343,7 +343,7 @@ class CmdEmit(COMMAND_DEFAULT_CLASS):
     """
     key = "@emit"
     aliases = ["@pemit", "@remit"]
-    options = ("room", "accounts", "contents")
+    switch_options = ("room", "accounts", "contents")
     locks = "cmd:perm(emit) or perm(Builder)"
     help_category = "Admin"
 
@@ -453,7 +453,7 @@ class CmdPerm(COMMAND_DEFAULT_CLASS):
     """
     key = "@perm"
     aliases = "@setperm"
-    options = ("del", "account")
+    switch_options = ("del", "account")
     locks = "cmd:perm(perm) or perm(Developer)"
     help_category = "Admin"
 

--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -36,6 +36,7 @@ class CmdBoot(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@boot"
+    options = ("quiet", "sid")
     locks = "cmd:perm(boot) or perm(Admin)"
     help_category = "Admin"
 
@@ -265,6 +266,7 @@ class CmdDelAccount(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@delaccount"
+    options = ("delobj",)
     locks = "cmd:perm(delaccount) or perm(Developer)"
     help_category = "Admin"
 
@@ -329,9 +331,9 @@ class CmdEmit(COMMAND_DEFAULT_CLASS):
       @pemit           [<obj>, <obj>, ... =] <message>
 
     Switches:
-      room : limit emits to rooms only (default)
-      accounts : limit emits to accounts only
-      contents : send to the contents of matched objects too
+      room     -  limit emits to rooms only (default)
+      accounts -  limit emits to accounts only
+      contents -  send to the contents of matched objects too
 
     Emits a message to the selected objects or to
     your immediate surroundings. If the object is a room,
@@ -341,6 +343,7 @@ class CmdEmit(COMMAND_DEFAULT_CLASS):
     """
     key = "@emit"
     aliases = ["@pemit", "@remit"]
+    options = ("room", "accounts", "contents")
     locks = "cmd:perm(emit) or perm(Builder)"
     help_category = "Admin"
 
@@ -442,14 +445,15 @@ class CmdPerm(COMMAND_DEFAULT_CLASS):
       @perm[/switch] *<account> [= <permission>[,<permission>,...]]
 
     Switches:
-      del : delete the given permission from <object> or <account>.
-      account : set permission on an account (same as adding * to name)
+      del     -  delete the given permission from <object> or <account>.
+      account -  set permission on an account (same as adding * to name)
 
     This command sets/clears individual permission strings on an object
     or account. If no permission is given, list all permissions on <object>.
     """
     key = "@perm"
     aliases = "@setperm"
+    options = ("del", "account")
     locks = "cmd:perm(perm) or perm(Developer)"
     help_category = "Admin"
 

--- a/evennia/commands/default/batchprocess.py
+++ b/evennia/commands/default/batchprocess.py
@@ -237,7 +237,7 @@ class CmdBatchCommands(_COMMAND_DEFAULT_CLASS):
     """
     key = "@batchcommands"
     aliases = ["@batchcommand", "@batchcmd"]
-    options = ("interactive",)
+    switch_options = ("interactive",)
     locks = "cmd:perm(batchcommands) or perm(Developer)"
     help_category = "Building"
 
@@ -348,7 +348,7 @@ class CmdBatchCode(_COMMAND_DEFAULT_CLASS):
     """
     key = "@batchcode"
     aliases = ["@batchcodes"]
-    options = ("interactive", "debug")
+    switch_options = ("interactive", "debug")
     locks = "cmd:superuser()"
     help_category = "Building"
 

--- a/evennia/commands/default/batchprocess.py
+++ b/evennia/commands/default/batchprocess.py
@@ -237,6 +237,7 @@ class CmdBatchCommands(_COMMAND_DEFAULT_CLASS):
     """
     key = "@batchcommands"
     aliases = ["@batchcommand", "@batchcmd"]
+    options = ("interactive",)
     locks = "cmd:perm(batchcommands) or perm(Developer)"
     help_category = "Building"
 
@@ -347,6 +348,7 @@ class CmdBatchCode(_COMMAND_DEFAULT_CLASS):
     """
     key = "@batchcode"
     aliases = ["@batchcodes"]
+    options = ("interactive", "debug")
     locks = "cmd:superuser()"
     help_category = "Building"
 

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2427,7 +2427,7 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
     key = "@tel"
     aliases = "@teleport"
     switch_options = ("quiet", "intoexit", "tonone", "loc")
-    rhs_split = " to "
+    rhs_split = ("=", " to ")  # Prefer = delimiter, but allow " to " usage.
     locks = "cmd:perm(teleport) or perm(Builder)"
     help_category = "Building"
 

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -124,7 +124,7 @@ class CmdSetObjAlias(COMMAND_DEFAULT_CLASS):
 
     key = "@alias"
     aliases = "@setobjalias"
-    options = ("category",)
+    switch_options = ("category",)
     locks = "cmd:perm(setobjalias) or perm(Builder)"
     help_category = "Building"
 
@@ -219,7 +219,7 @@ class CmdCopy(ObjManipCommand):
     """
 
     key = "@copy"
-    options = ("reset",)
+    switch_options = ("reset",)
     locks = "cmd:perm(copy) or perm(Builder)"
     help_category = "Building"
 
@@ -301,7 +301,7 @@ class CmdCpAttr(ObjManipCommand):
     If you don't supply a source object, yourself is used.
     """
     key = "@cpattr"
-    options = ("move",)
+    switch_options = ("move",)
     locks = "cmd:perm(cpattr) or perm(Builder)"
     help_category = "Building"
 
@@ -443,7 +443,7 @@ class CmdMvAttr(ObjManipCommand):
     object. If you don't supply a source object, yourself is used.
     """
     key = "@mvattr"
-    options = ("copy",)
+    switch_options = ("copy",)
     locks = "cmd:perm(mvattr) or perm(Builder)"
     help_category = "Building"
 
@@ -492,7 +492,7 @@ class CmdCreate(ObjManipCommand):
     """
 
     key = "@create"
-    options = ("drop",)
+    switch_options = ("drop",)
     locks = "cmd:perm(create) or perm(Builder)"
     help_category = "Building"
 
@@ -578,7 +578,7 @@ class CmdDesc(COMMAND_DEFAULT_CLASS):
     """
     key = "@desc"
     aliases = "@describe"
-    options = ("edit",)
+    switch_options = ("edit",)
     locks = "cmd:perm(desc) or perm(Builder)"
     help_category = "Building"
 
@@ -657,7 +657,7 @@ class CmdDestroy(COMMAND_DEFAULT_CLASS):
 
     key = "@destroy"
     aliases = ["@delete", "@del"]
-    options = ("override", "force")
+    switch_options = ("override", "force")
     locks = "cmd:perm(destroy) or perm(Builder)"
     help_category = "Building"
 
@@ -781,7 +781,7 @@ class CmdDig(ObjManipCommand):
     would be 'north;no;n'.
     """
     key = "@dig"
-    options = ("teleport",)
+    switch_options = ("teleport",)
     locks = "cmd:perm(dig) or perm(Builder)"
     help_category = "Building"
 
@@ -924,7 +924,7 @@ class CmdTunnel(COMMAND_DEFAULT_CLASS):
 
     key = "@tunnel"
     aliases = ["@tun"]
-    options = ("oneway", "tel")
+    switch_options = ("oneway", "tel")
     locks = "cmd: perm(tunnel) or perm(Builder)"
     help_category = "Building"
 
@@ -2285,7 +2285,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
     key = "@find"
     aliases = "@search, @locate"
-    options = ("room", "exit", "char", "exact", "loc")
+    switch_options = ("room", "exit", "char", "exact", "loc")
     locks = "cmd:perm(find) or perm(Builder)"
     help_category = "Building"
 
@@ -2426,8 +2426,8 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
     """
     key = "@tel"
     aliases = "@teleport"
-    options = ("quiet", "intoexit", "tonone", "loc")
-    split = " to "
+    switch_options = ("quiet", "intoexit", "tonone", "loc")
+    rhs_split = " to "
     locks = "cmd:perm(teleport) or perm(Builder)"
     help_category = "Building"
 
@@ -2535,7 +2535,7 @@ class CmdScript(COMMAND_DEFAULT_CLASS):
 
     key = "@script"
     aliases = "@addscript"
-    options = ("start", "stop")
+    switch_options = ("start", "stop")
     locks = "cmd:perm(script) or perm(Builder)"
     help_category = "Building"
 
@@ -2777,7 +2777,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@spawn"
-    options = ("noloc", )
+    switch_options = ("noloc", )
     locks = "cmd:perm(spawn) or perm(Builder)"
     help_category = "Building"
 

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -124,6 +124,7 @@ class CmdSetObjAlias(COMMAND_DEFAULT_CLASS):
 
     key = "@alias"
     aliases = "@setobjalias"
+    options = ("category",)
     locks = "cmd:perm(setobjalias) or perm(Builder)"
     help_category = "Building"
 
@@ -218,6 +219,7 @@ class CmdCopy(ObjManipCommand):
     """
 
     key = "@copy"
+    options = ("reset",)
     locks = "cmd:perm(copy) or perm(Builder)"
     help_category = "Building"
 
@@ -299,6 +301,7 @@ class CmdCpAttr(ObjManipCommand):
     If you don't supply a source object, yourself is used.
     """
     key = "@cpattr"
+    options = ("move",)
     locks = "cmd:perm(cpattr) or perm(Builder)"
     help_category = "Building"
 
@@ -440,6 +443,7 @@ class CmdMvAttr(ObjManipCommand):
     object. If you don't supply a source object, yourself is used.
     """
     key = "@mvattr"
+    options = ("copy",)
     locks = "cmd:perm(mvattr) or perm(Builder)"
     help_category = "Building"
 
@@ -488,6 +492,7 @@ class CmdCreate(ObjManipCommand):
     """
 
     key = "@create"
+    options = ("drop",)
     locks = "cmd:perm(create) or perm(Builder)"
     help_category = "Building"
 
@@ -573,6 +578,7 @@ class CmdDesc(COMMAND_DEFAULT_CLASS):
     """
     key = "@desc"
     aliases = "@describe"
+    options = ("edit",)
     locks = "cmd:perm(desc) or perm(Builder)"
     help_category = "Building"
 
@@ -631,11 +637,11 @@ class CmdDestroy(COMMAND_DEFAULT_CLASS):
     Usage:
        @destroy[/switches] [obj, obj2, obj3, [dbref-dbref], ...]
 
-    switches:
+    Switches:
        override - The @destroy command will usually avoid accidentally
                   destroying account objects. This switch overrides this safety.
        force - destroy without confirmation.
-    examples:
+    Examples:
        @destroy house, roof, door, 44-78
        @destroy 5-10, flower, 45
        @destroy/force north
@@ -648,6 +654,7 @@ class CmdDestroy(COMMAND_DEFAULT_CLASS):
 
     key = "@destroy"
     aliases = ["@delete", "@del"]
+    options = ("override", "force")
     locks = "cmd:perm(destroy) or perm(Builder)"
     help_category = "Building"
 
@@ -771,6 +778,7 @@ class CmdDig(ObjManipCommand):
     would be 'north;no;n'.
     """
     key = "@dig"
+    options = ("teleport",)
     locks = "cmd:perm(dig) or perm(Builder)"
     help_category = "Building"
 
@@ -880,7 +888,7 @@ class CmdDig(ObjManipCommand):
                                                        new_back_exit.dbref,
                                                        alias_string)
         caller.msg("%s%s%s" % (room_string, exit_to_string, exit_back_string))
-        if new_room and ('teleport' in self.switches or "tel" in self.switches):
+        if new_room and 'teleport' in self.switches:
             caller.move_to(new_room)
 
 
@@ -913,6 +921,7 @@ class CmdTunnel(COMMAND_DEFAULT_CLASS):
 
     key = "@tunnel"
     aliases = ["@tun"]
+    options = ("oneway", "tel")
     locks = "cmd: perm(tunnel) or perm(Builder)"
     help_category = "Building"
 
@@ -2256,6 +2265,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
     key = "@find"
     aliases = "@search, @locate"
+    options = ("room", "exit", "char", "exact", "loc")
     locks = "cmd:perm(find) or perm(Builder)"
     help_category = "Building"
 
@@ -2292,7 +2302,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
         restrictions = ""
         if self.switches:
-            restrictions = ", %s" % (",".join(self.switches))
+            restrictions = ", %s" % (", ".join(self.switches))
 
         if is_dbref or is_account:
 
@@ -2372,7 +2382,7 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
     teleport object to another location
 
     Usage:
-      @tel/switch [<object> =] <target location>
+      @tel/switch [<object> to||=] <target location>
 
     Examples:
       @tel Limbo
@@ -2395,6 +2405,8 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
     is teleported to the target location.     """
     key = "@tel"
     aliases = "@teleport"
+    options = ("quiet", "intoexit", "tonone", "loc")
+    split = " to "
     locks = "cmd:perm(teleport) or perm(Builder)"
     help_category = "Building"
 
@@ -2502,6 +2514,7 @@ class CmdScript(COMMAND_DEFAULT_CLASS):
 
     key = "@script"
     aliases = "@addscript"
+    options = ("start", "stop")
     locks = "cmd:perm(script) or perm(Builder)"
     help_category = "Building"
 
@@ -2601,6 +2614,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
 
     key = "@tag"
     aliases = ["@tags"]
+    options = ("search", "del")
     locks = "cmd:perm(tag) or perm(Builder)"
     help_category = "Building"
     arg_regex = r"(/\w+?(\s|$))|\s|$"
@@ -2742,6 +2756,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@spawn"
+    options = ("noloc", )
     locks = "cmd:perm(spawn) or perm(Builder)"
     help_category = "Building"
 

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -385,7 +385,7 @@ class CmdCBoot(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@cboot"
-    options = ("quiet",)
+    switch_options = ("quiet",)
     locks = "cmd: not pperm(channel_banned)"
     help_category = "Comms"
 
@@ -454,7 +454,7 @@ class CmdCemit(COMMAND_DEFAULT_CLASS):
 
     key = "@cemit"
     aliases = ["@cmsg"]
-    options = ("sendername", "quiet")
+    switch_options = ("sendername", "quiet")
     locks = "cmd: not pperm(channel_banned) and pperm(Player)"
     help_category = "Comms"
 
@@ -685,7 +685,7 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
 
     key = "page"
     aliases = ['tell']
-    options = ("last", "list")
+    switch_options = ("last", "list")
     locks = "cmd:not pperm(page_banned)"
     help_category = "Comms"
 
@@ -853,7 +853,7 @@ class CmdIRC2Chan(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@irc2chan"
-    options = ("delete", "remove", "disconnect", "list", "ssl")
+    switch_options = ("delete", "remove", "disconnect", "list", "ssl")
     locks = "cmd:serversetting(IRC_ENABLED) and pperm(Developer)"
     help_category = "Comms"
 
@@ -1020,7 +1020,7 @@ class CmdRSS2Chan(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@rss2chan"
-    options = ("disconnect", "remove", "list")
+    switch_options = ("disconnect", "remove", "list")
     locks = "cmd:serversetting(RSS_ENABLED) and pperm(Developer)"
     help_category = "Comms"
 

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -377,7 +377,7 @@ class CmdCBoot(COMMAND_DEFAULT_CLASS):
     Usage:
        @cboot[/quiet] <channel> = <account> [:reason]
 
-    Switches:
+    Switch:
        quiet - don't notify the channel
 
     Kicks an account or object from a channel you control.
@@ -385,6 +385,7 @@ class CmdCBoot(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@cboot"
+    options = ("quiet",)
     locks = "cmd: not pperm(channel_banned)"
     help_category = "Comms"
 
@@ -453,6 +454,7 @@ class CmdCemit(COMMAND_DEFAULT_CLASS):
 
     key = "@cemit"
     aliases = ["@cmsg"]
+    options = ("sendername", "quiet")
     locks = "cmd: not pperm(channel_banned) and pperm(Player)"
     help_category = "Comms"
 
@@ -683,6 +685,7 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
 
     key = "page"
     aliases = ['tell']
+    options = ("last", "list")
     locks = "cmd:not pperm(page_banned)"
     help_category = "Comms"
 
@@ -850,6 +853,7 @@ class CmdIRC2Chan(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@irc2chan"
+    options = ("delete", "remove", "disconnect", "list", "ssl")
     locks = "cmd:serversetting(IRC_ENABLED) and pperm(Developer)"
     help_category = "Comms"
 
@@ -1016,6 +1020,7 @@ class CmdRSS2Chan(COMMAND_DEFAULT_CLASS):
     """
 
     key = "@rss2chan"
+    options = ("disconnect", "remove", "list")
     locks = "cmd:serversetting(RSS_ENABLED) and pperm(Developer)"
     help_category = "Comms"
 

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -448,7 +448,7 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
     placing it in their inventory.
     """
     key = "give"
-    rhs_split = " to "
+    rhs_split = ("=", " to ")  # Prefer = delimiter, but allow " to " usage.
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -117,7 +117,7 @@ class CmdNick(COMMAND_DEFAULT_CLASS):
 
     """
     key = "nick"
-    options = ("inputline", "object", "account", "list", "delete", "clearall")
+    switch_options = ("inputline", "object", "account", "list", "delete", "clearall")
     aliases = ["nickname", "nicks"]
     locks = "cmd:all()"
 
@@ -448,7 +448,7 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
     placing it in their inventory.
     """
     key = "give"
-    split = " to "
+    rhs_split = " to "
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -88,8 +88,7 @@ class CmdNick(COMMAND_DEFAULT_CLASS):
     Switches:
       inputline - replace on the inputline (default)
       object    - replace on object-lookup
-      account    - replace on account-lookup
-
+      account   - replace on account-lookup
       list      - show all defined aliases (also "nicks" works)
       delete    - remove nick by index in /list
       clearall  - clear all nicks
@@ -118,6 +117,7 @@ class CmdNick(COMMAND_DEFAULT_CLASS):
 
     """
     key = "nick"
+    options = ("inputline", "object", "account", "list", "delete", "clearall")
     aliases = ["nickname", "nicks"]
     locks = "cmd:all()"
 
@@ -377,12 +377,13 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
     give away something to someone
 
     Usage:
-      give <inventory obj> = <target>
+      give <inventory obj> <to||=> <target>
 
     Gives an items from your inventory to another character,
     placing it in their inventory.
     """
     key = "give"
+    split = " to "
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -317,7 +317,7 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
 
     """
     key = "@sethelp"
-    options = ("edit", "replace", "append", "extend", "delete")
+    switch_options = ("edit", "replace", "append", "extend", "delete")
     locks = "cmd:perm(Helper)"
     help_category = "Building"
 

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -317,6 +317,7 @@ class CmdSetHelp(COMMAND_DEFAULT_CLASS):
 
     """
     key = "@sethelp"
+    options = ("edit", "replace", "append", "extend", "delete")
     locks = "cmd:perm(Helper)"
     help_category = "Building"
 

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -114,6 +114,8 @@ class MuxCommand(Command):
 
         # split out switches
         switches, delimiters = [], self.rhs_split
+        if self.switch_options:
+            self.switch_options = [opt.lower() for opt in self.switch_options]
         if args and len(args) > 1 and raw[0] == "/":
             # we have a switch, or a set of switches. These end with a space.
             switches = args[1:].split(None, 1)
@@ -127,16 +129,16 @@ class MuxCommand(Command):
             if switches and self.switch_options:
                 valid_switches, unused_switches, extra_switches = [], [], []
                 for element in switches:
-                    option_check = [each for each in self.switch_options
-                                    if each.lower() == element.lower() or
-                                    each.lower().startswith(element.lower())]
+                    option_check = [opt for opt in self.switch_options if opt == element]
+                    if not option_check:
+                        option_check = [opt for opt in self.switch_options if opt.startswith(element)]
                     match_count = len(option_check)
                     if match_count > 1:
-                        extra_switches += option_check  # Either the option provided is ambiguous,
+                        extra_switches.extend(option_check)  # Either the option provided is ambiguous,
                     elif match_count == 1:
-                        valid_switches += option_check  # or it is a valid option abbreviation,
+                        valid_switches.extend(option_check)  # or it is a valid option abbreviation,
                     elif match_count == 0:
-                        unused_switches += [element]  # or an extraneous option to be ignored.
+                        unused_switches.append(element)  # or an extraneous option to be ignored.
                 if extra_switches:  # User provided switches
                     self.msg('|g%s|n: |wAmbiguous switch supplied: Did you mean /|C%s|w?' %
                              (self.cmdstring, ' |nor /|C'.join(extra_switches)))

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -84,7 +84,7 @@ class MuxCommand(Command):
                                   command (without the /))
           self.rhs_split       - Alternate string delimiter or tuple of strings
                                  to separate left/right hand sides. tuple form
-                                 gives priority split to first string delimeter.
+                                 gives priority split to first string delimiter.
 
         This parser breaks self.args into its constituents and stores them in the
         following variables:
@@ -149,13 +149,15 @@ class MuxCommand(Command):
 
         # check for arg1, arg2, ... = argA, argB, ... constructs
         lhs, rhs = args.strip(), None
-        best_split = self.rhs_split
         if lhs:
-            if hasattr(self.rhs_split, '__iter__'):
+            if hasattr(self.rhs_split, '__iter__'):  # If delimiter is iterable, try each
+                best_split = self.rhs_split[0]
                 for this_split in self.rhs_split:
-                    if this_split in lhs:  # First delimiter to allow a successful
-                        best_split = this_split  # split is the best split.
+                    if this_split in lhs:  # delimiter to allow first successful
+                        best_split = this_split  # split to be the best split.
                         break
+            else:
+                best_split = self.rhs_split
             # Parse to separate left into left/right sides using best_split delimiter string
             if best_split in lhs:
                 lhs, rhs = lhs.split(best_split, 1)

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -82,8 +82,9 @@ class MuxCommand(Command):
         Optional variables to aid in parsing, if set:
           self.switch_options  - (tuple of valid /switches expected by this
                                   command (without the /))
-          self.rhs_split       - Alternate string delimiter to separate
-                                 left/right hand sides.
+          self.rhs_split       - Alternate string delimiter or tuple of strings
+                                 to separate left/right hand sides. tuple form
+                                 gives priority split to first string delimeter.
 
         This parser breaks self.args into its constituents and stores them in the
         following variables:
@@ -103,11 +104,6 @@ class MuxCommand(Command):
         """
         raw = self.args
         args = raw.strip()
-        # Temporary code to use the old settings before renaming     # #
-        if hasattr(self, "options"):                                   #
-            self.switch_options = self.options                         #
-        if hasattr(self, "split") and not hasattr(self, "rhs_split"):  #
-            self.rhs_split = self.split                            # # #
         # Without explicitly setting these attributes, they assume default values:
         if not hasattr(self, "switch_options"):
             self.switch_options = None

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -113,7 +113,7 @@ class MuxCommand(Command):
             self.account_caller = False
 
         # split out switches
-        switches = []
+        switches, delimiters = [], self.rhs_split
         if args and len(args) > 1 and raw[0] == "/":
             # we have a switch, or a set of switches. These end with a space.
             switches = args[1:].split(None, 1)
@@ -150,14 +150,14 @@ class MuxCommand(Command):
         # check for arg1, arg2, ... = argA, argB, ... constructs
         lhs, rhs = args.strip(), None
         if lhs:
-            if hasattr(self.rhs_split, '__iter__'):  # If delimiter is iterable, try each
-                best_split = self.rhs_split[0]
-                for this_split in self.rhs_split:
-                    if this_split in lhs:  # delimiter to allow first successful
-                        best_split = this_split  # split to be the best split.
+            if delimiters and hasattr(delimiters, '__iter__'):  # If delimiter is iterable,
+                best_split = delimiters[0]  # (default to first delimiter)
+                for this_split in delimiters:  # try each delimiter
+                    if this_split in lhs:  # to find first successful split
+                        best_split = this_split  # to be the best split.
                         break
             else:
-                best_split = self.rhs_split
+                best_split = delimiters
             # Parse to separate left into left/right sides using best_split delimiter string
             if best_split in lhs:
                 lhs, rhs = lhs.split(best_split, 1)

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -245,7 +245,7 @@ class CmdPy(COMMAND_DEFAULT_CLASS):
     """
     key = "@py"
     aliases = ["!"]
-    options = ("time", "edit")
+    switch_options = ("time", "edit")
     locks = "cmd:perm(py) or perm(Developer)"
     help_category = "System"
 
@@ -329,7 +329,7 @@ class CmdScripts(COMMAND_DEFAULT_CLASS):
     """
     key = "@scripts"
     aliases = ["@globalscript", "@listscripts"]
-    options = ("start", "stop", "kill", "validate")
+    switch_options = ("start", "stop", "kill", "validate")
     locks = "cmd:perm(listscripts) or perm(Admin)"
     help_category = "System"
 
@@ -523,7 +523,7 @@ class CmdService(COMMAND_DEFAULT_CLASS):
 
     key = "@service"
     aliases = ["@services"]
-    options = ("list", "start", "stop", "delete")
+    switch_options = ("list", "start", "stop", "delete")
     locks = "cmd:perm(service) or perm(Developer)"
     help_category = "System"
 
@@ -706,7 +706,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
     """
     key = "@server"
     aliases = ["@serverload", "@serverprocess"]
-    options = ("mem", "flushmem")
+    switch_options = ("mem", "flushmem")
     locks = "cmd:perm(list) or perm(Developer)"
     help_category = "System"
 

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -245,6 +245,7 @@ class CmdPy(COMMAND_DEFAULT_CLASS):
     """
     key = "@py"
     aliases = ["!"]
+    options = ("time", "edit")
     locks = "cmd:perm(py) or perm(Developer)"
     help_category = "System"
 
@@ -328,6 +329,7 @@ class CmdScripts(COMMAND_DEFAULT_CLASS):
     """
     key = "@scripts"
     aliases = ["@globalscript", "@listscripts"]
+    options = ("start", "stop", "kill", "validate")
     locks = "cmd:perm(listscripts) or perm(Admin)"
     help_category = "System"
 
@@ -521,6 +523,7 @@ class CmdService(COMMAND_DEFAULT_CLASS):
 
     key = "@service"
     aliases = ["@services"]
+    options = ("list", "start", "stop", "delete")
     locks = "cmd:perm(service) or perm(Developer)"
     help_category = "System"
 
@@ -672,7 +675,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
     Usage:
        @server[/mem]
 
-    Switch:
+    Switches:
         mem - return only a string of the current memory usage
         flushmem - flush the idmapper cache
 
@@ -703,6 +706,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
     """
     key = "@server"
     aliases = ["@serverload", "@serverprocess"]
+    options = ("mem", "flushmem")
     locks = "cmd:perm(list) or perm(Developer)"
     help_category = "System"
 

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -140,6 +140,13 @@ class TestGeneral(CommandTest):
         self.call(general.CmdGet(), "Obj", "You pick up Obj.")
         self.call(general.CmdDrop(), "Obj", "You drop Obj.")
 
+    def test_give(self):
+        self.call(general.CmdGive(), "Obj to Char2", "You aren't carrying Obj.")
+        self.call(general.CmdGive(), "Obj = Char2", "You aren't carrying Obj.")
+        self.call(general.CmdGet(), "Obj", "You pick up Obj.")
+        self.call(general.CmdGive(), "Obj to Char2", "You give")
+        self.call(general.CmdGive(), "Obj = Char", "You give", caller=self.char2)
+
     def test_say(self):
         self.call(general.CmdSay(), "Testing", "You say, \"Testing\"")
 

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -21,6 +21,7 @@ from mock import Mock, mock
 from evennia.commands.default.cmdset_character import CharacterCmdSet
 from evennia.utils.test_resources import EvenniaTest
 from evennia.commands.default import help, general, system, admin, account, building, batchprocess, comms
+from evennia.commands.default.muxcommand import MuxCommand
 from evennia.commands.command import Command, InterruptCommand
 from evennia.utils import ansi, utils
 from evennia.server.sessionhandler import SESSIONS
@@ -146,6 +147,26 @@ class TestGeneral(CommandTest):
         self.call(general.CmdGet(), "Obj", "You pick up Obj.")
         self.call(general.CmdGive(), "Obj to Char2", "You give")
         self.call(general.CmdGive(), "Obj = Char", "You give", caller=self.char2)
+
+    def test_mux_command(self):
+
+        class CmdTest(MuxCommand):
+            key = 'test'
+            switch_options = ('test', 'testswitch', 'testswitch2')
+
+            def func(self):
+                self.msg("Switches matched: {}".format(self.switches))
+
+        self.call(CmdTest(), "/test/testswitch/testswitch2", "Switches matched: ['test', 'testswitch', 'testswitch2']")
+        self.call(CmdTest(), "/test", "Switches matched: ['test']")
+        self.call(CmdTest(), "/test/testswitch", "Switches matched: ['test', 'testswitch']")
+        self.call(CmdTest(), "/testswitch/testswitch2", "Switches matched: ['testswitch', 'testswitch2']")
+        self.call(CmdTest(), "/testswitch", "Switches matched: ['testswitch']")
+        self.call(CmdTest(), "/testswitch2", "Switches matched: ['testswitch2']")
+        self.call(CmdTest(), "/t", "test: Ambiguous switch supplied: "
+                                   "Did you mean /test or /testswitch or /testswitch2?|Switches matched: []")
+        self.call(CmdTest(), "/tests", "test: Ambiguous switch supplied: "
+                                       "Did you mean /testswitch or /testswitch2?|Switches matched: []")
 
     def test_say(self):
         self.call(general.CmdSay(), "Testing", "You say, \"Testing\"")

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -72,7 +72,6 @@ class CommandTest(EvenniaTest):
         cmdobj.obj = obj or (caller if caller else self.char1)
         # test
         old_msg = receiver.msg
-        returned_msg = ""
         try:
             receiver.msg = Mock()
             cmdobj.at_pre_cmd()
@@ -126,9 +125,12 @@ class TestGeneral(CommandTest):
         self.call(general.CmdPose(), "looks around", "Char looks around")
 
     def test_nick(self):
-        self.call(general.CmdNick(), "testalias = testaliasedstring1", "Inputlinenick 'testalias' mapped to 'testaliasedstring1'.")
-        self.call(general.CmdNick(), "/account testalias = testaliasedstring2", "Accountnick 'testalias' mapped to 'testaliasedstring2'.")
-        self.call(general.CmdNick(), "/object testalias = testaliasedstring3", "Objectnick 'testalias' mapped to 'testaliasedstring3'.")
+        self.call(general.CmdNick(), "testalias = testaliasedstring1",
+                  "Inputlinenick 'testalias' mapped to 'testaliasedstring1'.")
+        self.call(general.CmdNick(), "/account testalias = testaliasedstring2",
+                  "Accountnick 'testalias' mapped to 'testaliasedstring2'.")
+        self.call(general.CmdNick(), "/object testalias = testaliasedstring3",
+                  "Objectnick 'testalias' mapped to 'testaliasedstring3'.")
         self.assertEqual(u"testaliasedstring1", self.char1.nicks.get("testalias"))
         self.assertEqual(None, self.char1.nicks.get("testalias", category="account"))
         self.assertEqual(u"testaliasedstring2", self.char1.account.nicks.get("testalias", category="account"))
@@ -225,7 +227,8 @@ class TestAccount(CommandTest):
         self.call(account.CmdColorTest(), "ansi", "ANSI colors:", caller=self.account)
 
     def test_char_create(self):
-        self.call(account.CmdCharCreate(), "Test1=Test char", "Created new character Test1. Use @ic Test1 to enter the game", caller=self.account)
+        self.call(account.CmdCharCreate(), "Test1=Test char",
+                  "Created new character Test1. Use @ic Test1 to enter the game", caller=self.account)
 
     def test_quell(self):
         self.call(account.CmdQuell(), "", "Quelling to current puppet's permissions (developer).", caller=self.account)
@@ -234,7 +237,8 @@ class TestAccount(CommandTest):
 class TestBuilding(CommandTest):
     def test_create(self):
         name = settings.BASE_OBJECT_TYPECLASS.rsplit('.', 1)[1]
-        self.call(building.CmdCreate(), "/drop TestObj1", "You create a new %s: TestObj1." % name)
+        self.call(building.CmdCreate(), "/d TestObj1",   # /d switch is abbreviated form of /drop
+                  "You create a new %s: TestObj1." % name)
 
     def test_examine(self):
         self.call(building.CmdExamine(), "Obj", "Name/key: Obj")
@@ -244,7 +248,8 @@ class TestBuilding(CommandTest):
         self.call(building.CmdSetObjAlias(), "Obj = TestObj1b", "Alias(es) for 'Obj(#4)' set to 'testobj1b'.")
 
     def test_copy(self):
-        self.call(building.CmdCopy(), "Obj = TestObj2;TestObj2b, TestObj3;TestObj3b", "Copied Obj to 'TestObj3' (aliases: ['TestObj3b']")
+        self.call(building.CmdCopy(), "Obj = TestObj2;TestObj2b, TestObj3;TestObj3b",
+                  "Copied Obj to 'TestObj3' (aliases: ['TestObj3b']")
 
     def test_attribute_commands(self):
         self.call(building.CmdSetAttribute(), "Obj/test1=\"value1\"", "Created attribute Obj/test1 = 'value1'")
@@ -287,7 +292,8 @@ class TestBuilding(CommandTest):
 
     def test_typeclass(self):
         self.call(building.CmdTypeclass(), "Obj = evennia.objects.objects.DefaultExit",
-                  "Obj changed typeclass from evennia.objects.objects.DefaultObject to evennia.objects.objects.DefaultExit.")
+                  "Obj changed typeclass from evennia.objects.objects.DefaultObject "
+                  "to evennia.objects.objects.DefaultExit.")
 
     def test_lock(self):
         self.call(building.CmdLock(), "Obj = test:perm(Developer)", "Added lock 'test:perm(Developer)' to Obj.")
@@ -297,15 +303,24 @@ class TestBuilding(CommandTest):
         expect = "One Match(#1#7, loc):\n   " +\
                  "Char2(#7)  evennia.objects.objects.DefaultCharacter (location: Room(#1))"
         self.call(building.CmdFind(), "Char2", expect, cmdstring="locate")
+        self.call(building.CmdFind(), "/ex Char2",  # /ex is an ambiguous switch
+                  "locate: Ambiguous switch supplied: Did you mean /exit or /exact?|" + expect,
+                  cmdstring="locate")
         self.call(building.CmdFind(), "Char2", expect, cmdstring="@locate")
-        self.call(building.CmdFind(), "/loc Char2", expect, cmdstring="find")
+        self.call(building.CmdFind(), "/l Char2", expect, cmdstring="find")  # /l switch is abbreviated form of /loc
         self.call(building.CmdFind(), "Char2", "One Match", cmdstring="@find")
 
     def test_script(self):
         self.call(building.CmdScript(), "Obj = scripts.Script", "Script scripts.Script successfully added")
 
     def test_teleport(self):
-        self.call(building.CmdTeleport(), "Room2", "Room2(#2)\n|Teleported to Room2.")
+        self.call(building.CmdTeleport(), "/quiet Room2", "Room2(#2)\n|Teleported to Room2.")
+        self.call(building.CmdTeleport(), "/t",  # /t switch is abbreviated form of /tonone
+                  "Cannot teleport a puppeted object (Char, puppeted by TestAccount(account 1)) to a Nonelocation.")
+        self.call(building.CmdTeleport(), "/l Room2",  # /l switch is abbreviated form of /loc
+                  "Destination has no location.")
+        self.call(building.CmdTeleport(), "/q me to Room2",  # /q switch is abbreviated form of /quiet
+                  "Char is already at Room2.")
 
     def test_spawn(self):
         def getObject(commandTest, objKeyStr):
@@ -321,7 +336,7 @@ class TestBuilding(CommandTest):
         self.call(building.CmdSpawn(), " ", "Usage: @spawn")
 
         # Tests "@spawn <prototype_dictionary>" without specifying location.
-        self.call(building.CmdSpawn(), \
+        self.call(building.CmdSpawn(),
                   "{'key':'goblin', 'typeclass':'evennia.DefaultCharacter'}", "Spawned goblin")
         goblin = getObject(self, "goblin")
 
@@ -340,8 +355,8 @@ class TestBuilding(CommandTest):
             # char1's default location in the future...
             spawnLoc = self.room1
 
-        self.call(building.CmdSpawn(), \
-                  "{'prototype':'GOBLIN', 'key':'goblin', 'location':'%s'}" \
+        self.call(building.CmdSpawn(),
+                  "{'prototype':'GOBLIN', 'key':'goblin', 'location':'%s'}"
                   % spawnLoc.dbref, "Spawned goblin")
         goblin = getObject(self, "goblin")
         self.assertEqual(goblin.location, spawnLoc)
@@ -354,70 +369,81 @@ class TestBuilding(CommandTest):
         self.assertIsInstance(ball, DefaultObject)
         ball.delete()
 
-        # Tests "@spawn/noloc ..." without specifying a location.
+        # Tests "@spawn/n ..." without specifying a location.
         # Location should be "None".
-        self.call(building.CmdSpawn(), "/noloc 'BALL'", "Spawned Ball")
+        self.call(building.CmdSpawn(), "/n 'BALL'", "Spawned Ball")   # /n switch is abbreviated form of /noloc
         ball = getObject(self, "Ball")
         self.assertIsNone(ball.location)
         ball.delete()
 
         # Tests "@spawn/noloc ...", but DO specify a location.
         # Location should be the specified location.
-        self.call(building.CmdSpawn(),  \
-                  "/noloc {'prototype':'BALL', 'location':'%s'}" \
+        self.call(building.CmdSpawn(),
+                  "/noloc {'prototype':'BALL', 'location':'%s'}"
                   % spawnLoc.dbref, "Spawned Ball")
         ball = getObject(self, "Ball")
         self.assertEqual(ball.location, spawnLoc)
         ball.delete()
 
         # test calling spawn with an invalid prototype.
-        self.call(building.CmdSpawn(), \
-                  "'NO_EXIST'", "No prototype named 'NO_EXIST'")
+        self.call(building.CmdSpawn(), "'NO_EXIST'", "No prototype named 'NO_EXIST'")
 
 
 class TestComms(CommandTest):
 
     def setUp(self):
         super(CommandTest, self).setUp()
-        self.call(comms.CmdChannelCreate(), "testchan;test=Test Channel", "Created channel testchan and connected to it.", receiver=self.account)
+        self.call(comms.CmdChannelCreate(), "testchan;test=Test Channel",
+                  "Created channel testchan and connected to it.", receiver=self.account)
 
     def test_toggle_com(self):
-        self.call(comms.CmdAddCom(), "tc = testchan", "You are already connected to channel testchan. You can now", receiver=self.account)
+        self.call(comms.CmdAddCom(), "tc = testchan",
+                  "You are already connected to channel testchan. You can now", receiver=self.account)
         self.call(comms.CmdDelCom(), "tc", "Your alias 'tc' for channel testchan was cleared.", receiver=self.account)
 
     def test_channels(self):
-        self.call(comms.CmdChannels(), "", "Available channels (use comlist,addcom and delcom to manage", receiver=self.account)
+        self.call(comms.CmdChannels(), "",
+                  "Available channels (use comlist,addcom and delcom to manage", receiver=self.account)
 
     def test_all_com(self):
-        self.call(comms.CmdAllCom(), "", "Available channels (use comlist,addcom and delcom to manage", receiver=self.account)
+        self.call(comms.CmdAllCom(), "",
+                  "Available channels (use comlist,addcom and delcom to manage", receiver=self.account)
 
     def test_clock(self):
-        self.call(comms.CmdClock(), "testchan=send:all()", "Lock(s) applied. Current locks on testchan:", receiver=self.account)
+        self.call(comms.CmdClock(),
+                  "testchan=send:all()", "Lock(s) applied. Current locks on testchan:", receiver=self.account)
 
     def test_cdesc(self):
-        self.call(comms.CmdCdesc(), "testchan = Test Channel", "Description of channel 'testchan' set to 'Test Channel'.", receiver=self.account)
+        self.call(comms.CmdCdesc(), "testchan = Test Channel",
+                  "Description of channel 'testchan' set to 'Test Channel'.", receiver=self.account)
 
     def test_cemit(self):
-        self.call(comms.CmdCemit(), "testchan = Test Message", "[testchan] Test Message|Sent to channel testchan: Test Message", receiver=self.account)
+        self.call(comms.CmdCemit(), "testchan = Test Message",
+                  "[testchan] Test Message|Sent to channel testchan: Test Message", receiver=self.account)
 
     def test_cwho(self):
         self.call(comms.CmdCWho(), "testchan", "Channel subscriptions\ntestchan:\n  TestAccount", receiver=self.account)
 
     def test_page(self):
-        self.call(comms.CmdPage(), "TestAccount2 = Test", "TestAccount2 is offline. They will see your message if they list their pages later.|You paged TestAccount2 with: 'Test'.", receiver=self.account)
+        self.call(comms.CmdPage(), "TestAccount2 = Test",
+                  "TestAccount2 is offline. They will see your message if they list their pages later."
+                  "|You paged TestAccount2 with: 'Test'.", receiver=self.account)
 
     def test_cboot(self):
         # No one else connected to boot
         self.call(comms.CmdCBoot(), "", "Usage: @cboot[/quiet] <channel> = <account> [:reason]", receiver=self.account)
 
     def test_cdestroy(self):
-        self.call(comms.CmdCdestroy(), "testchan", "[testchan] TestAccount: testchan is being destroyed. Make sure to change your aliases.|Channel 'testchan' was destroyed.", receiver=self.account)
+        self.call(comms.CmdCdestroy(), "testchan",
+                  "[testchan] TestAccount: testchan is being destroyed. Make sure to change your aliases."
+                  "|Channel 'testchan' was destroyed.", receiver=self.account)
 
 
 class TestBatchProcess(CommandTest):
     def test_batch_commands(self):
         # cannot test batchcode here, it must run inside the server process
-        self.call(batchprocess.CmdBatchCommands(), "example_batch_cmds", "Running Batchcommand processor  Automatic mode for example_batch_cmds")
+        self.call(batchprocess.CmdBatchCommands(), "example_batch_cmds",
+                  "Running Batchcommand processor  Automatic mode for example_batch_cmds")
         # we make sure to delete the button again here to stop the running reactor
         confirm = building.CmdDestroy.confirm
         building.CmdDestroy.confirm = False

--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -527,7 +527,7 @@ class SubscriptionHandler(object):
         for subscriber in make_iter(entity):
             if subscriber:
                 clsname = subscriber.__dbclass__.__name__
-                print("subscriber:", subscriber, clsname)
+                print("subscriber:", subscriber, clsname)  # DEBUG
                 # chooses the right type
                 if clsname == "ObjectDB":
                     self.obj.db_object_subscriptions.add(subscriber)

--- a/evennia/contrib/extended_room.py
+++ b/evennia/contrib/extended_room.py
@@ -367,6 +367,7 @@ class CmdExtendedDesc(default_cmds.CmdDesc):
 
     """
     aliases = ["describe", "detail"]
+    options = ()  # Inherits from default_cmds.CmdDesc, but unused here
 
     def reset_times(self, obj):
         """By deleteting the caches we force a re-load."""

--- a/evennia/contrib/extended_room.py
+++ b/evennia/contrib/extended_room.py
@@ -367,7 +367,7 @@ class CmdExtendedDesc(default_cmds.CmdDesc):
 
     """
     aliases = ["describe", "detail"]
-    options = ()  # Inherits from default_cmds.CmdDesc, but unused here
+    switch_options = ()  # Inherits from default_cmds.CmdDesc, but unused here
 
     def reset_times(self, obj):
         """By deleteting the caches we force a re-load."""


### PR DESCRIPTION
### Brief overview of PR changes/additions
#### MUX command switch abbreviations

Allowing the shortest unique  text to be used as a command switch.
#### Use an alternate delimiter
https://github.com/evennia/evennia/wiki/Coding-FAQ#add-parsing-with-the-to-delimiter

This is easy to add as an optional feature, just like switch abbreviations, so adding it to `CmdTeleport` and `CmdGet` demonstrates how they work to developers creating new commands.


### Motivation for adding to Evennia
MUX command switch abbreviations is a useful time-saver for users familiar with all the switches of a command. 

An example is typing `@tel/l Griatch` as a shortcut for the `/loc` switch.  

A side effect of this feature is that it relies on the command class knowing which options are valid, which helps organize them, but is purely optional.

The split delimiter is something that several developers have asked about.

### Other info (issues closed, discussion etc)
Although unit tests were added, to be sure, this should be user tested in develop branch.
