### PR TITLE
Fix #1668 - up arrow key regression

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/history.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/history.js
@@ -44,14 +44,6 @@ let history_plugin = (function () {
     }
 
     //
-    // Go to the last history line
-    var end = function () {
-        // move to the end of the history stack
-        history_pos = 0;
-        return history[history.length -1];
-    }
-
-    //
     // Add input to the scratch line
     var scratch = function (input) {
         // Put the input into the last history entry (which is normally empty)
@@ -69,27 +61,16 @@ let history_plugin = (function () {
         var history_entry = null;
         var inputfield = $("#inputfield");
 
-        if (inputfield[0].selectionStart == inputfield.val().length) {
-            // Only process up/down arrow if cursor is at the end of the line.
-            if (code === 38) { // Arrow up
-                history_entry = back();
-            }
-            else if (code === 40) { // Arrow down
-                history_entry = fwd();
-            }
+        if (code === 38) { // Arrow up
+            history_entry = back();
+        }
+        else if (code === 40) { // Arrow down
+            history_entry = fwd();
         }
 
         if (history_entry !== null) {
             // Doing a history navigation; replace the text in the input.
             inputfield.val(history_entry);
-        }
-        else {
-            // Save the current contents of the input to the history scratch area.
-            setTimeout(function () {
-                // Need to wait until after the key-up to capture the value.
-                scratch(inputfield.val());
-                end();
-            }, 0);
         }
 
         return false;
@@ -99,6 +80,7 @@ let history_plugin = (function () {
     // Listen for onSend lines to add to history
     var onSend = function (line) {
         add(line);
+        return null; // we are not returning an altered input line
     }
 
     //


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This restores the ability to cycle back through the last 21 input lines using the up/down arrow keys.

#### Motivation for adding to Evennia

The old implementation of tracking the current typing (character-by-character into a temp buffer by firing a timer and then resetting the history count to zero and then only listening for up/down arrow events when the cursor position is at the end of the input line) conflicts with the new plugin onKeydown and onSend approach.

#### Other info (issues closed, discussion etc)
Bug fix for #1668

This is not the only way to fix this, but this is the simplest code.  If the scratch area handling is a must-have, then I would suggest having the fwd() and back() functions store/restore the current inputfield value to/from the scratch area. 
