### PR TITLE
Fixes failure to pass credentials to website when authenticating through webclient (#1723)

### DIFF
--- a/evennia/web/utils/middleware.py
+++ b/evennia/web/utils/middleware.py
@@ -15,14 +15,15 @@ class SharedLoginMiddleware(object):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
         
+        # Synchronize credentials between webclient and website
+        # Must be performed *before* rendering the view (issue #1723)
+        self.make_shared_login(request)
+        
         # Process view
         response = self.get_response(request)
 
         # Code to be executed for each request/response after
         # the view is called.
-        
-        # Synchronize credentials
-        self.make_shared_login(request)
         
         # Return processed view
         return response

--- a/evennia/web/webclient/views.py
+++ b/evennia/web/webclient/views.py
@@ -12,52 +12,13 @@ from evennia.accounts.models import AccountDB
 from evennia.utils import logger
 
 
-def _shared_login(request):
-    """
-    Handle the shared login between website and webclient.
-
-    """
-    csession = request.session
-    account = request.user
-    # these can have 3 values:
-    #   None - previously unused (auto-login)
-    #   False - actively logged out (don't auto-login)
-    #   <uid> - logged in User/Account id
-    website_uid = csession.get("website_authenticated_uid", None)
-    webclient_uid = csession.get("webclient_authenticated_uid", None)
-
-    # check if user has authenticated to website
-    if not csession.session_key:
-        # this is necessary to build the sessid key
-        csession.save()
-
-    if webclient_uid:
-        # The webclient has previously registered a login to this browser_session
-        if not account.is_authenticated() and not website_uid:
-            try:
-                account = AccountDB.objects.get(id=webclient_uid)
-            except AccountDB.DoesNotExist:
-                # this can happen e.g. for guest accounts or deletions
-                csession["website_authenticated_uid"] = False
-                csession["webclient_authenticated_uid"] = False
-                return
-            try:
-                # calls our custom authenticate in web/utils/backends.py
-                account = authenticate(autologin=account)
-                login(request, account)
-                csession["website_authenticated_uid"] = webclient_uid
-            except AttributeError:
-                logger.log_trace()
-
-
 def webclient(request):
     """
     Webclient page template loading.
 
     """
-    # handle webclient-website shared login
-    _shared_login(request)
-
+    # auto-login is now handled by evennia.web.utils.middleware
+    
     # make sure to store the browser session's hash so the webclient can get to it!
     pagevars = {'browser_sessid': request.session.session_key}
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes incorrect order of operations when synchronizing credentials across webclient/website and removes redundant code from webclient view.