### PR TITLE
Fix duplicate script calls

### DIFF
--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -328,7 +328,7 @@ class DefaultScript(ScriptBase):
         """
         if self.is_active and not force_restart:
             # The script is already running, but make sure we have a _task if this is after a cache flush
-            if not self.ndb._task:
+            if not self.ndb._task and self.db_interval >= 0:
                 self.ndb._task = ExtendedLoopingCall(self._step_task)
                 try:
                     start_delay, callcount = SCRIPT_FLUSH_TIMERS[self.id]

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -292,7 +292,7 @@ class DefaultScript(ScriptBase):
     def at_idmapper_flush(self):
         """If we're flushing this object, make sure the LoopingCall is gone too"""
         ret = super(DefaultScript, self).at_idmapper_flush()
-        if ret:
+        if ret and self.ndb._task:
             try:
                 from twisted.internet import reactor
                 global FLUSHING_INSTANCES


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This tries to fix duplicate script calls that can be caused when the idmapper flush is called on scripts without their `_task` being properly stopped.

#### Motivation for adding to Evennia
Avoid `at_repeat` being called more than once on a script after a cache flush.

#### Other info (issues closed, discussion etc)
Fixes #1519 