### PR TITLE
Add support for MUDINFO 1.1 query at login screen

### DIFF
--- a/evennia/commands/default/cmdset_unloggedin.py
+++ b/evennia/commands/default/cmdset_unloggedin.py
@@ -23,3 +23,4 @@ class UnloggedinCmdSet(CmdSet):
         self.add(unloggedin.CmdUnconnectedHelp())
         self.add(unloggedin.CmdUnconnectedEncoding())
         self.add(unloggedin.CmdUnconnectedScreenreader())
+        self.add(unloggedin.CmdUnconnectedInfo())

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -14,15 +14,16 @@ main test suite started with
 
 import re
 import types
+import datetime
 
 from django.conf import settings
 from mock import Mock, mock
 
 from evennia.commands.default.cmdset_character import CharacterCmdSet
 from evennia.utils.test_resources import EvenniaTest
-from evennia.commands.default import help, general, system, admin, account, building, batchprocess, comms
+from evennia.commands.default import help, general, system, admin, account, building, batchprocess, comms, unloggedin
 from evennia.commands.command import Command, InterruptCommand
-from evennia.utils import ansi, utils
+from evennia.utils import ansi, utils, gametime
 from evennia.server.sessionhandler import SESSIONS
 from evennia import search_object
 from evennia import DefaultObject, DefaultCharacter
@@ -433,3 +434,12 @@ class TestInterruptCommand(CommandTest):
     def test_interrupt_command(self):
         ret = self.call(CmdInterrupt(), "")
         self.assertEqual(ret, "")
+
+
+class TestUnconnectedCommand(CommandTest):
+    def test_info_command(self):
+        expected = "## BEGIN INFO 1.1\nName: %s\nUptime: %s\nConnected: %d\nVersion: Evennia %s\n## END INFO" % (
+                        settings.SERVERNAME,
+                        datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime(),
+                        SESSIONS.account_count(), utils.get_evennia_version())
+        self.call(unloggedin.CmdUnconnectedInfo(), "", expected)

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -521,18 +521,19 @@ class CmdUnconnectedScreenreader(COMMAND_DEFAULT_CLASS):
 class CmdUnconnectedInfo(COMMAND_DEFAULT_CLASS):
     """
     Provides MUDINFO output, so that Evennia games can be added to Mudconnector
-    and Mudstats.
+    and Mudstats.  Sadly, the MUDINFO specification seems to have dropped off the
+    face of the net, but it is still used by some crawlers.  This implementation
+    was created by looking at the MUDINFO implementation in MUX2, TinyMUSH, Rhost,
+    and PennMUSH.
     """
     key = "info"
     locks = "cmd:all()"
 
     def func(self):
-        self.caller.msg("## BEGIN INFO 1.1")
-        self.caller.msg("Name: %s" % settings.SERVERNAME)
-        self.caller.msg("Uptime: %s" % datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime())
-        self.caller.msg("Connected: %d" % SESSIONS.account_count())
-        self.caller.msg("Version: Evennia %s" % utils.get_evennia_version())
-        self.caller.msg("## END INFO")
+        self.caller.msg("## BEGIN INFO 1.1\nName: %s\nUptime: %s\nConnected: %d\nVersion: Evennia %s\n## END INFO" % (
+                        settings.SERVERNAME,
+                        datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime(),
+                        SESSIONS.account_count(), utils.get_evennia_version()))
 
 
 def _create_account(session, accountname, password, permissions, typeclass=None, email=None):

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -3,6 +3,7 @@ Commands that are available from the connect screen.
 """
 import re
 import time
+import datetime
 from collections import defaultdict
 from random import getrandbits
 from django.conf import settings
@@ -11,8 +12,9 @@ from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from evennia.server.models import ServerConfig
 from evennia.comms.models import ChannelDB
+from evennia.server.sessionhandler import SESSIONS
 
-from evennia.utils import create, logger, utils
+from evennia.utils import create, logger, utils, gametime
 from evennia.commands.cmdhandler import CMD_LOGINSTART
 
 COMMAND_DEFAULT_CLASS = utils.class_from_module(settings.COMMAND_DEFAULT_CLASS)
@@ -514,6 +516,23 @@ class CmdUnconnectedScreenreader(COMMAND_DEFAULT_CLASS):
         string = "Screenreader mode turned |w%s|n." % ("on" if new_setting else "off")
         self.caller.msg(string)
         self.session.sessionhandler.session_portal_sync(self.session)
+
+
+class CmdUnconnectedInfo(COMMAND_DEFAULT_CLASS):
+    """
+    Provides MUDINFO output, so that Evennia games can be added to Mudconnector
+    and Mudstats.
+    """
+    key = "info"
+    locks = "cmd:all()"
+
+    def func(self):
+        self.caller.msg("## BEGIN INFO 1.1")
+        self.caller.msg("Name: %s" % settings.SERVERNAME)
+        self.caller.msg("Uptime: %s" % datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime())
+        self.caller.msg("Connected: %d" % SESSIONS.account_count())
+        self.caller.msg("Version: Evennia %s" % utils.get_evennia_version())
+        self.caller.msg("## END INFO")
 
 
 def _create_account(session, accountname, password, permissions, typeclass=None, email=None):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added a simple 'INFO' command which outputs a handful of statistics in MUDINFO 1.1 format. 

#### Motivation for adding to Evennia
This will allow Evennia games (like Arx) to be added to mudconnector and mudstats, who insist on polling a game with MUDINFO to ensure the game is up/running/active.
