### PR TITLE
Add a simple 'force' command to force objects to execute commands.

### DIFF
--- a/evennia/commands/default/cmdset_character.py
+++ b/evennia/commands/default/cmdset_character.py
@@ -57,6 +57,7 @@ class CharacterCmdSet(CmdSet):
         self.add(admin.CmdEmit())
         self.add(admin.CmdPerm())
         self.add(admin.CmdWall())
+        self.add(admin.CmdForce())
 
         # Building and world manipulation
         self.add(building.CmdTeleport())

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -243,6 +243,9 @@ class TestAdmin(CommandTest):
     def test_ban(self):
         self.call(admin.CmdBan(), "Char", "Name-Ban char was added.")
 
+    def test_force(self):
+        self.call(admin.CmdForce(), "Char2=say test", 'Char2(#7) says, "test"|You have forced Char2 to: say test')
+
 
 class TestAccount(CommandTest):
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add a simple command to the other admin commands to allow a staff member to force an object to execute a command.

#### Motivation for adding to Evennia
It's a simple use case that comes up occasionally, such as when someone is running a roleplay event and wants to force objects to execute specific commands, and saves people the trouble of resorting to `@py`.

#### Other info (issues closed, discussion etc)
N/A