### PR TITLE
Add /contains switch to find.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2270,11 +2270,12 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
       @locate - this is a shorthand for using the /loc switch.
 
     Switches:
-      room - only look for rooms (location=None)
-      exit - only look for exits (destination!=None)
-      char - only look for characters (BASE_CHARACTER_TYPECLASS)
-      exact- only exact matches are returned.
-      loc  - display object location if exists and match has one result
+      room    - only look for rooms (location=None)
+      exit    - only look for exits (destination!=None)
+      char    - only look for characters (BASE_CHARACTER_TYPECLASS)
+      exact   - only exact matches are returned.
+      loc     - display object location if exists and match has one result
+      contains- search for names containing the string, rather than starting with.
 
     Searches the database for an object of a particular name or exact #dbref.
     Use *accountname to search for an account. The switches allows for
@@ -2358,6 +2359,10 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
             if "exact" in switches:
                 keyquery = Q(db_key__iexact=searchstring, id__gte=low, id__lte=high)
                 aliasquery = Q(db_tags__db_key__iexact=searchstring,
+                               db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
+            elif "contains" in switches:
+                keyquery = Q(db_key__icontains=searchstring, id__gte=low, id__lte=high)
+                aliasquery = Q(db_tags__db_key__icontains=searchstring,
                                db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
             else:
                 keyquery = Q(db_key__istartswith=searchstring, id__gte=low, id__lte=high)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2270,12 +2270,12 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
       @locate - this is a shorthand for using the /loc switch.
 
     Switches:
-      room    - only look for rooms (location=None)
-      exit    - only look for exits (destination!=None)
-      char    - only look for characters (BASE_CHARACTER_TYPECLASS)
-      exact   - only exact matches are returned.
-      loc     - display object location if exists and match has one result
-      contains- search for names containing the string, rather than starting with.
+      room       - only look for rooms (location=None)
+      exit       - only look for exits (destination!=None)
+      char       - only look for characters (BASE_CHARACTER_TYPECLASS)
+      exact      - only exact matches are returned.
+      loc        - display object location if exists and match has one result
+      startswith - search for names starting with the string, rather than containing
 
     Searches the database for an object of a particular name or exact #dbref.
     Use *accountname to search for an account. The switches allows for
@@ -2286,7 +2286,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
     key = "@find"
     aliases = "@search, @locate"
-    switch_options = ("room", "exit", "char", "exact", "loc", "contains")
+    switch_options = ("room", "exit", "char", "exact", "loc", "startswith")
     locks = "cmd:perm(find) or perm(Builder)"
     help_category = "Building"
 
@@ -2360,13 +2360,13 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
                 keyquery = Q(db_key__iexact=searchstring, id__gte=low, id__lte=high)
                 aliasquery = Q(db_tags__db_key__iexact=searchstring,
                                db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
-            elif "contains" in switches:
-                keyquery = Q(db_key__icontains=searchstring, id__gte=low, id__lte=high)
-                aliasquery = Q(db_tags__db_key__icontains=searchstring,
-                               db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
-            else:
+            elif "startswith" in switches:
                 keyquery = Q(db_key__istartswith=searchstring, id__gte=low, id__lte=high)
                 aliasquery = Q(db_tags__db_key__istartswith=searchstring,
+                               db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
+            else:
+                keyquery = Q(db_key__icontains=searchstring, id__gte=low, id__lte=high)
+                aliasquery = Q(db_tags__db_key__icontains=searchstring,
                                db_tags__db_tagtype__iexact="alias", id__gte=low, id__lte=high)
 
             results = ObjectDB.objects.filter(keyquery | aliasquery).distinct()

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2286,7 +2286,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
 
     key = "@find"
     aliases = "@search, @locate"
-    switch_options = ("room", "exit", "char", "exact", "loc")
+    switch_options = ("room", "exit", "char", "exact", "loc", "contains")
     locks = "cmd:perm(find) or perm(Builder)"
     help_category = "Building"
 

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -327,7 +327,7 @@ class TestBuilding(CommandTest):
         self.call(building.CmdLock(), "Obj = test:perm(Developer)", "Added lock 'test:perm(Developer)' to Obj.")
 
     def test_find(self):
-        self.call(building.CmdFind(), "Room2", "One Match")
+        self.call(building.CmdFind(), "oom2", "One Match")
         expect = "One Match(#1#7, loc):\n   " +\
                  "Char2(#7)  evennia.objects.objects.DefaultCharacter (location: Room(#1))"
         self.call(building.CmdFind(), "Char2", expect, cmdstring="locate")
@@ -337,7 +337,7 @@ class TestBuilding(CommandTest):
         self.call(building.CmdFind(), "Char2", expect, cmdstring="@locate")
         self.call(building.CmdFind(), "/l Char2", expect, cmdstring="find")  # /l switch is abbreviated form of /loc
         self.call(building.CmdFind(), "Char2", "One Match", cmdstring="@find")
-        self.call(building.CmdFind(), "/contains om2", "One Match")
+        self.call(building.CmdFind(), "/startswith Room2", "One Match")
 
     def test_script(self):
         self.call(building.CmdScript(), "Obj = scripts.Script", "Script scripts.Script successfully added")

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -337,6 +337,7 @@ class TestBuilding(CommandTest):
         self.call(building.CmdFind(), "Char2", expect, cmdstring="@locate")
         self.call(building.CmdFind(), "/l Char2", expect, cmdstring="find")  # /l switch is abbreviated form of /loc
         self.call(building.CmdFind(), "Char2", "One Match", cmdstring="@find")
+        self.call(building.CmdFind(), "/contains om2", "One Match")
 
     def test_script(self):
         self.call(building.CmdScript(), "Obj = scripts.Script", "Script scripts.Script successfully added")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added a /contains switch to the find command, to allow searching with an icontains filter rather than an istartswith.

#### Motivation for adding to Evennia
On a large game like Arx, it is _really_ hard to find objects sometimes, especially rooms, when you want to find "Hidden Room" and it's actually called "Arx - Ward of House Foobar - Smith Manor - Back Hallway - Hidden Room".  

Adding a contains switch makes it much easier to find such things, since you can merely "find/contains Hidden Room" and find the appropriate room that way.