### PR TITLE
Bug 1499: [READY FOR REVIEW AND MERGE] No way to clear object descs without resulting to `@py`

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -589,12 +589,12 @@ class CmdDesc(COMMAND_DEFAULT_CLASS):
             self.edit_handler()
             return
 
-        if self.rhs:
+        if '=' in self.args:
             # We have an =
             obj = caller.search(self.lhs)
             if not obj:
                 return
-            desc = self.rhs
+            desc = self.rhs or ''
         else:
             obj = caller.location or self.msg("|rYou can't describe oblivion.|n")
             if not obj:

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -270,7 +270,7 @@ class TestBuilding(CommandTest):
         o2d = self.obj2.db.desc
         r1d = self.room1.db.desc
         self.call(building.CmdDesc(), "Obj2=", "The description was set on Obj2(#5).")
-        assert self.obj2.db.desc == ''
+        assert self.obj2.db.desc == '' and self.obj2.db.desc != o2d
         assert self.room1.db.desc == r1d
 
     def test_desc_default_to_room(self):
@@ -279,7 +279,7 @@ class TestBuilding(CommandTest):
         r1d = self.room1.db.desc
         self.call(building.CmdDesc(), "Obj2", "The description was set on Room(#1).")
         assert self.obj2.db.desc == o2d
-        assert self.room1.db.desc == 'Obj2'
+        assert self.room1.db.desc == 'Obj2' and self.room1.db.desc != r1d
 
     def test_wipe(self):
         confirm = building.CmdDestroy.confirm

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -263,6 +263,20 @@ class TestBuilding(CommandTest):
     def test_desc(self):
         self.call(building.CmdDesc(), "Obj2=TestDesc", "The description was set on Obj2(#5).")
 
+    def test_empty_desc(self):
+        o2d = self.obj2.db.desc
+        r1d = self.room1.db.desc
+        self.call(building.CmdDesc(), "Obj2=", "The description was set on Obj2(#5).")
+        assert self.obj2.db.desc == ''
+        assert self.room1.db.desc == r1d
+
+    def test_desc_default_to_room(self):
+        o2d = self.obj2.db.desc
+        r1d = self.room1.db.desc
+        self.call(building.CmdDesc(), "Obj2", "The description was set on Room(#1).")
+        assert self.obj2.db.desc == o2d
+        assert self.room1.db.desc == 'Obj2'
+
     def test_wipe(self):
         confirm = building.CmdDestroy.confirm
         building.CmdDestroy.confirm = False

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -264,6 +264,9 @@ class TestBuilding(CommandTest):
         self.call(building.CmdDesc(), "Obj2=TestDesc", "The description was set on Obj2(#5).")
 
     def test_empty_desc(self):
+        """
+        empty desc sets desc as ''
+        """
         o2d = self.obj2.db.desc
         r1d = self.room1.db.desc
         self.call(building.CmdDesc(), "Obj2=", "The description was set on Obj2(#5).")
@@ -271,6 +274,7 @@ class TestBuilding(CommandTest):
         assert self.room1.db.desc == r1d
 
     def test_desc_default_to_room(self):
+        """no rhs changes room's desc"""
         o2d = self.obj2.db.desc
         r1d = self.room1.db.desc
         self.call(building.CmdDesc(), "Obj2", "The description was set on Room(#1).")


### PR DESCRIPTION
- Resolution for #1499
- Tests for `@desc obj=`

Failing tests demonstrates 2 issues (commit fde9f151889):
1. `@desc obj=` doesn't clear `obj` description.
2. `@desc obj=` sets the current room description as `'obj='`.
