### PR TITLE
Fix CommandTest to stop if at_pre_cmd should stop execution.

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -75,7 +75,8 @@ class CommandTest(EvenniaTest):
         returned_msg = ""
         try:
             receiver.msg = Mock()
-            cmdobj.at_pre_cmd()
+            if cmdobj.at_pre_cmd():
+                return
             cmdobj.parse()
             ret = cmdobj.func()
             if isinstance(ret, types.GeneratorType):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
So `CommandTest` currently calls all the different hooks, but if `at_pre_cmd` returns a truthy value, command execution is supposed to stop, and currently it just ignores the value. This just is a small fix to that.

#### Motivation for adding to Evennia
Let commands that use `at_pre_cmd` to stop execution pass tests when using `CommandTest`.

#### Other info (issues closed, discussion etc)
N/A
