### PR TITLE
Implements password validation via Django

### DIFF
--- a/evennia/contrib/security/validators.py
+++ b/evennia/contrib/security/validators.py
@@ -1,0 +1,51 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+import re
+
+class EvenniaPasswordValidator:
+    
+    def __init__(self, regex=r"^[\w. @+\-',]+$", policy="Password should contain a mix of letters, spaces, digits and @/./+/-/_/'/, only."):
+        """
+        Constructs a standard Django password validator.
+    
+        Args:
+            regex (str): Regex pattern of valid characters to allow.
+            policy (str): Brief explanation of what the defined regex permits.
+    
+        """
+        self.regex = regex
+        self.policy = policy
+    
+    def validate(self, password, user=None):
+        """
+        Validates a password string to make sure it meets predefined Evennia
+        acceptable character policy.
+    
+        Args:
+            password (str): Password to validate
+            user (None): Unused argument but required by Django
+            
+        Returns:
+            None (None): None if password successfully validated,
+                raises ValidationError otherwise.
+    
+        """
+        # Check complexity
+        if not re.findall(self.regex, password):
+            raise ValidationError(
+                _(self.policy),
+                code='evennia_password_policy',
+            )
+
+    def get_help_text(self):
+        """
+        Returns a user-facing explanation of the password policy defined
+        by this validator.
+    
+        Returns:
+            text (str): Explanation of password policy.
+    
+        """
+        return _(
+            "%s From a terminal client, you can also use a phrase of multiple words if you enclose the password in double quotes." % self.policy
+        )

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -802,6 +802,29 @@ INSTALLED_APPS = (
 # This should usually not be changed.
 AUTH_USER_MODEL = "accounts.AccountDB"
 
+# Password validation
+# https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 8,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+    {
+        'NAME': 'evennia.contrib.security.validators.EvenniaPasswordValidator',
+    },
+]
+
 # Use a custom test runner that just tests Evennia-specific apps.
 TEST_RUNNER = 'evennia.server.tests.EvenniaTestSuiteRunner'
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Evennia's current password validation functionality is copied and pasted across many Command objects and given the contextual impositions of Commands, are completely unavailable from the web server. This leads to unsafe and hard-coded policies such a default minimum password length of 4 characters and allowing public-known compromised passwords to be used.

This PR enables the 4 default validators that would otherwise be enabled by default in any new Django 1.9+ project, sets the default minimum password length to a more sane 8 (can be reverted in settings.py/server.conf per Django conventions) and adds a 5th validator based on the character set Evennia currently allows. 

It does not attempt to integrate with or modify any of the default commands or impact users' existing passwords, but any stock Django forms (including the Admin interface) will enforce these policies on new passwords.

#### Motivation for adding to Evennia
Adherence to DRY principles and more consistent application of password policy going forward.