### PR TITLE
Adds trailing slash to authenticate endpoint in urls.py to correct we…

### DIFF
--- a/evennia/web/website/urls.py
+++ b/evennia/web/website/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     url(r'^tbi/', website_views.to_be_implemented, name='to_be_implemented'),
 
     # User Authentication (makes login/logout url names available)
-    url(r'^authenticate', include('django.contrib.auth.urls')),
+    url(r'^authenticate/', include('django.contrib.auth.urls')),
 
     # Django original admin page. Make this URL is always available, whether
     # we've chosen to use Evennia's custom admin or not.


### PR DESCRIPTION
…ird '/authenticatelogin' path.

#### Brief overview of PR changes/additions
Evennia has always had a confusing typoed path for login authentication at /authenticatelogin. This PR corrects this to the proper /authenticate/login path that is more consistent with most Django projects.

#### Motivation for adding to Evennia
Spelling counts!

#### Other info (issues closed, discussion etc)
Supercedes #1652; my branches were tangled.