### PR TITLE
Update split.min.js CDN URL - fixes #1737

### DIFF
--- a/evennia/web/webclient/templates/webclient/base.html
+++ b/evennia/web/webclient/templates/webclient/base.html
@@ -64,7 +64,7 @@ JQuery available.
     <script src={% static "webclient/js/evennia.js" %} language="javascript" type="text/javascript" charset="utf-8"/></script>
 
     <!-- set up splits before loading the GUI -->
-    <script src="https://unpkg.com/split.js/split.min.js"></script>
+    <script src="https://unpkg.com/split.js@1.5.9/dist/split.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
 
     <!-- Load gui library -->


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Update URL for the CDN for split.min.js - fixes #1737 

#### Motivation for adding to Evennia
The CDN URL changed for split.min.js - this fixes that, and also keeps the version the same.

#### Other info (issues closed, discussion etc)
Closes #1737 and fixes the same bug on desktop.
