### PR TITLE
Move query/unpickling out of loop for mutelist.

### DIFF
--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -91,7 +91,8 @@ class DefaultChannel(with_metaclass(TypeclassBase, ChannelDB)):
     @property
     def wholist(self):
         subs = self.subscriptions.all()
-        listening = [ob for ob in subs if ob.is_connected and ob not in self.mutelist]
+        muted = list(self.mutelist)
+        listening = [ob for ob in subs if ob.is_connected and ob not in muted]
         if subs:
             # display listening subscribers in bold
             string = ", ".join([account.key if account not in listening else "|w%s|n" % account.key for account in subs])


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I was trying to figure out why there was so much lag in channels on peak times, and I realized that the mutelist property I created was being retrieved inside a loop. Whoops!

#### Motivation for adding to Evennia
Reduce execution time for high-traffic channels by a large amount.

#### Other info (issues closed, discussion etc)
The amount of horsepower it needed for channels during peak hours could have been a contributing factor in #1305 - hopefully it'll be reduced a bit now.