### PR TITLE
Change callability check

### DIFF
--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -296,9 +296,9 @@ class CmdSet(with_metaclass(_CmdSetMeta, object)):
             result (any): An instantiated Command or the input unmodified.
 
         """
-        try:
+        if callable(cmd):
             return cmd()
-        except TypeError:
+        else:
             return cmd
 
     def _duplicate(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes an `except TypeError ` to a `callable()` check in the `_instantiate()` function of `cmdset.py`.

#### Motivation for adding to Evening
`TypeError`s can be thrown for many different reasons; expecting them to always come from calling an uncallable object should be considered a bug. Python has a built-in function, `callable()`, to test whether an object can be invoked. If a class's `__init__` method unexpectedly throws a `TypeError`, an extremely cryptic exception about unbound methods is raised from `cmdparser.py`, which is, to say the least, counterintuitive. 