### PR TITLE
Force evennia.set_trace() to go to the upper frame

### DIFF
--- a/evennia/__init__.py
+++ b/evennia/__init__.py
@@ -365,7 +365,9 @@ def set_trace(debugger="auto", term_size=(140, 40)):
         import pdb
         dbg = pdb.Pdb(stdout=sys.__stdout__)
 
+    # Force the debugger to go up one frame
+    # (Otherwise, `set_trace` will be placed on this function, not the call)
     #
     # stopped at breakpoint. Use 'n' (next) to continue into the code.
     #
-    dbg.set_trace()
+    dbg.set_trace(sys._getframe().f_back)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When a user uses `evennia.set_trace`, it places a breakpoint in the `evennia.set_trace` function.  This PR allows to place the initial breakpoint where the `evennia.set_trace` function was called.

Note: it works fine with `pdb`, but I was unable to test with `pudb`, though the signature seems fine.