### PR TITLE
Improved Throttle

### DIFF
--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -4,13 +4,14 @@ Commands that are available from the connect screen.
 import re
 import time
 import datetime
-from collections import defaultdict
+from collections import defaultdict, deque
 from random import getrandbits
 from django.conf import settings
 from django.contrib.auth import authenticate
 from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from evennia.server.models import ServerConfig
+from evennia.server.throttle import Throttle
 from evennia.comms.models import ChannelDB
 from evennia.server.sessionhandler import SESSIONS
 
@@ -26,58 +27,11 @@ __all__ = ("CmdUnconnectedConnect", "CmdUnconnectedCreate",
 MULTISESSION_MODE = settings.MULTISESSION_MODE
 CONNECTION_SCREEN_MODULE = settings.CONNECTION_SCREEN_MODULE
 
-# Helper function to throttle failed connection attempts.
-# This can easily be used to limit account creation too,
-# (just supply a different storage dictionary), but this
-# would also block dummyrunner, so it's not added as default.
+# Create an object to store account creation attempts per IP
+CREATION_THROTTLE = Throttle(limit=2, timeout=10 * 60)
 
-_LATEST_FAILED_LOGINS = defaultdict(list)
-
-
-def _throttle(session, maxlim=None, timeout=None, storage=_LATEST_FAILED_LOGINS):
-    """
-    This will check the session's address against the
-    _LATEST_LOGINS dictionary to check they haven't
-    spammed too many fails recently.
-
-    Args:
-        session (Session): Session failing
-        maxlim (int): max number of attempts to allow
-        timeout (int): number of timeout seconds after
-            max number of tries has been reached.
-
-    Returns:
-        throttles (bool): True if throttling is active,
-            False otherwise.
-
-    Notes:
-        If maxlim and/or timeout are set, the function will
-        just do the comparison, not append a new datapoint.
-
-    """
-    address = session.address
-    if isinstance(address, tuple):
-        address = address[0]
-    now = time.time()
-    if maxlim and timeout:
-        # checking mode
-        latest_fails = storage[address]
-        if latest_fails and len(latest_fails) >= maxlim:
-            # too many fails recently
-            if now - latest_fails[-1] < timeout:
-                # too soon - timeout in play
-                return True
-            else:
-                # timeout has passed. Reset faillist
-                storage[address] = []
-                return False
-        else:
-            return False
-    else:
-        # store the time of the latest fail
-        storage[address].append(time.time())
-        return False
-
+# Create an object to store failed login attempts per IP
+LOGIN_THROTTLE = Throttle(limit=5, timeout=5 * 60)
 
 def create_guest_account(session):
     """
@@ -134,7 +88,7 @@ def create_guest_account(session):
         session.msg("An error occurred. Please e-mail an admin if the problem persists.")
         logger.log_trace()
         raise
-
+    
 
 def create_normal_account(session, name, password):
     """
@@ -149,8 +103,11 @@ def create_normal_account(session, name, password):
         account (Account): the account which was created from the name and password.
     """
     # check for too many login errors too quick.
-    if _throttle(session, maxlim=5, timeout=5 * 60):
-        # timeout is 5 minutes.
+    address = session.address
+    if isinstance(address, tuple):
+        address = address[0]
+        
+    if LOGIN_THROTTLE.check(address):
         session.msg("|RYou made too many connection attempts. Try again in a few minutes.|n")
         return None
 
@@ -161,7 +118,7 @@ def create_normal_account(session, name, password):
         # No accountname or password match
         session.msg("Incorrect login information given.")
         # this just updates the throttle
-        _throttle(session)
+        LOGIN_THROTTLE.update(address)
         # calls account hook for a failed login if possible.
         account = AccountDB.objects.get_account_from_name(name)
         if account:
@@ -171,7 +128,6 @@ def create_normal_account(session, name, password):
     # Check IP and/or name bans
     bans = ServerConfig.objects.conf("server_bans")
     if bans and (any(tup[0] == account.name.lower() for tup in bans) or
-
                  any(tup[2].match(session.address) for tup in bans if tup[2])):
         # this is a banned IP or name!
         string = "|rYou have been banned and cannot continue from here." \
@@ -181,7 +137,6 @@ def create_normal_account(session, name, password):
         return None
 
     return account
-
 
 class CmdUnconnectedConnect(COMMAND_DEFAULT_CLASS):
     """
@@ -211,7 +166,10 @@ class CmdUnconnectedConnect(COMMAND_DEFAULT_CLASS):
         session = self.caller
 
         # check for too many login errors too quick.
-        if _throttle(session, maxlim=5, timeout=5 * 60, storage=_LATEST_FAILED_LOGINS):
+        address = session.address
+        if isinstance(address, tuple):
+            address = address[0]
+        if CONNECTION_THROTTLE.check(address):
             # timeout is 5 minutes.
             session.msg("|RYou made too many connection attempts. Try again in a few minutes.|n")
             return
@@ -234,6 +192,7 @@ class CmdUnconnectedConnect(COMMAND_DEFAULT_CLASS):
             session.msg("\n\r Usage (without <>): connect <name> <password>")
             return
 
+        CONNECTION_THROTTLE.update(address)
         name, password = parts
         account = create_normal_account(session, name, password)
         if account:
@@ -262,6 +221,15 @@ class CmdUnconnectedCreate(COMMAND_DEFAULT_CLASS):
 
         session = self.caller
         args = self.args.strip()
+        
+        # Rate-limit account creation.
+        address = session.address
+        
+        if isinstance(address, tuple):
+            address = address[0]
+        if CREATION_THROTTLE.check(address):
+            session.msg("|RYou are creating too many accounts. Try again in a few minutes.|n")
+            return
 
         # extract double quoted parts
         parts = [part.strip() for part in re.split(r"\"", args) if part.strip()]
@@ -322,6 +290,10 @@ class CmdUnconnectedCreate(COMMAND_DEFAULT_CLASS):
                 if MULTISESSION_MODE < 2:
                     default_home = ObjectDB.objects.get_id(settings.DEFAULT_HOME)
                     _create_character(session, new_account, typeclass, default_home, permissions)
+                
+                # Update the throttle to indicate a new account was created from this IP    
+                CREATION_THROTTLE.update(address)
+                
                 # tell the caller everything went well.
                 string = "A new account '%s' was created. Welcome!"
                 if " " in accountname:

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -4,7 +4,6 @@ Commands that are available from the connect screen.
 import re
 import time
 import datetime
-from collections import defaultdict, deque
 from random import getrandbits
 from django.conf import settings
 from django.contrib.auth import authenticate

--- a/evennia/server/throttle.py
+++ b/evennia/server/throttle.py
@@ -1,0 +1,98 @@
+from collections import defaultdict, deque
+import time
+
+_LATEST_FAILURES = defaultdict(deque)
+
+class Throttle(object):
+    """
+    Keeps a running count of failed actions per IP address. 
+    
+    Available methods indicate whether or not the number of failures exceeds a
+    particular threshold.
+    
+    This version of the throttle is usable by both the terminal server as well
+    as the web server, imposes limits on memory consumption by using deques
+    with length limits instead of open-ended lists, and removes sparse keys when
+    no recent failures have been recorded.
+    """
+    
+    error_msg = 'Too many failed attempts; you must wait a few minutes before trying again.'
+    cache_size = 20
+    
+    @classmethod
+    def get(cls, ip=None, storage=_LATEST_FAILURES):
+        """
+        Convenience function that appends a new event to the table.
+    
+        Args:
+            ip (str, optional): IP address of requestor
+    
+        Returns:
+            storage (dict): When no IP is provided, returns a dict of all 
+                current IPs being tracked and the timestamps of their recent 
+                failures.
+            timestamps (deque): When an IP is provided, returns a deque of 
+                timestamps of recent failures only for that IP.
+    
+        """
+        if ip: return storage.get(ip, deque(maxlen=cls.cache_size))
+        return storage
+    
+    @classmethod
+    def update(cls, ip):
+        """
+        Convenience function that appends a new event to the table.
+    
+        Args:
+            ip (str): IP address of requestor
+    
+        Returns:
+            throttled (False): Always returns False
+    
+        """
+        return cls.check(ip)
+    
+    @classmethod
+    def check(cls, ip, maxlim=None, timeout=None, storage=_LATEST_FAILURES):
+        """
+        This will check the session's address against the
+        _LATEST_FAILURES dictionary to check they haven't
+        spammed too many fails recently.
+    
+        Args:
+            ip (str): IP address of requestor
+            maxlim (int): max number of attempts to allow
+            timeout (int): number of timeout seconds after
+                max number of tries has been reached.
+    
+        Returns:
+            throttled (bool): True if throttling is active,
+                False otherwise.
+    
+        Notes:
+            If maxlim and/or timeout are set, the function will
+            just do the comparison, not append a new datapoint.
+        """
+        now = time.time()
+        ip = str(ip)
+        if maxlim and timeout:
+            # checking mode
+            latest_fails = storage[ip]
+            if latest_fails and len(latest_fails) >= maxlim:
+                # too many fails recently
+                if now - latest_fails[-1] < timeout:
+                    # too soon - timeout in play
+                    return True
+                else:
+                    # timeout has passed. clear faillist
+                    del(storage[ip])
+                    return False
+            else:
+                return False
+        else:
+            # store the time of the latest fail
+            if ip not in storage or not storage[ip].maxlen:
+                storage[ip] = deque(maxlen=cls.cache_size)
+                
+            storage[ip].append(time.time())
+            return False


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Reimplements the existing _throttle function as a standalone class and removes the Session requirement so that it may be used to restrict traffic on both the webserver and the terminal server.

#### Motivation for adding to Evennia
The existing throttle is a nifty feature with a lot of potential but limited in what it can be used for due to the fact that it is a private function buried in an obscure module (evennia/commands/default/unloggedin.py) and requires a Session object.

The current implementation also stores empty lists on keys instead of purging them once timeouts have elapsed, and there are no constraints (beyond network bandwidth) on the growth of member lists. This PR drops sparse keys upon detection and uses deques to limit the number of timestamps recorded per IP.