### PR TITLE
Fixes incorrect LOGIN_URL and LOGOUT_URL values

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -13,6 +13,7 @@ always be sure of what you have changed and what is default behaviour.
 
 """
 from builtins import range
+from django.urls import reverse_lazy
 
 import os
 import sys
@@ -697,9 +698,9 @@ ROOT_URLCONF = 'web.urls'
 # Where users are redirected after logging in via contrib.auth.login.
 LOGIN_REDIRECT_URL = '/'
 # Where to redirect users when using the @login_required decorator.
-LOGIN_URL = '/accounts/login'
+LOGIN_URL = reverse_lazy('login')
 # Where to redirect users who wish to logout.
-LOGOUT_URL = '/accounts/login'
+LOGOUT_URL = reverse_lazy('logout')
 # URL that handles the media served from MEDIA_ROOT.
 # Example: "http://media.lawrence.com"
 MEDIA_URL = '/media/'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Modifies settings_default to lazily reverse the named URLs for login and logout endpoints (instead of using hardcoded values).

#### Motivation for adding to Evennia
Settings has `/accounts/login` and `/accounts/logout` set for login and logout (stock Django values), but there are no endpoints by either name in Evennia-- here the authentication endpoints are located as subpaths of `/authenticate/`.

Usage of Django LoginRequired view controls will yield 404 errors when the user is redirected to a login endpoint that does not exist.

https://github.com/evennia/evennia/blob/8c0dca25002378156d5748ee0b5c1d7d53d58885/evennia/web/website/urls.py#L16