### PR TITLE
Implements Help views

### DIFF
--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -11,7 +11,11 @@ game world, policy info, rules and similar.
 """
 from builtins import object
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.urls import reverse
+from django.utils.text import slugify
+
 from evennia.utils.idmapper.models import SharedMemoryModel
 from evennia.help.manager import HelpEntryManager
 from evennia.typeclasses.models import Tag, TagHandler, AliasHandler
@@ -107,3 +111,158 @@ class HelpEntry(SharedMemoryModel):
         default - what to return if no lock of access_type was found
         """
         return self.locks.check(accessing_obj, access_type=access_type, default=default)
+        
+    #
+    # Web/Django methods
+    #
+
+    def web_get_admin_url(self):
+        """
+        Returns the URI path for the Django Admin page for this object.
+
+        ex. Account#1 = '/admin/accounts/accountdb/1/change/'
+
+        Returns:
+            path (str): URI path to Django Admin page for object.
+
+        """
+        content_type = ContentType.objects.get_for_model(self.__class__)
+        return reverse("admin:%s_%s_change" % (content_type.app_label,
+                                               content_type.model), args=(self.id,))
+
+    @classmethod
+    def web_get_create_url(cls):
+        """
+        Returns the URI path for a View that allows users to create new
+        instances of this object.
+
+        ex. Chargen = '/characters/create/'
+
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-create' would be referenced by this method.
+
+        ex.
+        url(r'characters/create/', ChargenView.as_view(), name='character-create')
+
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can create new objects is the
+        developer's responsibility.
+
+        Returns:
+            path (str): URI path to object creation page, if defined.
+
+        """
+        try:
+            return reverse('%s-create' % slugify(cls._meta.verbose_name))
+        except:
+            return '#'
+
+    def web_get_detail_url(self):
+        """
+        Returns the URI path for a View that allows users to view details for
+        this object.
+
+        ex. Oscar (Character) = '/characters/oscar/1/'
+
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-detail' would be referenced by this method.
+
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$',
+            CharDetailView.as_view(), name='character-detail')
+
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can view this object is the developer's
+        responsibility.
+
+        Returns:
+            path (str): URI path to object detail page, if defined.
+
+        """
+        try:
+            return reverse('%s-detail' % slugify(self._meta.verbose_name),
+               kwargs={
+                   'category': slugify(self.db_help_category), 
+                   'topic': slugify(self.db_key)})
+        except Exception as e:
+            print(e)
+            return '#'
+
+
+    def web_get_update_url(self):
+        """
+        Returns the URI path for a View that allows users to update this
+        object.
+
+        ex. Oscar (Character) = '/characters/oscar/1/change/'
+
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-update' would be referenced by this method.
+
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/change/$',
+            CharUpdateView.as_view(), name='character-update')
+
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can modify objects is the developer's
+        responsibility.
+
+        Returns:
+            path (str): URI path to object update page, if defined.
+
+        """
+        try:
+            return reverse('%s-update' % slugify(self._meta.verbose_name),
+               kwargs={
+                   'category': slugify(self.db_help_category), 
+                   'topic': slugify(self.db_key)})
+        except:
+            return '#'
+
+    def web_get_delete_url(self):
+        """
+        Returns the URI path for a View that allows users to delete this object.
+
+        ex. Oscar (Character) = '/characters/oscar/1/delete/'
+
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-detail' would be referenced by this method.
+
+        ex.
+        url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/delete/$',
+            CharDeleteView.as_view(), name='character-delete')
+
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can delete this object is the developer's
+        responsibility.
+
+        Returns:
+            path (str): URI path to object deletion page, if defined.
+
+        """
+        try:
+            return reverse('%s-delete' % slugify(self._meta.verbose_name),
+               kwargs={
+                   'category': slugify(self.db_help_category), 
+                   'topic': slugify(self.db_key)})
+        except:
+            return '#'
+
+    # Used by Django Sites/Admin
+    get_absolute_url = web_get_detail_url

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -755,7 +755,6 @@ TEMPLATES = [{
             'django.contrib.auth.context_processors.auth',
             'django.template.context_processors.media',
             'django.template.context_processors.debug',
-            'django.contrib.messages.context_processors.messages',
             'sekizai.context_processors.sekizai',
             'evennia.web.utils.general_context.general_context'],
         # While true, show "pretty" error messages for template syntax errors.
@@ -790,7 +789,6 @@ INSTALLED_APPS = (
     'django.contrib.flatpages',
     'django.contrib.sites',
     'django.contrib.staticfiles',
-    'django.contrib.messages',
     'sekizai',
     'evennia.utils.idmapper',
     'evennia.server',

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -13,6 +13,7 @@ always be sure of what you have changed and what is default behaviour.
 
 """
 from builtins import range
+from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 
 import os
@@ -827,6 +828,12 @@ AUTH_USERNAME_VALIDATORS = [
 
 # Use a custom test runner that just tests Evennia-specific apps.
 TEST_RUNNER = 'evennia.server.tests.EvenniaTestSuiteRunner'
+
+# Messages and Bootstrap don't classify events the same way; this setting maps 
+# messages.error() to Bootstrap 'danger' classes.
+MESSAGE_TAGS = {
+    messages.ERROR: 'danger',
+}
 
 ######################################################################
 # Django extensions

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -755,6 +755,7 @@ TEMPLATES = [{
             'django.contrib.auth.context_processors.auth',
             'django.template.context_processors.media',
             'django.template.context_processors.debug',
+            'django.contrib.messages.context_processors.messages',
             'sekizai.context_processors.sekizai',
             'evennia.web.utils.general_context.general_context'],
         # While true, show "pretty" error messages for template syntax errors.
@@ -789,6 +790,7 @@ INSTALLED_APPS = (
     'django.contrib.flatpages',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'django.contrib.messages',
     'sekizai',
     'evennia.utils.idmapper',
     'evennia.server',

--- a/evennia/web/website/forms.py
+++ b/evennia/web/website/forms.py
@@ -100,16 +100,17 @@ class CharacterForm(ObjectForm):
     text and numbers respectively. IntegerFields have some neat validation tricks 
     they can do, like mandating values fall within a certain range. 
     
-    For example, a complete "age" field might look like:
+    For example, a complete "age" field (which stores its value to
+    `character.db.age` might look like:
     
     age = forms.IntegerField(
         label="Your Age",
         min_value=18, max_value=9000, 
         help_text="Years since your birth.")
         
-    Default input fields are generic text boxes. You can control what sort of 
-    input field users will see by specifying a "widget." An example of this is
-    used for the 'desc' field to show a Textarea box instead of a Textbox.
+    Default input fields are generic single-line text boxes. You can control what 
+    sort of input field users will see by specifying a "widget." An example of 
+    this is used for the 'desc' field to show a Textarea box instead of a Textbox.
     
     For help in building out your form, please see:
     https://docs.djangoproject.com/en/1.11/topics/forms/#building-a-form-in-django

--- a/evennia/web/website/forms.py
+++ b/evennia/web/website/forms.py
@@ -139,8 +139,10 @@ class CharacterForm(ObjectForm):
             'db_key': 'Name',
         }
         
-    # Fields pertaining to user-configurable attributes on the Character object.
-    desc = forms.CharField(label='Description', widget=forms.Textarea(attrs={'rows': 3}), max_length=2048, required=False)
+    # Fields pertaining to configurable attributes on the Character object.
+    desc = forms.CharField(label='Description', max_length=2048, required=False,
+        widget=forms.Textarea(attrs={'rows': 3}),
+        help_text="A brief description of your character.")
     
 class CharacterUpdateForm(CharacterForm):
     """

--- a/evennia/web/website/forms.py
+++ b/evennia/web/website/forms.py
@@ -32,7 +32,7 @@ class EvenniaForm(forms.Form):
         cleaned = {k:escape(v) for k,v in cleaned.items()}
         return cleaned
 
-class AccountForm(EvenniaForm, UserCreationForm):
+class AccountForm(UserCreationForm):
     """
     This is a generic Django form tailored to the Account model.
     

--- a/evennia/web/website/forms.py
+++ b/evennia/web/website/forms.py
@@ -6,8 +6,26 @@ from django.utils.html import escape
 from evennia.utils import class_from_module
 
 class EvenniaForm(forms.Form):
+    """
+    This is a stock Django form, but modified so that all values provided
+    through it are escaped (sanitized). Validation is performed by the fields
+    you define in the form.
     
+    This has little to do with Evennia itself and is more general web security-
+    related.
+    
+    https://www.owasp.org/index.php/Input_Validation_Cheat_Sheet#Goals_of_Input_Validation
+    
+    """
     def clean(self):
+        """
+        Django hook. Performed on form submission.
+        
+        Returns:
+            cleaned (dict): Dictionary of key:value pairs submitted on the form.
+            
+        """
+        # Call parent function
         cleaned = super(EvenniaForm, self).clean()
         
         # Escape all values provided by user
@@ -15,30 +33,106 @@ class EvenniaForm(forms.Form):
         return cleaned
 
 class AccountForm(EvenniaForm, UserCreationForm):
+    """
+    This is a generic Django form tailored to the Account model.
     
+    In this incarnation it does not allow getting/setting of attributes, only
+    core User model fields (username, email, password).
+    
+    """
     class Meta:
+        """
+        This is a Django construct that provides additional configuration to
+        the form.
+        
+        """
+        # The model/typeclass this form creates
         model = class_from_module(settings.BASE_ACCOUNT_TYPECLASS)
+        
+        # The fields to display on the form, in the given order
         fields = ("username", "email")
+        
+        # Any overrides of field classes
         field_classes = {'username': UsernameField}
     
+    # Username is collected as part of the core UserCreationForm, so we just need
+    # to add a field to (optionally) capture email.
     email = forms.EmailField(help_text="A valid email address. Optional; used for password resets.", required=False)
     
 class ObjectForm(EvenniaForm, ModelForm):
+    """
+    This is a Django form for generic Evennia Objects that allows modification
+    of attributes when called from a descendent of ObjectUpdate or ObjectCreate
+    views.
     
+    It defines no fields by default; you have to do that by extending this class
+    and defining what fields you want to be recorded. See the CharacterForm for
+    a simple example of how to do this.
+    
+    """
     class Meta:
+        """
+        This is a Django construct that provides additional configuration to
+        the form.
+        
+        """
+        # The model/typeclass this form creates
         model = class_from_module(settings.BASE_OBJECT_TYPECLASS)
+        
+        # The fields to display on the form, in the given order
         fields = ("db_key",)
+        
+        # This lets us rename ugly db-specific keys to something more human
         labels = {
             'db_key': 'Name',
         }
     
 class CharacterForm(ObjectForm):
+    """
+    This is a Django form for Evennia Character objects.
     
+    Since Evennia characters only have one attribute by default, this form only
+    defines a field for that single attribute. The names of fields you define should 
+    correspond to their names as stored in the dbhandler; you can display 
+    'prettier' versions of the fieldname on the form using the 'label' kwarg.
+    
+    The basic field types are CharFields and IntegerFields, which let you enter
+    text and numbers respectively. IntegerFields have some neat validation tricks 
+    they can do, like mandating values fall within a certain range. 
+    
+    For example, a complete "age" field might look like:
+    
+    age = forms.IntegerField(
+        label="Your Age",
+        min_value=18, max_value=9000, 
+        help_text="Years since your birth.")
+        
+    Default input fields are generic text boxes. You can control what sort of 
+    input field users will see by specifying a "widget." An example of this is
+    used for the 'desc' field to show a Textarea box instead of a Textbox.
+    
+    For help in building out your form, please see:
+    https://docs.djangoproject.com/en/1.11/topics/forms/#building-a-form-in-django
+    
+    For more information on fields and their capabilities, see:
+    https://docs.djangoproject.com/en/1.11/ref/forms/fields/
+    
+    For more on widgets, see:
+    https://docs.djangoproject.com/en/1.11/ref/forms/widgets/
+    
+    """
     class Meta:
+        """
+        This is a Django construct that provides additional configuration to
+        the form.
+        
+        """
         # Get the correct object model
         model = class_from_module(settings.BASE_CHARACTER_TYPECLASS)
+        
         # Allow entry of the 'key' field
         fields = ("db_key",)
+        
         # Rename 'key' to something more intelligible
         labels = {
             'db_key': 'Name',
@@ -49,8 +143,12 @@ class CharacterForm(ObjectForm):
     
 class CharacterUpdateForm(CharacterForm):
     """
-    Provides a form that only allows updating of db attributes, not model
-    attributes.
+    This is a Django form for updating Evennia Character objects.
+    
+    By default it is the same as the CharacterForm, but if there are circumstances
+    in which you don't want to let players edit all the same attributes they had
+    access to during creation, you can redefine this form with those fields you do
+    wish to allow.
     
     """
     pass

--- a/evennia/web/website/templates/website/_menu.html
+++ b/evennia/web/website/templates/website/_menu.html
@@ -29,7 +29,10 @@ folder and edit it to add/remove links to the menu.
               <a class="nav-link" href="https://github.com/evennia/evennia/wiki/Evennia-Introduction/">About</a>
             </li>
             <li><a class="nav-link" href="https://github.com/evennia/evennia/wiki">Documentation</a></li>
-            <li><a class="nav-link" href="{% url 'admin:index' %}">Admin Interface</a></li>
+            {% if user.is_staff %}
+            <li><a class="nav-link" href="{% url 'admin:index' %}">Admin</a></li>
+            {% endif %}
+            <li><a class="nav-link" href="{% url 'help' %}">Help</a></li>
             {% if webclient_enabled %}
             <li><a class="nav-link" href="{% url 'webclient:index' %}">Play Online</a></li>
             {% endif %}

--- a/evennia/web/website/templates/website/help_detail.html
+++ b/evennia/web/website/templates/website/help_detail.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block titleblock %}
+{{ view.page_title }} ({{ object|title }})
+{% endblock %}
+
+{% block content %}
+
+{% load addclass %}
+<div class="row">
+  <div class="col">
+    
+    <!-- main content -->  
+    <div class="card mb-3">
+      <div class="card-body">
+        <h1 class="card-title">{{ view.page_title }} ({{ object|title }})</h1>
+        <hr />
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="{% url 'help' %}">Compendium</a></li>
+          <li class="breadcrumb-item"><a href="{% url 'help' %}#{{ object.db_help_category }}">{{ object.db_help_category|title }}</a></li>
+          <li class="breadcrumb-item active" aria-current="page">{{ object.db_key|title }}</li>
+        </ol>
+        <hr />
+
+        <div class="row">
+          <!-- left column -->
+          <div class="col-lg-9 col-sm-12">
+            <p>{{ entry_text|safe }}</p>
+            
+            {% if topic_previous or topic_next %}
+            <hr />
+            <!-- navigation -->
+            <nav aria-label="Topic Navigation">
+              <ul class="pagination justify-content-center">
+                {% if topic_previous %}
+                <li class="page-item">
+                  <a class="page-link" href="{{ topic_previous.web_get_detail_url }}">Previous ({{ topic_previous|title }})</a>
+                </li>
+                {% endif %}
+                
+                {% if topic_next %}
+                <li class="page-item">
+                  <a class="page-link" href="{{ topic_next.web_get_detail_url }}">Next ({{ topic_next|title }})</a>
+                </li>
+                {% endif %}
+              </ul>
+            </nav>
+            <!-- end navigation -->
+            {% endif %}
+            
+          </div>
+          <!-- end left column -->
+          
+          <!-- right column (sidebar) -->
+          <div class="col-lg-3 col-sm-12">
+            
+            {% if request.user.is_staff %}
+            <!-- admin button -->
+            <a class="btn btn-info btn-block mb-3" href="{{ object.web_get_admin_url }}">Edit</a>
+            <!-- end admin button -->
+            <hr />
+            {% endif %}
+            
+            <div class="card mb-3">
+              <div class="card-header">{{ object.db_help_category|title }}</div>
+              
+              <ul class="list-group list-group-flush">
+                {% for topic in topic_list %}
+                <a href="{{ topic.web_get_detail_url }}" class="list-group-item {% if topic == object %}active disabled{% endif %}">{{ topic|title }}</a>
+                {% endfor %}
+              </ul>
+              
+            </div>
+          </div>
+          <!-- end right column -->
+          
+        </div>
+        <hr />
+          
+      </div>
+    </div>
+    <!-- end main content -->
+    
+  </div>
+</div>
+{% endblock %}

--- a/evennia/web/website/templates/website/help_list.html
+++ b/evennia/web/website/templates/website/help_list.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+
+{% block titleblock %}
+{{ view.page_title }}
+{% endblock %}
+
+{% block content %}
+
+{% load addclass %}
+<div class="row">
+  <div class="col">
+    <div class="card">
+      <div class="card-body">
+        <h1 class="card-title">{{ view.page_title }}</h1>
+        <hr />
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="{% url 'help' %}">Compendium</a></li>
+        </ol>
+        <hr />
+        <div class="row">
+          {% regroup object_list by help_category as category_list %}
+          
+          {% if category_list %}
+          <!-- left column -->
+          <div class="col-lg-9 col-sm-12">
+            
+            <!-- intro -->
+            <div class="card border-light">
+              <div class="card-body">
+                <h4 class="card-title">The {{ game_name }} Compendium</h4>
+                <p>This section of the site is your guide to learning all about {{ game_name }}-- its rules, its setting, its people, customs, classes, castes, conflicts, races, religions, lore and more!</p>
+                <p>It is organized first by category, then by topic. The box to the right will let you skip to particular categories.</p>
+              </div>
+            </div>
+            <hr />
+            <!-- end intro -->
+            
+            <!-- index list -->
+            <div class="mx-3">
+              {% for help_category in category_list %}
+              <h5><a id="{{ help_category.grouper }}"></a>{{ help_category.grouper|title }}</h5>
+              <ul>
+                  {% for object in help_category.list %}
+                  <li><a href="{{ object.web_get_detail_url }}">{{ object|title }}</a></li>
+                  {% endfor %}
+              </ul>
+              {% endfor %}
+              <!-- end index list -->
+            </div>
+            
+          </div>
+          <!-- end left column -->
+          
+          <!-- right column (index) -->
+          <div class="col-lg-3 col-sm-12">
+            {% if user.is_staff %}
+            <!-- admin button -->
+            <a class="btn btn-info btn-block mb-3" href="/admin/help/helpentry/add/">Create New</a>
+            <!-- end admin button -->
+            <hr />
+            {% endif %}
+            
+            <div class="card mb-3">
+              <div class="card-header">Category Index</div>
+              
+              <ul class="list-group list-group-flush">
+                {% for category in category_list %}
+                <a href="#{{ category.grouper }}" class="list-group-item">{{ category.grouper|title }}</a>
+                {% endfor %}
+              </ul>
+              
+            </div>
+          </div>
+          <!-- end right column -->
+          {% else %}
+          {% if user.is_staff %}
+          <div class="col-lg-12 col-sm-12">
+            <div class="alert alert-warning" role="alert">
+              <h4 class="alert-heading">Hey, staff member {{ user.get_username }}!</h4>
+              <hr />
+              <p><strong>Your Help section is currently blank!</strong></p>
+              <p>You're missing out on an opportunity to attract visitors (and potentially new players) to {{ game_name }}!</p>
+              <p>Use Evennia's <a href="https://github.com/evennia/evennia/wiki/Help-System#database-help-entries" class="alert-link" target="_blank">Help System</a> to tell the world about the universe you've created, its lore and legends, its people and creatures, and their customs and conflicts!</p>
+              <p>You don't even need coding skills-- writing Help Entries is no more complicated than writing an email or blog post. Once you publish your first entry, these ugly boxes go away and this page will turn into an index of everything you've written about {{ game_name }}.</p>
+              <p>The documentation you write is eventually picked up by search engines, so the more you write about how {{ game_name }} works, the larger your web presence will be-- and the more traffic you'll attract. 
+              <p>Everything you write can be viewed either on this site or within the game itself, using the in-game help commands.</p>
+              <hr>
+              <p class="mb-0"><a href="/admin/help/helpentry/add/" class="alert-link">Click here</a> to start writing about {{ game_name }}!</p>
+            </div>
+          </div>
+          {% endif %}
+          
+          <div class="col-lg-12 col-sm-12">
+            <div class="alert alert-secondary" role="alert">
+              <h4 class="alert-heading">Under Construction!</h4>
+              <p>Thanks for your interest, but we're still working on developing and documenting the {{ game_name }} universe!</p>
+              <p>Check back later for more information as we publish it.</p>
+              <hr>
+              <p class="mb-0"><a href="{% url 'index' %}" class="alert-link">Click here</a> to go back to the main page.</p>
+            </div>
+          </div>
+          {% endif %}
+          
+        </div>
+        <hr />
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/evennia/web/website/templates/website/object_detail.html
+++ b/evennia/web/website/templates/website/object_detail.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block titleblock %}
+{{ view.page_title }} ({{ object }})
+{% endblock %}
+
+{% block content %}
+
+{% load addclass %}
+<div class="row">
+  <div class="col">
+    <div class="card">
+      <div class="card-body">
+        <h1 class="card-title">{{ view.page_title }}</h1>
+        <hr />
+
+        <div class="row">
+          
+          <!-- left/avatar column -->
+          <div class="col-lg-3 col-sm-12">
+            <img class="d-flex mr-3" src="http://placehold.jp/250x250.png" alt="Image of {{ object }}">
+          </div>
+          <!-- end left/avatar column -->
+          
+          <!-- right/content column -->
+          <div class="col-lg-9 col-sm-12">
+            <dl>
+            {% for attribute, value in attribute_list.items %}
+              <dt>{{ attribute }}</dt>
+              <dd>{{ value }}</dd>
+            {% endfor %}
+            </dl>
+          </div>
+          <!-- end right/content column -->
+          
+        </div>
+          
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/evennia/web/website/templates/website/object_list.html
+++ b/evennia/web/website/templates/website/object_list.html
@@ -1,27 +1,25 @@
 {% extends "base.html" %}
 
 {% block titleblock %}
-List
+{{ view.page_title }}
 {% endblock %}
 
 {% block content %}
 
 {% load addclass %}
-<div class="container main-content mt-4" id="main-copy">
-  <div class="row">
-    <div class="col">
-      <div class="card mt-3">
-        <div class="card-body">
-          <h1 class="card-title">List</h1>
-          <hr />
+<div class="row">
+  <div class="col">
+    <div class="card mt-3">
+      <div class="card-body">
+        <h1 class="card-title">{{ view.page_title }}</h1>
+        <hr />
 
-            <ul>
-                {% for object in object_list %}
-                <li>{{ object }}</li>
-                {% endfor %}
-            </ul>
-            
-        </div>
+          <ul>
+              {% for object in object_list %}
+              <li><a href="{{ object.web_get_detail_url }}">{{ object }}</a></li>
+              {% endfor %}
+          </ul>
+          
       </div>
     </div>
   </div>

--- a/evennia/web/website/urls.py
+++ b/evennia/web/website/urls.py
@@ -13,8 +13,12 @@ urlpatterns = [
     url(r'^tbi/', website_views.to_be_implemented, name='to_be_implemented'),
 
     # User Authentication (makes login/logout url names available)
-    url(r'^auth/', include('django.contrib.auth.urls')),
     url(r'^auth/register', website_views.AccountCreateView.as_view(), name="register"),
+    url(r'^auth/', include('django.contrib.auth.urls')),
+    
+    # Help Topics
+    url(r'^help/$', website_views.HelpListView.as_view(), name="help"),
+    url(r'^help/(?P<category>[\w\d\-]+)/(?P<topic>[\w\d\-]+)/$', website_views.HelpDetailView.as_view(), name="help-entry-detail"),
     
     # Character management
     url(r'^characters/create/$', website_views.CharacterCreateView.as_view(), name="character-create"),

--- a/evennia/web/website/urls.py
+++ b/evennia/web/website/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     # Character management
     url(r'^characters/create/$', website_views.CharacterCreateView.as_view(), name="character-create"),
     url(r'^characters/manage/$', website_views.CharacterManageView.as_view(), name="character-manage"),
+    url(r'^characters/detail/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterDetailView.as_view(), name="character-detail"),
     url(r'^characters/puppet/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterPuppetView.as_view(), name="character-puppet"),
     url(r'^characters/update/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterUpdateView.as_view(), name="character-update"),
     url(r'^characters/delete/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$', website_views.CharacterDeleteView.as_view(), name="character-delete"),

--- a/evennia/web/website/views.py
+++ b/evennia/web/website/views.py
@@ -659,6 +659,9 @@ class CharacterDetailView(CharacterMixin, ObjectDetailView):
     a character, owned by them or not.
     
     """
+    # -- Django constructs --
+    template_name = 'website/object_detail.html'
+    
     # -- Evennia constructs --
     # What attributes to display for this object
     attributes = ['name', 'desc']

--- a/evennia/web/website/views.py
+++ b/evennia/web/website/views.py
@@ -512,7 +512,7 @@ class AccountMixin(object):
     form_class = AccountForm
 
 
-class AccountCreateView(AccountMixin, ObjectCreateView):
+class AccountCreateView(AccountMixin, EvenniaCreateView):
     """
     Account creation view.
     
@@ -729,7 +729,7 @@ class CharacterCreateView(CharacterMixin, ObjectCreateView):
 #
 # Help views
 #
-#from evennia.help.models import HelpEntry
+
 class HelpMixin(object):
     """
     This is a "mixin", a modifier of sorts.
@@ -741,27 +741,36 @@ class HelpMixin(object):
     # -- Django constructs --
     model = HelpEntry
     
+    # -- Evennia constructs --
+    page_title = 'Help'
+    
     def get_queryset(self):
         """
         Django hook; here we want to return a list of only those HelpEntries
-        that the current user is allowed to see.
+        and other documentation that the current user is allowed to see.
         
         Returns:
             queryset (QuerySet): List of Help entries available to the user.
             
         """
+        account = self.request.user
+        
         # Get list of all HelpEntries
-        entries = HelpEntry.objects.all()
+        entries = self.model.objects.all().iterator()
         
         # Now figure out which ones the current user is allowed to see
-        bucket = []
-        for entry in entries:
-            if entry.access(self.request.user, 'view'):
-                bucket.append(entry.id)
-                
-        # Re-query to just get those
-        entries = HelpEntry.objects.filter(id__in=bucket)
-        return entries
+        bucket = [entry.id for entry in entries if entry.access(account, 'view')]
+        
+        # Re-query and set a sorted list
+        filtered = self.model.objects.filter(
+            id__in=bucket
+        ).order_by(
+            Lower('db_key')
+        ).order_by(
+            Lower('db_help_category')
+        )
+        
+        return filtered
         
 class HelpListView(HelpMixin, ListView):
     """
@@ -770,5 +779,85 @@ class HelpListView(HelpMixin, ListView):
     
     """
     # -- Django constructs --
-    paginate_by = 10
-    template_name = 'website/object_list.html'
+    paginate_by = 500
+    template_name = 'website/help_list.html'
+    
+    # -- Evennia constructs --
+    page_title = "Help Index"
+    
+class HelpDetailView(HelpMixin, EvenniaDetailView):
+    """
+    Returns the detail page for a given help entry.
+    
+    """
+    # -- Django constructs --
+    template_name = 'website/help_detail.html'
+    
+    def get_context_data(self, **kwargs):
+        """
+        Adds navigational data to the template to let browsers go to the next
+        or previous entry in the help list.
+        
+        Returns:
+            context (dict): Django context object
+        
+        """
+        context = super(HelpDetailView, self).get_context_data(**kwargs)
+        
+        # Get the object in question
+        obj = self.get_object()
+        
+        # Get queryset and filter out non-related categories
+        queryset = self.get_queryset().filter(db_help_category=obj.db_help_category).order_by(Lower('db_key'))
+        context['topic_list'] = queryset
+        
+        # Find the index position of the given obj in the queryset
+        objs = list(queryset)
+        for i, x in enumerate(objs):
+            if obj is x:
+                break
+            
+        # Find the previous and next topics, if either exist
+        try: 
+            assert i+1 <= len(objs) and objs[i+1] is not obj
+            context['topic_next'] = objs[i+1]
+        except: context['topic_next'] = None
+        
+        try: 
+            assert i-1 >= 0 and objs[i-1] is not obj
+            context['topic_previous'] = objs[i-1]
+        except: context['topic_previous'] = None
+    
+        # Format the help entry using HTML instead of newlines
+        text = obj.db_entrytext
+        text = text.replace('\r\n\r\n', '\n\n')
+        text = text.replace('\r\n', '\n')
+        text = text.replace('\n', '<br />')
+        context['entry_text'] = text
+        
+        return context
+    
+    def get_object(self, queryset=None):
+        """
+        Override of Django hook that retrieves an object by category and topic
+        instead of pk and slug.
+        
+        Returns:
+            entry (HelpEntry): HelpEntry requested in the URL.
+        
+        """
+        # Get the queryset for the help entries the user can access
+        if not queryset:
+            queryset = self.get_queryset()
+            
+        # Find the object in the queryset
+        category = slugify(self.kwargs.get('category', ''))
+        topic = slugify(self.kwargs.get('topic', ''))
+        obj = next((x for x in queryset if slugify(x.db_help_category)==category and slugify(x.db_key)==topic), None)
+        
+        # Check if this object was requested in a valid manner
+        if not obj:
+            raise HttpResponseBadRequest(u"No %(verbose_name)s found matching the query" %
+              {'verbose_name': queryset.model._meta.verbose_name})
+
+        return obj


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* Adds `web_get_*_url()` methods to HelpEntry objects
* Adds two views to list and display individual Help Entries (subject to authentication and authorization).
* Displays the details about your world in a more public and readily-consumable format.
* Fixes a bug with the account registration page not displaying the username field (ouch).

#### Motivation for adding to Evennia
Puts any written Help documentation to more productive use.

Better web presence and SEO for fledgling games, and by serving as a wiki of sorts it provides an easier entry point for non-coders to get involved with developing a world by contributing narrative.