### PR TITLE
Removes 'safe' template tag from help detail page (vulnerability).

### DIFF
--- a/evennia/web/website/templates/website/help_detail.html
+++ b/evennia/web/website/templates/website/help_detail.html
@@ -25,7 +25,7 @@
         <div class="row">
           <!-- left column -->
           <div class="col-lg-9 col-sm-12">
-            <p>{{ entry_text|safe }}</p>
+            <p>{{ entry_text }}</p>
             
             {% if topic_previous or topic_next %}
             <hr />


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes the 'safe' template tag from the help detail template.

#### Motivation for adding to Evennia
I put the tag in with the intention of letting writers use HTML in their help entries but in retrospect this makes little sense (HTML won't render if the same entry is viewed in a terminal client) and is a security vulnerability anyway (malicious HTML/scripts that find its way into a help entry will be happily rendered).

It would be better to ship secure by default and force user acceptance of the risks by modifying the template themselves.