### PR TITLE
Add procps dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@
 #   install `docker` (http://docker.com)
 #
 # Usage:
-#    cd to a folder where you want your game data to be (or where it already is). 
+#    cd to a folder where you want your game data to be (or where it already is).
 #
 #	docker run -it -p 4000:4000 -p 4001:4001 -p 4005:4005 -v $PWD:/usr/src/game evennia/evennia
-#    
-#    (If your OS does not support $PWD, replace it with the full path to your current 
+#
+#    (If your OS does not support $PWD, replace it with the full path to your current
 #    folder).
 #
 #    You will end up in a shell where the `evennia` command is available. From here you
@@ -24,7 +24,8 @@ FROM alpine
 MAINTAINER www.evennia.com
 
 # install compilation environment
-RUN apk update && apk add python py-pip python-dev py-setuptools gcc musl-dev jpeg-dev zlib-dev bash
+RUN apk update && apk add python py-pip python-dev py-setuptools gcc \
+musl-dev jpeg-dev zlib-dev bash procps
 
 # add the project source
 ADD . /usr/src/evennia
@@ -33,7 +34,7 @@ ADD . /usr/src/evennia
 RUN pip install -e /usr/src/evennia --trusted-host pypi.python.org
 
 # add the game source when rebuilding a new docker image from inside
-# a game dir 
+# a game dir
 ONBUILD ADD . /usr/src/game
 
 # make the game source hierarchy persistent with a named volume.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds `procps` to the Dockerfile as a dependency.

#### Motivation for adding to Evennia
Certain evennia commands, such as the `@server` command, rely upon `ps` to run correctly. Unfortunately, alpine uses the BusyBox `ps`, which is somewhat idiosyncratic in its option handling. Adding the `procps` dependency installs a more standard `ps`, allowing server maintenance commands to work correctly. 

For further background, see gliderlabs/docker-alpine#173.

#### Other info (issues closed, discussion etc)

This fixes #1635.