### PR TITLE
Object URL references, named paths and pseudo-slugs

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -14,7 +14,9 @@ instead for most things).
 import time
 from django.conf import settings
 from django.contrib.auth import password_validation
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.urls import reverse_lazy
 from django.utils import timezone
 from evennia.typeclasses.models import TypeclassBase
 from evennia.accounts.manager import AccountManager
@@ -189,6 +191,25 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
     @lazy_property
     def sessions(self):
         return AccountSessionHandler(self)
+        
+    def get_absolute_url(self):
+        """
+        Returns the canonical URL for an Account. 
+        
+        To callers, this method should appear to return a string that can be 
+        used to refer to the object over HTTP.
+        
+        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
+        """
+        try: return reverse_lazy('account-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def get_admin_url(self):
+        """
+        Returns a link to this object's entry within the Django Admin panel.
+        """
+        content_type = ContentType.objects.get_for_model(self.__class__)
+        return reverse_lazy("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
 
     # session-related methods
 

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -14,9 +14,7 @@ instead for most things).
 import time
 from django.conf import settings
 from django.contrib.auth import password_validation
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.urls import reverse
 from django.utils import timezone
 from evennia.typeclasses.models import TypeclassBase
 from evennia.accounts.manager import AccountManager
@@ -191,41 +189,6 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
     @lazy_property
     def sessions(self):
         return AccountSessionHandler(self)
-        
-    def get_absolute_url(self):
-        """
-        Returns the canonical URL for an Account. 
-        
-        To callers, this method should appear to return a string that can be 
-        used to refer to the object over HTTP.
-        
-        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
-        """
-        try: return reverse('account-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_delete_url(self):
-        """
-        Returns the canonical URL to the page that allows deleting an object. 
-        
-        """
-        try: return reverse('account-delete', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_update_url(self):
-        """
-        Returns the canonical URL to the page that allows updating an object. 
-        
-        """
-        try: return reverse('account-update', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_admin_url(self):
-        """
-        Returns a link to this object's entry within the Django Admin panel.
-        """
-        content_type = ContentType.objects.get_for_model(self.__class__)
-        return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
 
     # session-related methods
 

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -204,6 +204,22 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
         try: return reverse_lazy('account-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
         except: return '#'
         
+    def get_delete_url(self):
+        """
+        Returns the canonical URL to the page that allows deleting an object. 
+        
+        """
+        try: return reverse('account-delete', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def get_update_url(self):
+        """
+        Returns the canonical URL to the page that allows updating an object. 
+        
+        """
+        try: return reverse('account-update', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
     def get_admin_url(self):
         """
         Returns a link to this object's entry within the Django Admin panel.

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.contrib.auth import password_validation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.urls import reverse_lazy
+from django.urls import reverse
 from django.utils import timezone
 from evennia.typeclasses.models import TypeclassBase
 from evennia.accounts.manager import AccountManager
@@ -201,7 +201,7 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
         
         https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
         """
-        try: return reverse_lazy('account-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        try: return reverse('account-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
         except: return '#'
         
     def get_delete_url(self):
@@ -225,7 +225,7 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
         Returns a link to this object's entry within the Django Admin panel.
         """
         content_type = ContentType.objects.get_for_model(self.__class__)
-        return reverse_lazy("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
+        return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
 
     # session-related methods
 

--- a/evennia/accounts/tests.py
+++ b/evennia/accounts/tests.py
@@ -64,14 +64,14 @@ class TestDefaultAccount(TestCase):
         "Get URL for account detail page on website"
         self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
                 email="test@test.com", password="testpassword", typeclass=DefaultAccount)
-        self.assertTrue(self.account.get_absolute_url())
+        self.assertTrue(self.account.web_detail_url())
         
     def test_admin_url(self):
         "Get object's URL for access via Admin pane"
         self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
                 email="test@test.com", password="testpassword", typeclass=DefaultAccount)
-        self.assertTrue(self.account.get_admin_url())
-        self.assertTrue(self.account.get_admin_url() != '#')
+        self.assertTrue(self.account.web_admin_url())
+        self.assertTrue(self.account.web_admin_url() != '#')
 
     def test_password_validation(self):
         "Check password validators deny bad passwords"

--- a/evennia/accounts/tests.py
+++ b/evennia/accounts/tests.py
@@ -64,14 +64,14 @@ class TestDefaultAccount(TestCase):
         "Get URL for account detail page on website"
         self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
                 email="test@test.com", password="testpassword", typeclass=DefaultAccount)
-        self.assertTrue(self.account.web_detail_url())
+        self.assertTrue(self.account.web_get_detail_url())
         
     def test_admin_url(self):
         "Get object's URL for access via Admin pane"
         self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
                 email="test@test.com", password="testpassword", typeclass=DefaultAccount)
-        self.assertTrue(self.account.web_admin_url())
-        self.assertTrue(self.account.web_admin_url() != '#')
+        self.assertTrue(self.account.web_get_admin_url())
+        self.assertTrue(self.account.web_get_admin_url() != '#')
 
     def test_password_validation(self):
         "Check password validators deny bad passwords"

--- a/evennia/accounts/tests.py
+++ b/evennia/accounts/tests.py
@@ -59,6 +59,19 @@ class TestDefaultAccount(TestCase):
         self.s1 = Session()
         self.s1.puppet = None
         self.s1.sessid = 0
+        
+    def test_absolute_url(self):
+        "Get URL for account detail page on website"
+        self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
+                email="test@test.com", password="testpassword", typeclass=DefaultAccount)
+        self.assertTrue(self.account.get_absolute_url())
+        
+    def test_admin_url(self):
+        "Get object's URL for access via Admin pane"
+        self.account = create.create_account("TestAccount%s" % randint(100000, 999999),
+                email="test@test.com", password="testpassword", typeclass=DefaultAccount)
+        self.assertTrue(self.account.get_admin_url())
+        self.assertTrue(self.account.get_admin_url() != '#')
 
     def test_password_validation(self):
         "Check password validators deny bad passwords"

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -12,6 +12,9 @@ from future.utils import with_metaclass
 from collections import defaultdict
 
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from django.utils.text import slugify
 
 from evennia.typeclasses.models import TypeclassBase
 from evennia.typeclasses.attributes import NickHandler
@@ -324,6 +327,25 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             # look at 'an egg'.
             self.aliases.add(singular, category="plural_key")
         return singular, plural
+        
+    def get_absolute_url(self):
+        """
+        Returns the canonical URL for an object. 
+        
+        To callers, this method should appear to return a string that can be 
+        used to refer to the object over HTTP.
+        
+        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
+        """
+        try: return reverse('object-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def get_admin_url(self):
+        """
+        Returns a link to this object's entry within the Django Admin panel.
+        """
+        content_type = ContentType.objects.get_for_model(self.__class__)
+        return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
 
     def search(self, searchdata,
                global_search=False,
@@ -1821,6 +1843,17 @@ class DefaultCharacter(DefaultObject):
     a character avatar controlled by an account.
 
     """
+    def get_absolute_url(self):
+        """
+        Returns the canonical URL for a Character. 
+        
+        To callers, this method should appear to return a string that can be 
+        used to refer to the object over HTTP.
+        
+        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
+        """
+        try: return reverse('character-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return super(DefaultCharacter, self).get_absolute_url()
 
     def basetype_setup(self):
         """
@@ -1938,6 +1971,17 @@ class DefaultRoom(DefaultObject):
     This is the base room object. It's just like any Object except its
     location is always `None`.
     """
+    def get_absolute_url(self):
+        """
+        Returns the canonical URL for a Room. 
+        
+        To callers, this method should appear to return a string that can be 
+        used to refer to the object over HTTP.
+        
+        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
+        """
+        try: return reverse('location-detail', kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return super(DefaultRoom, self).get_absolute_url()
 
     def basetype_setup(self):
         """

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -329,52 +329,6 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             self.aliases.add(singular, category="plural_key")
         return singular, plural
         
-    def get_url_prefix(self):
-        """
-        Derives the object name from the class name.
-        
-        i.e. 'DefaultAccount' = 'default-account', 'Character' = 'character'
-        """
-        klass = self.__class__.__name__
-        terms = [x.lower() for x in re.split('([A-Z][a-z]+)', klass) if x]
-        return slugify(' '.join(terms))
-        
-    def get_absolute_url(self):
-        """
-        Returns the canonical URL to view an object. 
-        
-        To callers, this method should appear to return a string that can be 
-        used to refer to the object over HTTP.
-        
-        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
-        """
-        try: return reverse('%s-detail' % self.get_url_prefix(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_delete_url(self):
-        """
-        Returns the canonical URL to the page that allows deleting an object. 
-        
-        """
-        try: return reverse('%s-delete' % self.get_url_prefix(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_update_url(self):
-        """
-        Returns the canonical URL to the page that allows updating an object. 
-        
-        """
-        try: return reverse('%s-update' % self.get_url_prefix(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
-        except: return '#'
-        
-    def get_admin_url(self):
-        """
-        Returns a link to this object's entry within the Django Admin panel.
-        
-        """
-        content_type = ContentType.objects.get_for_model(self.__class__)
-        return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
-
     def search(self, searchdata,
                global_search=False,
                use_nicks=True,

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -5,7 +5,7 @@ class DefaultObjectTest(EvenniaTest):
     def test_urls(self):
         "Make sure objects are returning URLs"
         self.assertTrue(self.char1.get_absolute_url())
-        self.assertTrue('admin' in self.char1.get_admin_url())
+        self.assertTrue('admin' in self.char1.web_get_admin_url())
         
         self.assertTrue(self.room1.get_absolute_url())
-        self.assertTrue('admin' in self.room1.get_admin_url())
+        self.assertTrue('admin' in self.room1.web_get_admin_url())

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -1,0 +1,11 @@
+from evennia.utils.test_resources import EvenniaTest
+
+class DefaultObjectTest(EvenniaTest):
+    
+    def test_urls(self):
+        "Make sure objects are returning URLs"
+        self.assertTrue(self.char1.get_absolute_url())
+        self.assertTrue('admin' in self.char1.get_admin_url())
+        
+        self.assertTrue(self.room1.get_absolute_url())
+        self.assertTrue('admin' in self.room1.get_admin_url())

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -31,9 +31,12 @@ from django.db.models import signals
 
 from django.db.models.base import ModelBase
 from django.db import models
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
+from django.urls import reverse
 from django.utils.encoding import smart_str
+from django.utils.text import slugify
 
 from evennia.typeclasses.attributes import Attribute, AttributeHandler, NAttributeHandler
 from evennia.typeclasses.tags import Tag, TagHandler, AliasHandler, PermissionHandler
@@ -733,3 +736,145 @@ class TypedObject(SharedMemoryModel):
 
         """
         pass
+
+    #
+    # Web/Django methods
+    #
+    
+    def web_admin_url(self):
+        """
+        Returns the URI path for the Django Admin page for this object.
+        
+        ex. Account#1 = '/admin/accounts/accountdb/1/change/'
+        
+        Returns:
+            path (str): URI path to Django Admin page for object.
+            
+        """
+        content_type = ContentType.objects.get_for_model(self.__class__)
+        return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
+        
+    @classmethod
+    def web_create_url(cls):
+        """
+        Returns the URI path for a View that allows users to create new
+        instances of this object.
+        
+        ex. Chargen = '/characters/create/'
+        
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-create' would be referenced by this method.
+        
+        ex.
+        url(r'characters/create/', ChargenView.as_view(), name='character-create')
+        
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+        
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can create new objects is the 
+        developer's responsibility.
+        
+        Returns:
+            path (str): URI path to object creation page, if defined.
+            
+        """
+        try: return reverse('%s-create' % cls._meta.verbose_name.lower())
+        except: return '#'
+        
+    def web_detail_url(self):
+        """
+        Returns the URI path for a View that allows users to view details for 
+        this object.
+        
+        ex. Oscar (Character) = '/characters/oscar/1/'
+        
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-detail' would be referenced by this method.
+        
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', CharDetailView.as_view(), name='character-detail')
+        
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+        
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can view this object is the developer's 
+        responsibility.
+        
+        Returns:
+            path (str): URI path to object detail page, if defined.
+            
+        """
+        try: return reverse('%s-detail' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def web_update_url(self):
+        """
+        Returns the URI path for a View that allows users to update this
+        object.
+        
+        ex. Oscar (Character) = '/characters/oscar/1/change/'
+        
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-update' would be referenced by this method.
+        
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/change/$', CharUpdateView.as_view(), name='character-update')
+        
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+        
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can modify objects is the developer's 
+        responsibility.
+        
+        Returns:
+            path (str): URI path to object update page, if defined.
+            
+        """
+        try: return reverse('%s-update' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def web_delete_url(self):
+        """
+        Returns the URI path for a View that allows users to delete this object.
+        
+        ex. Oscar (Character) = '/characters/oscar/1/delete/'
+        
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-detail' would be referenced by this method.
+
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/delete/$', CharDeleteView.as_view(), name='character-delete')
+        
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+        
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can delete this object is the developer's 
+        responsibility.
+        
+        Returns:
+            path (str): URI path to object deletion page, if defined.
+            
+        """
+        try: return reverse('%s-delete' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
+        except: return '#'
+        
+    def get_absolute_url(self):
+        """
+        Django construct; used by Django Sites framework and within the Admin
+        panel for reverse linking to the object detail page. 
+        
+        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
+        
+        Returns:
+            path (str): URI path to object detail page, if defined.
+            
+        """
+        return self.web_detail_url()

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -741,7 +741,7 @@ class TypedObject(SharedMemoryModel):
     # Web/Django methods
     #
     
-    def web_admin_url(self):
+    def web_get_admin_url(self):
         """
         Returns the URI path for the Django Admin page for this object.
         
@@ -755,7 +755,7 @@ class TypedObject(SharedMemoryModel):
         return reverse("admin:%s_%s_change" % (content_type.app_label, content_type.model), args=(self.id,))
         
     @classmethod
-    def web_create_url(cls):
+    def web_get_create_url(cls):
         """
         Returns the URI path for a View that allows users to create new
         instances of this object.
@@ -783,7 +783,7 @@ class TypedObject(SharedMemoryModel):
         try: return reverse('%s-create' % cls._meta.verbose_name.lower())
         except: return '#'
         
-    def web_detail_url(self):
+    def web_get_detail_url(self):
         """
         Returns the URI path for a View that allows users to view details for 
         this object.
@@ -811,7 +811,7 @@ class TypedObject(SharedMemoryModel):
         try: return reverse('%s-detail' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
         except: return '#'
         
-    def web_update_url(self):
+    def web_get_update_url(self):
         """
         Returns the URI path for a View that allows users to update this
         object.
@@ -839,7 +839,7 @@ class TypedObject(SharedMemoryModel):
         try: return reverse('%s-update' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
         except: return '#'
         
-    def web_delete_url(self):
+    def web_get_delete_url(self):
         """
         Returns the URI path for a View that allows users to delete this object.
         
@@ -866,15 +866,5 @@ class TypedObject(SharedMemoryModel):
         try: return reverse('%s-delete' % self._meta.verbose_name.lower(), kwargs={'pk': self.pk, 'slug': slugify(self.name)})
         except: return '#'
         
-    def get_absolute_url(self):
-        """
-        Django construct; used by Django Sites framework and within the Admin
-        panel for reverse linking to the object detail page. 
-        
-        https://docs.djangoproject.com/en/2.1/ref/models/instances/#get-absolute-url
-        
-        Returns:
-            path (str): URI path to object detail page, if defined.
-            
-        """
-        return self.web_detail_url()
+    # Used by Django Sites/Admin
+    get_absolute_url = web_get_detail_url


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR is designed to let one generate paths to an object's web interface(s) from within a Django template.

It adds a set of methods to retrieve HTTP paths for DefaultAccount objects and all children of DefaultObject:
* `get_admin_url()`: Returns a path that, if followed, will display the object in the Admin backend.
* `get_absolute_url()`: Django construct; returns a path that should display the object in a DetailView.
* `get_update_url()`: Returns a path that should display the object in an UpdateView.
* `get_delete_url()`: Returns a path that should display the object in a DeleteView.

Note that this does not magically expose all your objects, create DeleteViews for everything, let random users into Admin or enable any sort of new or scary functionality.

The admin function works out of the box. It lets you do things in templates like:
```
{% if request.user.is_staff %}
<a href="{{ object.get_admin_url }}">Admin</a>
{% endif %}
```
...so when looking at an object (say, on a DetailView) staff can quickly pivot to the Admin backend to change things.

For the rest to work, you need to have defined named URLs that map typeclasses to actions. It must follow a particular naming convention (`object-action`, so `account-update`, `character-delete` or `room-detail` would yield the link to an appropriate view).

```
    # Character management
    url(r'^characters/create/$', website_views.CharacterCreateView.as_view(), name="character-create"),
    url(r'^characters/manage/$', website_views.CharacterManageView.as_view(), name="character-manage"),
    url(r'^characters/update/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterUpdateView.as_view(), name="character-update"),
    url(r'^characters/delete/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterDeleteView.as_view(), name="character-delete"),
```

This enables template functionality like:
```
{% for character in characters %}
<li>{{ character }} 
    <a href="{{ character.get_absolute_url }}">View</a> 
    <a href="{{ character.get_update_url }}">Update</a> 
    <a href="{{ character.get_delete_url }}">Delete</a>
</li>
{% endfor %}
```
...to let developers quickly generate links to the appropriate views governing disposition of an object. Securing those views and restricting access is entirely the responsibility of the developer; this PR does not facilitate anything that isn't already possible, just makes things more convenient for frontend development.

This PR also makes it more difficult to enumerate predictable endpoints (`/accounts/1/`, `/accounts/2/`, etc.). Evennia doesn't do slugs natively, though Django heavily encourages their use. When the link is generated, it passes the object pk as well as the slugified object name as kwargs. This means that the corresponding view must also be configured to receive and check an arbitrary `slug` kwarg, which is not the case by default. The receiving view should retrieve the object by pk but confirm the slug relates to the object name. This will inhibit scrapers and crawlers from probing random object IDs by requiring knowledge of both the object ID *and* the slugified version of the object name to be supplied to the view. It also makes the URL more intelligible (`/accounts/johnny/1/`, `/accounts/frank/2/`, etc.).