### PR TITLE
Fix TypeclassManager filtering for annotate, values, values_list methods

### DIFF
--- a/evennia/typeclasses/managers.py
+++ b/evennia/typeclasses/managers.py
@@ -619,6 +619,18 @@ class TypeclassManager(TypedObjectManager):
         """
         return super(TypeclassManager, self).filter(db_typeclass_path=self.model.path).count()
 
+    def annotate(self, *args, **kwargs):
+        """
+        Overload annotate method to first call .all() to filter on typeclass before annotating.
+        Args:
+            *args (any): Positional arguments passed along to queryset annotate method.
+            **kwargs (any): Keyword arguments passed along to queryset annotate method.
+
+        Returns:
+            Annotated queryset.
+        """
+        return super(TypeclassManager, self).filter(db_typeclass_path=self.model.path).annotate(*args, **kwargs)
+
     def _get_subclasses(self, cls):
         """
         Recursively get all subclasses to a class.

--- a/evennia/typeclasses/managers.py
+++ b/evennia/typeclasses/managers.py
@@ -621,7 +621,7 @@ class TypeclassManager(TypedObjectManager):
 
     def annotate(self, *args, **kwargs):
         """
-        Overload annotate method to first call .all() to filter on typeclass before annotating.
+        Overload annotate method to filter on typeclass before annotating.
         Args:
             *args (any): Positional arguments passed along to queryset annotate method.
             **kwargs (any): Keyword arguments passed along to queryset annotate method.
@@ -630,6 +630,30 @@ class TypeclassManager(TypedObjectManager):
             Annotated queryset.
         """
         return super(TypeclassManager, self).filter(db_typeclass_path=self.model.path).annotate(*args, **kwargs)
+
+    def values(self, *args, **kwargs):
+        """
+        Overload values method to filter on typeclass first.
+        Args:
+            *args (any): Positional arguments passed along to values method.
+            **kwargs (any): Keyword arguments passed along to values method.
+
+        Returns:
+            Queryset of values dictionaries, just filtered by typeclass first.
+        """
+        return super(TypeclassManager, self).filter(db_typeclass_path=self.model.path).values(*args, **kwargs)
+
+    def values_list(self, *args, **kwargs):
+        """
+        Overload values method to filter on typeclass first.
+        Args:
+            *args (any): Positional arguments passed along to values_list method.
+            **kwargs (any): Keyword arguments passed along to values_list method.
+
+        Returns:
+            Queryset of value_list tuples, just filtered by typeclass first.
+        """
+        return super(TypeclassManager, self).filter(db_typeclass_path=self.model.path).values_list(*args, **kwargs)
 
     def _get_subclasses(self, cls):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
It dawned on me that annotate wasn't defined as a manager method to add the appropriate `db_typeclass_path` filtering, so I went ahead and added that.

Edit: Also added values and values_list, for the same reason.

#### Motivation for adding to Evennia
To allow `TypeclassManager.objects` methods `.annotate`, `.values`, and `.values_list` to filter by the corresponding typeclass path automatically, as expected.

#### Other info (issues closed, discussion etc)
I'll need to edit the [object search tutorial](https://github.com/evennia/evennia/wiki/Tutorial:-Searching-For-Objects) to fix that bit about annotations not playing well with typeclass paths. Whoops.