### PR TITLE
Makes webclient/terminal auto-puppet character selected on website

### DIFF
--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -181,7 +181,7 @@ class CmdUnconnectedCreate(COMMAND_DEFAULT_CLASS):
 
         username, password = parts
 
-        # everything's ok. Create the new account account.
+        # everything's ok. Create the new account.
         account, errors = Account.create(username=username, password=password, ip=address, session=session)
         if account:
             # tell the caller everything went well.

--- a/evennia/web/utils/general_context.py
+++ b/evennia/web/utils/general_context.py
@@ -71,8 +71,19 @@ def general_context(request):
     if request.user.is_authenticated(): account = request.user
 
     puppet = None
-    if account and request.session.get('puppet'):
-        pk = int(request.session.get('puppet'))
+    if account:
+        # Get puppet previously selected from the website
+        if request.session.get('puppet'):
+            pk = int(request.session.get('puppet'))
+            
+        # Get last puppet set from terminal
+        elif account.db._last_puppet:
+            pk = int(account.db._last_puppet.id)
+            
+        # Just get the first character
+        elif account.characters:
+            pk = account.characters[0].id
+            
         puppet = next((x for x in account.characters if x.pk == pk), None)
     
     return {

--- a/evennia/web/website/templates/website/403.html
+++ b/evennia/web/website/templates/website/403.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block titleblock %}404 - Not Found{% endblock %}
+{% block titleblock %}403 - Forbidden{% endblock %}
 
 {% block header_ext %}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
@@ -11,12 +11,12 @@
   <div class="col">
     <div class="card">
       <div class="card-body">
-        <h1 class="card-title">Error 404</h1>
-        <h4 class="card-subtitle">Page not found</h2>
+        <h1 class="card-title">Error 403</h1>
+        <h4 class="card-subtitle">Forbidden</h2>
         <hr />
-        <p>The page you requested could not be found.</p>
+        <p>You are not authorized to perform this action.</p>
         <hr />
-        <p><a href="/">Back to the home page</a></p>
+        <p><a href="{% url 'index' %}">Back to the home page</a></p>
       </div>
     </div>
   </div>

--- a/evennia/web/website/templates/website/_menu.html
+++ b/evennia/web/website/templates/website/_menu.html
@@ -60,7 +60,7 @@ folder and edit it to add/remove links to the menu.
                 {% for character in account.characters|slice:"10" %}
                   <a class="dropdown-item" href="{{ character.web_get_puppet_url }}?next={{ request.path }}">{{ character }}</a>
                 {% empty %} 
-                  <a class="dropdown-item" href="#">No characters found!</a>
+                  <a class="dropdown-item" href="{% url 'character-create' %}">No characters found!</a>
                 {% endfor %}
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="{% url 'password_change' %}">Change Password</a>

--- a/evennia/web/website/templates/website/character_manage_list.html
+++ b/evennia/web/website/templates/website/character_manage_list.html
@@ -19,8 +19,9 @@
             <a href="{{ object.web_get_detail_url }}"><img class="d-flex mr-3" src="http://placehold.jp/50x50.png" alt="" /></a>
             <div class="media-body">
               <p class="float-right ml-2">{{ object.db_date_created }}
-              <br /><a href="{{ object.web_get_delete_url }}">Delete</a>
-              <br /><a href="{{ object.web_get_update_url }}">Edit</a></p>
+              <br /><a href="{{ object.web_get_puppet_url }}?next={{ request.path }}">Puppet</a>
+              <br /><a href="{{ object.web_get_update_url }}">Update</a>
+              <br /><a href="{{ object.web_get_delete_url }}">Delete</a></p>
               <h5 class="mt-0"><a href="{{ object.web_get_detail_url }}">{{ object }}</a> {% if object.subtitle %}<small class="text-muted" style="white-space:nowrap;">{{ object.subtitle }}</small>{% endif %}</h5>
               <p>{{ object.db.desc }}</p>
             </div>

--- a/evennia/web/website/views.py
+++ b/evennia/web/website/views.py
@@ -597,6 +597,8 @@ class CharacterPuppetView(LoginRequiredMixin, CharacterMixin, RedirectView, Obje
             url (str): Path to post-puppet destination.
         
         """
+        account = self.request.user
+        
         # Get the requested character, if it belongs to the authenticated user
         char = self.get_object()
         
@@ -608,6 +610,11 @@ class CharacterPuppetView(LoginRequiredMixin, CharacterMixin, RedirectView, Obje
             # Django request's session (different from Evennia session!).
             # We do this because characters don't serialize well.
             self.request.session['puppet'] = int(char.pk)
+            
+            # We need to set this to have the webclient or terminal auto-connect 
+            # to this character
+            account.db._last_puppet = char
+            
             messages.success(self.request, "You become '%s'!" % char)
         else:
             # If the puppeting failed, clear out the cached puppet value


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR makes it so that if you select a character on the website and then hop into the game, you'll automatically become that character.

Also adds a link to the puppet activation URL as an action on the character management page.

#### Motivation for adding to Evennia
Currently the character quick-select on the website is cosmetic only and does nothing out of the box.