### PR TITLE
Adds a logger for security-related events.

### DIFF
--- a/evennia/utils/logger.py
+++ b/evennia/utils/logger.py
@@ -254,6 +254,23 @@ def log_dep(depmsg):
 
 log_depmsg = log_dep
 
+def log_sec(secmsg):
+    """
+    Prints a security-related message.
+
+    Args:
+        secmsg (str): The security message to log.
+    """
+    try:
+        secmsg = str(secmsg)
+    except Exception as e:
+        secmsg = str(e)
+    for line in secmsg.splitlines():
+        log_msg('[SS] %s' % line)
+
+
+log_secmsg = log_sec
+
 
 # Arbitrary file logger
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a logger to the existing collection that classifies log entries as security events (prefix "[SS]").

#### Motivation for adding to Evennia
#1383 and others have highlighted the need for better logging of security-related events, but we do not currently have a commonly accepted destination to send them to. This PR aims to define one.