### PR TITLE
EvForm tracebacks with dissimilar line length

### DIFF
--- a/evennia/utils/evform.py
+++ b/evennia/utils/evform.py
@@ -161,21 +161,12 @@ def _to_rect(lines):
         lines (list): list of `ANSIString`s
 
     Returns:
-        nlines (list): list of `ANSIString`s of
+        (list): list of `ANSIString`s of
         same length as the longest input line
 
     """
-    maxl = 0
-    for line in lines:
-        if isinstance(line, (ANSIString, basestring)):
-            maxl = max(len(line), maxl)
-        else:
-            raise ValueError()
-    nlines = []
-    for line in lines:
-        line += ' ' * (maxl - len(line))
-        nlines.append(line)
-    return nlines
+    maxl = max(len(line) for line in lines)
+    return [line + ' ' * (maxl - len(line)) for line in lines]
 
 
 def _to_ansi(obj, regexable=False):

--- a/evennia/utils/evform.py
+++ b/evennia/utils/evform.py
@@ -153,6 +153,31 @@ INVALID_FORMCHARS = r"\s\/\|\\\*\_\-\#\<\>\~\^\:\;\.\,"
 _ANSI_ESCAPE = re.compile(r"\|\|")
 
 
+def _to_rect(lines):
+    """
+    Forces all lines to be as long as the longest
+
+    Args:
+        lines (list): list of `ANSIString`s
+
+    Returns:
+        nlines (list): list of `ANSIString`s of
+        same length as the longest input line
+
+    """
+    maxl = 0
+    for line in lines:
+        if isinstance(line, (ANSIString, basestring)):
+            maxl = max(len(line), maxl)
+        else:
+            raise ValueError()
+    nlines = []
+    for line in lines:
+        line += ' ' * (maxl - len(line))
+        nlines.append(line)
+    return nlines
+
+
 def _to_ansi(obj, regexable=False):
     "convert to ANSIString"
     if isinstance(obj, basestring):
@@ -184,7 +209,7 @@ class EvForm(object):
             filename (str): Path to template file.
             cells (dict): A dictionary mapping of {id:text}
             tables (dict): A dictionary mapping of {id:EvTable}.
-            form (dict): A dictionary of {"CELLCHAR":char,
+            form (dict): A dictionary of {"FORMCHAR":char,
                                           "TABLECHAR":char,
                                           "FORM":templatestring}
                     if this is given, filename is not read.
@@ -408,7 +433,9 @@ class EvForm(object):
         self.tablechar = tablechar[0] if len(tablechar) > 1 else tablechar
 
         # split into a list of list of lines. Form can be indexed with form[iy][ix]
-        self.raw_form = _to_ansi(to_unicode(datadict.get("FORM", "")).split("\n"))
+        raw_form = _to_ansi(to_unicode(datadict.get("FORM", "")).split("\n"))
+        self.raw_form = _to_rect(raw_form)
+
         # strip first line
         self.raw_form = self.raw_form[1:] if self.raw_form else self.raw_form
 
@@ -440,7 +467,8 @@ def _test():
                     6: 5,
                     7: 18,
                     8: 10,
-                    9: 3})
+                    9: 3,
+                    "F": "rev 1"})
     # create the EvTables
     tableA = EvTable("HP", "MV", "MP",
                      table=[["**"], ["*****"], ["***"]],

--- a/evennia/utils/tests/data/evform_example.py
+++ b/evennia/utils/tests/data/evform_example.py
@@ -6,6 +6,7 @@ Test form
 FORMCHAR = "x"
 TABLECHAR = "c"
 
+
 FORM = """
 .------------------------------------------------.
 |                                                |
@@ -27,4 +28,6 @@ FORM = """
 | ccccccccc | ccccccccccccccccBccccccccccccccccc |
 |           |                                    |
  -----------`-------------------------------------
+ Footer: xxxFxxx
+ info
 """

--- a/evennia/utils/tests/test_evform.py
+++ b/evennia/utils/tests/test_evform.py
@@ -19,7 +19,7 @@ class TestEvForm(TestCase):
                          u'|\n'
                          u'|        \x1b[0m\x1b[1m\x1b[32mBouncer\x1b[0m    \x1b[0m                             |\n'
                          u'|                                                |\n'
-                         u' >----------------------------------------------<\n'
+                         u' >----------------------------------------------< \n'
                          u'|                                                |\n'
                          u'| Desc:  \x1b[0mA sturdy \x1b[0m  \x1b[0m'
                          u'    STR: \x1b[0m12 \x1b[0m\x1b[0m\x1b[0m\x1b[0m'
@@ -31,7 +31,7 @@ class TestEvForm(TestCase):
                          u'    LUC: \x1b[0m10 \x1b[0m\x1b[0m\x1b[0m'
                          u'    MAG: \x1b[0m3  \x1b[0m\x1b[0m\x1b[0m     |\n'
                          u'|                                                |\n'
-                         u' >----------.-----------------------------------<\n'
+                         u' >----------.-----------------------------------< \n'
                          u'|           |                                    |\n'
                          u'| \x1b[0mHP\x1b[0m|\x1b[0mMV \x1b[0m|\x1b[0mMP\x1b[0m '
                          u'| \x1b[0mSkill      \x1b[0m|\x1b[0mValue     \x1b[0m'
@@ -47,7 +47,10 @@ class TestEvForm(TestCase):
                          u'| \x1b[0mSmithing   \x1b[0m|\x1b[0m9         \x1b[0m'
                          u'|\x1b[0m205/900    \x1b[0m\x1b[0m\x1b[0m\x1b[0m\x1b[0m\x1b[0m\x1b[0m |\n'
                          u'|           |                                    |\n'
-                         u' -----------`-------------------------------------\n')
+                         u' -----------`-------------------------------------\n'
+                         u' Footer: \x1b[0mrev 1  \x1b[0m                                  \n'
+                         u' info                                             \n'
+                         u'                                                  ')
 
     def test_ansi_escape(self):
         # note that in a msg() call, the result would be the  correct |-----,


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Force evform.raw_form to have all lines of the same length - effectively a rectangle

#### Other info (issues closed, discussion etc)

See #1459

- [x] bug fixed
- [x] documentation updated 