### PR TITLE
#1704: traceback when prototype key contains `#Number` [READY FOR REVIEW/MERGE]

### DIFF
--- a/evennia/prototypes/protfuncs.py
+++ b/evennia/prototypes/protfuncs.py
@@ -37,6 +37,7 @@ prototype key (this value must be possible to serialize in an Attribute).
 
 from ast import literal_eval
 from random import randint as base_randint, random as base_random, choice as base_choice
+import re
 
 from evennia.utils import search
 from evennia.utils.utils import justify as base_justify, is_iter, to_str
@@ -325,3 +326,15 @@ def objlist(*args, **kwargs):
 
     """
     return ["#{}".format(obj.id) for obj in _obj_search(return_list=True, *args, **kwargs)]
+
+
+def dbref(*args, **kwargs):
+    """
+    Usage $dbref(<#dbref>)
+    Returns one Object searched globally by #dbref. Error if #dbref is invalid.
+    """
+    _RE_DBREF = re.compile(r"\#[0-9]+")
+    if not args or len(args) < 1 or _RE_DBREF.match(args[0]) is None:
+        raise ValueError('$dbref requires a valid #dbref argument.')
+
+    return obj(args[0])

--- a/evennia/prototypes/protfuncs.py
+++ b/evennia/prototypes/protfuncs.py
@@ -44,6 +44,8 @@ from evennia.utils.utils import justify as base_justify, is_iter, to_str
 
 _PROTLIB = None
 
+_RE_DBREF = re.compile(r"\#[0-9]+")
+
 
 # default protfuncs
 
@@ -333,7 +335,6 @@ def dbref(*args, **kwargs):
     Usage $dbref(<#dbref>)
     Returns one Object searched globally by #dbref. Error if #dbref is invalid.
     """
-    _RE_DBREF = re.compile(r"\#[0-9]+")
     if not args or len(args) < 1 or _RE_DBREF.match(args[0]) is None:
         raise ValueError('$dbref requires a valid #dbref argument.')
 

--- a/evennia/prototypes/prototypes.py
+++ b/evennia/prototypes/prototypes.py
@@ -5,7 +5,6 @@ Handling storage of prototypes, both database-based ones (DBPrototypes) and thos
 
 """
 
-import re
 import hashlib
 import time
 from ast import literal_eval
@@ -32,8 +31,6 @@ _PROTOTYPE_RESERVED_KEYS = _PROTOTYPE_META_NAMES + (
 _PROTOTYPE_TAG_CATEGORY = "from_prototype"
 _PROTOTYPE_TAG_META_CATEGORY = "db_prototype"
 PROT_FUNCS = {}
-
-_RE_DBREF = re.compile(r"\$dbref\((\#[0-9]+)\)")
 
 
 class PermissionError(RuntimeError):
@@ -575,9 +572,6 @@ def protfunc_parser(value, available_functions=None, testing=False, stacktrace=F
         value = to_str(value, force_string=True)
 
     available_functions = PROT_FUNCS if available_functions is None else available_functions
-
-    # $dbref(#Number) becomes $obj(#Number)
-    value = _RE_DBREF.sub("$obj(\\1)", value)
 
     result = inlinefuncs.parse_inlinefunc(
         value, available_funcs=available_functions,

--- a/evennia/prototypes/prototypes.py
+++ b/evennia/prototypes/prototypes.py
@@ -33,7 +33,7 @@ _PROTOTYPE_TAG_CATEGORY = "from_prototype"
 _PROTOTYPE_TAG_META_CATEGORY = "db_prototype"
 PROT_FUNCS = {}
 
-_RE_DBREF = re.compile(r"(?<!\$obj\()(#[0-9]+)")
+_RE_DBREF = re.compile(r"\$dbref\((\#[0-9]+)\)")
 
 
 class PermissionError(RuntimeError):
@@ -576,7 +576,7 @@ def protfunc_parser(value, available_functions=None, testing=False, stacktrace=F
 
     available_functions = PROT_FUNCS if available_functions is None else available_functions
 
-    # insert $obj(#dbref) for #dbref
+    # $dbref(#Number) becomes $obj(#Number)
     value = _RE_DBREF.sub("$obj(\\1)", value)
 
     result = inlinefuncs.parse_inlinefunc(

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -394,23 +394,29 @@ class TestProtFuncs(EvenniaTest):
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
             self.assertEqual(protlib.protfunc_parser("$objlist(#1)", session=self.session), ['#1'])
             mocked__obj_search.assert_called_once()
+            assert ('#1',) == mocked__obj_search.call_args[0]
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
             self.assertEqual(protlib.protfunc_parser("$obj(#1)", session=self.session), '#1')
             mocked__obj_search.assert_called_once()
+            assert ('#1',) == mocked__obj_search.call_args[0]
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
             self.assertEqual(protlib.protfunc_parser("$dbref(#1)", session=self.session), '#1')
             mocked__obj_search.assert_called_once()
+            assert ('#1',) == mocked__obj_search.call_args[0]
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
             self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
             mocked__obj_search.assert_called_once()
+            assert ('Char',) == mocked__obj_search.call_args[0]
 
 
         # bad invocation
 
-        self.assertEqual(protlib.protfunc_parser("$badfunc(#1)", session=self.session), '<UNKNOWN>')
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$badfunc(#1)", session=self.session), '<UNKNOWN>')
+            mocked__obj_search.assert_not_called()
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
             self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -262,6 +262,25 @@ class TestProtFuncs(EvenniaTest):
                      "prototype_desc": "testing prot",
                      "key": "ExampleObj"}
 
+    def test_RE_DBREF(self):
+        def check_RE_DBREF(value, expected_value):
+            try:
+                result = (
+                    protlib._RE_DBREF.match(value),
+                    protlib._RE_DBREF.search(value),
+                    protlib._RE_DBREF.sub("$obj(\\1)", value)
+                )
+                assert expected_value == result[2]
+            except Exception:
+                self.fail()
+                pass
+
+        check_RE_DBREF('#1234', '#1234')
+        check_RE_DBREF('(#1234)', '(#1234)')
+        check_RE_DBREF('obj(#1234)', 'obj(#1234)')
+        check_RE_DBREF('$obj(#1234)', '$obj(#1234)')
+        check_RE_DBREF('obj($obj(#1234))', 'obj($obj(#1234))')
+
     @mock.patch("evennia.prototypes.protfuncs.base_random", new=mock.MagicMock(return_value=0.5))
     @mock.patch("evennia.prototypes.protfuncs.base_randint", new=mock.MagicMock(return_value=5))
     def test_protfuncs(self):
@@ -315,9 +334,14 @@ class TestProtFuncs(EvenniaTest):
         self.assertEqual(protlib.protfunc_parser("$obj(#1)", session=self.session), '#1')
         self.assertEqual(protlib.protfunc_parser("stone(#12345)", session=self.session), 'stone(#12345)')
         self.assertEqual(protlib.protfunc_parser("#1", session=self.session), '#1')
+        self.assertEqual(protlib.protfunc_parser("#12345", session=self.session), '#12345')
+        self.assertEqual(protlib.protfunc_parser("nothing(#1)", session=self.session), 'nothing(#1)')
+        self.assertEqual(protlib.protfunc_parser("(#12345)", session=self.session), '(#12345)')
         self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
         self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
         self.assertEqual(protlib.protfunc_parser("$objlist(#1)", session=self.session), ['#1'])
+
+
 
         self.assertEqual(protlib.value_to_obj(
             protlib.protfunc_parser("#6", session=self.session)), self.char1)

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -11,6 +11,7 @@ from evennia.utils.test_resources import EvenniaTest
 from evennia.utils.tests.test_evmenu import TestEvMenu
 from evennia.prototypes import spawner, prototypes as protlib
 from evennia.prototypes import menus as olc_menus
+from evennia.prototypes import protfuncs as protofuncs
 
 from evennia.prototypes.prototypes import _PROTOTYPE_TAG_META_CATEGORY
 
@@ -344,23 +345,76 @@ class TestProtFuncs(EvenniaTest):
         self.assertEqual(protlib.protfunc_parser(
             "$eval({'test': '1', 2:3, 3: $toint(3.5)})"), {'test': '1', 2: 3, 3: 3})
 
-        self.assertEqual(protlib.protfunc_parser("obj(#1)", session=self.session), 'obj(#1)')
-        self.assertEqual(protlib.protfunc_parser("$obj(#1)", session=self.session), '#1')
-        self.assertEqual(protlib.protfunc_parser("dbref(#1)", session=self.session), 'dbref(#1)')
-        self.assertEqual(protlib.protfunc_parser("$dbref(#1)", session=self.session), '#1')
-        self.assertEqual(protlib.protfunc_parser("$badfunc(#1)", session=self.session), '<UNKNOWN>')
-        self.assertEqual(protlib.protfunc_parser("stone(#12345)", session=self.session), 'stone(#12345)')
-        self.assertEqual(protlib.protfunc_parser("#1", session=self.session), '#1')
-        self.assertEqual(protlib.protfunc_parser("#12345", session=self.session), '#12345')
-        self.assertEqual(protlib.protfunc_parser("nothing(#1)", session=self.session), 'nothing(#1)')
-        self.assertEqual(protlib.protfunc_parser("(#12345)", session=self.session), '(#12345)')
-        self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
-        self.assertEqual(protlib.protfunc_parser("obj(Char)", session=self.session), 'obj(Char)')
-        self.assertEqual(protlib.protfunc_parser("$objlist(#1)", session=self.session), ['#1'])
-        self.assertEqual(protlib.protfunc_parser("objlist(#1)", session=self.session), 'objlist(#1)')
-        self.assertEqual(protlib.protfunc_parser("dbref(Char)", session=self.session), 'dbref(Char)')
-        self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')
 
+        # no object search
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("obj(#1)", session=self.session), 'obj(#1)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("dbref(#1)", session=self.session), 'dbref(#1)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("stone(#12345)", session=self.session), 'stone(#12345)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("#1", session=self.session), '#1')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("#12345", session=self.session), '#12345')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("nothing(#1)", session=self.session), 'nothing(#1)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("(#12345)", session=self.session), '(#12345)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("obj(Char)", session=self.session), 'obj(Char)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("objlist(#1)", session=self.session), 'objlist(#1)')
+            mocked__obj_search.assert_not_called()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("dbref(Char)", session=self.session), 'dbref(Char)')
+            mocked__obj_search.assert_not_called()
+
+
+        # obj search happens
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$objlist(#1)", session=self.session), ['#1'])
+            mocked__obj_search.assert_called_once()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$obj(#1)", session=self.session), '#1')
+            mocked__obj_search.assert_called_once()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$dbref(#1)", session=self.session), '#1')
+            mocked__obj_search.assert_called_once()
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
+            mocked__obj_search.assert_called_once()
+
+
+        # bad invocation
+
+        self.assertEqual(protlib.protfunc_parser("$badfunc(#1)", session=self.session), '<UNKNOWN>')
+
+        with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
+            self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')
+            mocked__obj_search.assert_not_called()
 
 
         self.assertEqual(protlib.value_to_obj(

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -387,7 +387,7 @@ class TestProtFuncs(EvenniaTest):
             mocked__obj_search.assert_not_called()
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
-            # self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')
+            self.assertRaises(ValueError, protlib.protfunc_parser, "$dbref(Char)")
             mocked__obj_search.assert_not_called()
 
 

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -313,6 +313,7 @@ class TestProtFuncs(EvenniaTest):
             "$eval({'test': '1', 2:3, 3: $toint(3.5)})"), {'test': '1', 2: 3, 3: 3})
 
         self.assertEqual(protlib.protfunc_parser("$obj(#1)", session=self.session), '#1')
+        self.assertEqual(protlib.protfunc_parser("stone(#12345)", session=self.session), 'stone(#12345)')
         self.assertEqual(protlib.protfunc_parser("#1", session=self.session), '#1')
         self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')
         self.assertEqual(protlib.protfunc_parser("$obj(Char)", session=self.session), '#6')

--- a/evennia/prototypes/tests.py
+++ b/evennia/prototypes/tests.py
@@ -263,38 +263,6 @@ class TestProtFuncs(EvenniaTest):
                      "prototype_desc": "testing prot",
                      "key": "ExampleObj"}
 
-    def test_RE_DBREF(self):
-        def check_RE_DBREF(value, expected_value,
-                exp_is_match, exp_is_search):
-            try:
-                mm = protlib._RE_DBREF.match(value)
-                ms = protlib._RE_DBREF.search(value)
-                sub1 = protlib._RE_DBREF.sub("$obj(\\1)", value)
-                assert expected_value == sub1
-                assert (exp_is_match and mm) or (not exp_is_match and mm is None)
-                assert (exp_is_search and ms) or (not exp_is_search and ms is None)
-            except Exception as e:
-                self.fail("%r" % ((value, mm, ms, expected_value, exp_is_match, exp_is_search, e),))
-
-        check_RE_DBREF('1234', '1234', False, False)
-        check_RE_DBREF('#1234', '#1234', False, False)
-        check_RE_DBREF('(#1234)', '(#1234)', False, False)
-        check_RE_DBREF('obj(#1234)', 'obj(#1234)', False, False)
-        check_RE_DBREF('dbref(#1234)', 'dbref(#1234)', False, False)
-        check_RE_DBREF('$obj(#1234)', '$obj(#1234)', False, False)
-        check_RE_DBREF('$dbref(#1234)', '$obj(#1234)', True, True)
-        check_RE_DBREF('obj($obj(#1234))', 'obj($obj(#1234))', False, False)
-        check_RE_DBREF('obj($dbref(#1234))', 'obj($obj(#1234))', False, True)
-        check_RE_DBREF('some #1234 value', 'some #1234 value', False, False)
-        check_RE_DBREF('some (#1234) value', 'some (#1234) value', False, False)
-        check_RE_DBREF('some obj(#1234) value', 'some obj(#1234) value', False, False)
-        check_RE_DBREF('some dbref(#1234) value', 'some dbref(#1234) value', False, False)
-        check_RE_DBREF('some $dbref(#1234) value', 'some $obj(#1234) value', False, True)
-        check_RE_DBREF('some obj($obj(#1234) value)', 'some obj($obj(#1234) value)', False, False)
-        check_RE_DBREF('some obj($dbref(#1234) value)', 'some obj($obj(#1234) value)', False, True)
-        check_RE_DBREF('some dbref($obj(#1234) value)', 'some dbref($obj(#1234) value)', False, False)
-        check_RE_DBREF('some dbref($dbref(#1234) value)', 'some dbref($obj(#1234) value)', False, True)
-
     @mock.patch("evennia.prototypes.protfuncs.base_random", new=mock.MagicMock(return_value=0.5))
     @mock.patch("evennia.prototypes.protfuncs.base_randint", new=mock.MagicMock(return_value=5))
     def test_protfuncs(self):
@@ -419,7 +387,7 @@ class TestProtFuncs(EvenniaTest):
             mocked__obj_search.assert_not_called()
 
         with mock.patch("evennia.prototypes.protfuncs._obj_search", wraps=protofuncs._obj_search) as mocked__obj_search:
-            self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')
+            # self.assertEqual(protlib.protfunc_parser("$dbref(Char)", session=self.session), '<UNKNOWN>')
             mocked__obj_search.assert_not_called()
 
 


### PR DESCRIPTION
Fixes #1704 

- `#number` is not automatically converted to object search by `#dbref`. 
- New `$dbref()` protofunc is introduced as alias for `$obj(#Number)`.
- Traceback no longer happens as automatic object search is not done unless explicit `$obj()` or `$dbref()` protofunc is used.