### PR TITLE
Change Dockerfile to comply with best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,22 +21,30 @@
 #
 FROM alpine
 
-MAINTAINER www.evennia.com
+LABEL maintainer="www.evennia.com"
 
 # install compilation environment
-RUN apk update && apk add python py-pip python-dev py-setuptools gcc \
-musl-dev jpeg-dev zlib-dev bash py2-openssl procps
+RUN apk update && apk add bash gcc jpeg-dev musl-dev procps py-pip \
+py-setuptools py2-openssl python python-dev zlib-dev
 
-# add the project source
-ADD . /usr/src/evennia
+# add the files required for pip installation
+COPY ./setup.py /usr/src/evennia/
+COPY ./requirements.txt /usr/src/evennia/
+COPY ./evennia/VERSION.txt /usr/src/evennia/evennia/
+COPY ./bin /usr/src/evennia/bin/
 
 # install dependencies
 RUN pip install -e /usr/src/evennia --trusted-host pypi.python.org
 RUN pip install cryptography pyasn1 service_identity
 
+# add the project source; this should always be done after all
+# expensive operations have completed to avoid prematurely
+# invalidating the build cache.
+COPY . /usr/src/evennia
+
 # add the game source when rebuilding a new docker image from inside
 # a game dir
-ONBUILD ADD . /usr/src/game
+ONBUILD COPY . /usr/src/game
 
 # make the game source hierarchy persistent with a named volume.
 # mount on-disk game location here when using the container


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In order of decreasing significance:
* Move addition of all files later to avoid premature build cache invalidation
* Add separate instructions to copy over files needed earlier
* Change deprecated MAINTAINER instruction to LABEL maintainer
* Change ADD to COPY, as ADD apparently behaves weirdly in some cases
* Alphabetize dependencies for readability

#### Motivation for adding to Evening
Most of these are just stylistically nice, and therefore not particularly necessary, even if they do increase readability. However, the build cache change is significant, because it vastly reduces  (according to my limited testing, by more than 80%) docker build times in the common case of changes to code only.

The only other change to be somewhat significant is the change of `MAINTAINER` to ` LABEL maintainer`, as the former is deprecated and will probably be removed sooner or later. The other changes may be seen as solely stylistic, along the lines of PEP 8 compliance.

#### Other info (issues closed, discussion etc)

See also: [Best practices for writing Dockerfiles][1]

[1]: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/