### PR TITLE
Converts shared_login view function to a middleware class, updates middleware setting

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -765,14 +765,15 @@ TEMPLATES = [{
 # MiddleWare are semi-transparent extensions to Django's functionality.
 # see http://www.djangoproject.com/documentation/middleware/ for a more detailed
 # explanation.
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',  # 1.4?
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.admindocs.middleware.XViewMiddleware',
-    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',)
+    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+    'evennia.web.utils.middleware.SharedLoginMiddleware',)
 
 ######################################################################
 # Evennia components

--- a/evennia/web/utils/middleware.py
+++ b/evennia/web/utils/middleware.py
@@ -1,0 +1,60 @@
+from django.contrib.auth import authenticate, login
+from evennia.accounts.models import AccountDB
+from evennia.utils import logger
+
+class SharedLoginMiddleware(object):
+    """
+    Handle the shared login between website and webclient.
+
+    """
+    def __init__(self, get_response):
+        # One-time configuration and initialization.
+        self.get_response = get_response
+        
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+        
+        # Process view
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+        
+        # Synchronize credentials
+        self.make_shared_login(request)
+        
+        # Return processed view
+        return response
+        
+    @classmethod
+    def make_shared_login(cls, request):
+        csession = request.session
+        account = request.user
+        website_uid = csession.get("website_authenticated_uid", None)
+        webclient_uid = csession.get("webclient_authenticated_uid", None)
+    
+        if not csession.session_key:
+            # this is necessary to build the sessid key
+            csession.save()
+    
+        if account.is_authenticated():
+            # Logged into website
+            if not website_uid:
+                # fresh website login (just from login page)
+                csession["website_authenticated_uid"] = account.id
+                if webclient_uid is None:
+                    # auto-login web client
+                    csession["webclient_authenticated_uid"] = account.id
+    
+        elif webclient_uid:
+            # Not logged into website, but logged into webclient
+            if not website_uid:
+                csession["website_authenticated_uid"] = account.id
+                account = AccountDB.objects.get(id=webclient_uid)
+                try:
+                    # calls our custom authenticate, in web/utils/backend.py
+                    authenticate(autologin=account)
+                    login(request, account)
+                except AttributeError:
+                    logger.log_trace()

--- a/evennia/web/website/views.py
+++ b/evennia/web/website/views.py
@@ -20,43 +20,6 @@ from django.contrib.auth import login
 
 _BASE_CHAR_TYPECLASS = settings.BASE_CHARACTER_TYPECLASS
 
-
-def _shared_login(request):
-    """
-    Handle the shared login between website and webclient.
-
-    """
-    csession = request.session
-    account = request.user
-    website_uid = csession.get("website_authenticated_uid", None)
-    webclient_uid = csession.get("webclient_authenticated_uid", None)
-
-    if not csession.session_key:
-        # this is necessary to build the sessid key
-        csession.save()
-
-    if account.is_authenticated():
-        # Logged into website
-        if not website_uid:
-            # fresh website login (just from login page)
-            csession["website_authenticated_uid"] = account.id
-            if webclient_uid is None:
-                # auto-login web client
-                csession["webclient_authenticated_uid"] = account.id
-
-    elif webclient_uid:
-        # Not logged into website, but logged into webclient
-        if not website_uid:
-            csession["website_authenticated_uid"] = account.id
-            account = AccountDB.objects.get(id=webclient_uid)
-            try:
-                # calls our custom authenticate, in web/utils/backend.py
-                authenticate(autologin=account)
-                login(request, account)
-            except AttributeError:
-                logger.log_trace()
-
-
 def _gamestats():
     # Some misc. configurable stuff.
     # TODO: Move this to either SQL or settings.py based configuration.
@@ -96,10 +59,6 @@ def page_index(request):
     """
     Main root page.
     """
-
-    # handle webclient-website shared login
-    _shared_login(request)
-
     # get game db stats
     pagevars = _gamestats()
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* Renames `MIDDLEWARE_CLASSES` to `MIDDLEWARE` to adhere to Django 1.10+ new-style middleware expectations.
* Reimplements the `shared_login` view function as a middleware class.

#### Motivation for adding to Evennia
I haven't tested it, but based on the current logic I believe that given the way we had this set up, `_shared_login` would only kick off if someone went to the index page. It would not run if someone tried to access a protected page, received an auth prompt, was redirected back to the destination page, and then hopped over to the webclient. The webdev would likely have to call this method on all views.

Implementing this as middleware forces the credentials to synchronize on all submitted requests.

As for the rename, we didn't have any custom middleware written so it's a matter of renaming a setting for the sake of future-proofing. 

#### Other info (issues closed, discussion etc)
https://docs.djangoproject.com/es/1.10/topics/http/middleware/#writing-your-own-middleware