### PR TITLE
Returns 404 if webclient is supposed to be disabled (fixes #1731)

### DIFF
--- a/evennia/web/webclient/views.py
+++ b/evennia/web/webclient/views.py
@@ -5,6 +5,8 @@ page and serve it eventual static content.
 
 """
 from __future__ import print_function
+from django.conf import settings
+from django.http import Http404
 from django.shortcuts import render
 from django.contrib.auth import login, authenticate
 
@@ -18,6 +20,10 @@ def webclient(request):
 
     """
     # auto-login is now handled by evennia.web.utils.middleware
+    
+    # check if webclient should be enabled
+    if not settings.WEBCLIENT_ENABLED:
+        raise Http404
     
     # make sure to store the browser session's hash so the webclient can get to it!
     pagevars = {'browser_sessid': request.session.session_key}

--- a/evennia/web/website/tests.py
+++ b/evennia/web/website/tests.py
@@ -94,6 +94,18 @@ class PasswordResetTest(EvenniaWebTest):
 class WebclientTest(EvenniaWebTest):
     url_name = 'webclient:index'
     
+    @override_settings(WEBCLIENT_ENABLED=True)
+    def test_get(self):
+        self.authenticated_response = 200
+        self.unauthenticated_response = 200
+        super(WebclientTest, self).test_get()
+    
+    @override_settings(WEBCLIENT_ENABLED=False)
+    def test_get_disabled(self):
+        self.authenticated_response = 404
+        self.unauthenticated_response = 404
+        super(WebclientTest, self).test_get()
+    
 class ChannelListTest(EvenniaWebTest):
     url_name = 'channels'
     


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Webclient is currently hidden instead of disabled. This PR returns a 404 at the view level if the webclient is supposed to be disabled.

#### Other info (issues closed, discussion etc)
Issue #1731 