### PR TITLE
Add portal uptime to @time command.

### DIFF
--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -710,6 +710,7 @@ class CmdTime(COMMAND_DEFAULT_CLASS):
         """Show server time data in a table."""
         table1 = EvTable("|wServer time", "", align="l", width=78)
         table1.add_row("Current uptime", utils.time_format(gametime.uptime(), 3))
+        table1.add_row("Portal uptime", utils.time_format(gametime.portal_uptime(), 3))
         table1.add_row("Total runtime", utils.time_format(gametime.runtime(), 2))
         table1.add_row("First start", datetime.datetime.fromtimestamp(gametime.server_epoch()))
         table1.add_row("Current time", datetime.datetime.now())

--- a/evennia/server/amp_client.py
+++ b/evennia/server/amp_client.py
@@ -221,6 +221,7 @@ class AMPServerClientProtocol(amp.AMPMultiConnectionProtocol):
             server_restart_mode = kwargs.get("server_restart_mode", "shutdown")
             self.factory.server.run_init_hooks(server_restart_mode)
             server_sessionhandler.portal_sessions_sync(kwargs.get("sessiondata"))
+            server_sessionhandler.portal_start_time = kwargs.get("portal_start_time")
 
         elif operation == amp.SRELOAD:  # server reload
             # shut down in reload mode

--- a/evennia/server/portal/amp_server.py
+++ b/evennia/server/portal/amp_server.py
@@ -428,7 +428,8 @@ class AMPServerProtocol(amp.AMPMultiConnectionProtocol):
             self.send_AdminPortal2Server(amp.DUMMYSESSION,
                                          amp.PSYNC,
                                          server_restart_mode=server_restart_mode,
-                                         sessiondata=sessdata)
+                                         sessiondata=sessdata,
+                                         portal_start_time=self.factory.portal.start_time)
             self.factory.portal.sessions.at_server_connection()
 
             if self.factory.server_connection:

--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -11,6 +11,7 @@ from builtins import object
 
 import sys
 import os
+import time
 
 from os.path import dirname, abspath
 from twisted.application import internet, service
@@ -113,6 +114,8 @@ class Portal(object):
         self.server_process_id = None
         self.server_restart_mode = "shutdown"
         self.server_info_dict = {}
+
+        self.start_time = time.time()
 
         # in non-interactive portal mode, this gets overwritten by
         # cmdline sent by the evennia launcher

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -280,6 +280,8 @@ class ServerSessionHandler(SessionHandler):
         super(ServerSessionHandler, self).__init__(*args, **kwargs)
         self.server = None  # set at server initialization
         self.server_data = {"servername": _SERVERNAME}
+        # will be set on psync
+        self.portal_start_time = 0.0
 
     def _run_cmd_login(self, session):
         """

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -107,6 +107,17 @@ def uptime():
     return time.time() - SERVER_START_TIME
 
 
+def portal_uptime():
+    """
+    Get the current uptime of the portal.
+
+    Returns:
+        time (float): The uptime of the portal.
+    """
+    from evennia.server.sessionhandler import SESSIONS
+    return time.time() - SESSIONS.portal_start_time
+
+
 def game_epoch():
     """
     Get the game epoch.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Puts in tracking for the uptime of the portal and transmits that data upon the server connecting to the portal via the amp bridge, then makes that information accessible in `gametime`, which is then displayed in the `@time` command.

#### Motivation for adding to Evennia
Implementing an old feature request.

#### Other info (issues closed, discussion etc)
Resolves #1420 
