### PR TITLE
Move delaccount functionality to `@accounts/delete`

### DIFF
--- a/evennia/commands/default/cmdset_account.py
+++ b/evennia/commands/default/cmdset_account.py
@@ -55,7 +55,6 @@ class AccountCmdSet(CmdSet):
         self.add(system.CmdPy())
 
         # Admin commands
-        self.add(admin.CmdDelAccount())
         self.add(admin.CmdNewPassword())
 
         # Comm commands


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR implements feature request #1477.

It moves the code from CmdDelAccount into a switch check in CmdAccounts, making some minor style adjustments (mostly normalizing the quotes around strings and compressing newlines), and adding an explicit permission check to the new switch (as `@delaccount` has a higher permission lock than `@accounts`). It then completely removes all references to CmdDelAccount.

It does _not_ carry over the /delobj switch from CmdDelAccount as that switch appeared to be completely unimplemented.