### PR TITLE
Adds delete() lock to new character objects (#1729)

### DIFF
--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -162,8 +162,8 @@ class CmdCharCreate(COMMAND_DEFAULT_CLASS):
                                              home=default_home,
                                              permissions=permissions)
         # only allow creator (and developers) to puppet this char
-        new_character.locks.add("puppet:id(%i) or pid(%i) or perm(Developer) or pperm(Developer)" %
-                                (new_character.id, account.id))
+        new_character.locks.add("puppet:id(%i) or pid(%i) or perm(Developer) or pperm(Developer);delete:id(%i) or perm(Admin)" %
+                                (new_character.id, account.id, account.id))
         account.db._playable_characters.append(new_character)
         if desc:
             new_character.db.desc = desc
@@ -222,6 +222,12 @@ class CmdCharDelete(COMMAND_DEFAULT_CLASS):
 
             match = match[0]
             account.ndb._char_to_delete = match
+            
+            # Return if caller has no permission to delete this
+            if not match.access(account, 'delete'):
+                self.msg("You do not have permission to delete this character.")
+                return
+            
             prompt = "|rThis will permanently destroy '%s'. This cannot be undone.|n Continue yes/[no]?"
             get_input(account, prompt % match.key, _callback)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1894,7 +1894,7 @@ class DefaultCharacter(DefaultObject):
     """
     # lockstring of newly created rooms, for easy overloading.
     # Will be formatted with the appropriate attributes.
-    lockstring = "puppet:id({character_id}) or pid({account_id}) or perm(Developer) or pperm(Developer)"
+    lockstring = "puppet:id({character_id}) or pid({account_id}) or perm(Developer) or pperm(Developer);delete:id({account_id}) or perm(Admin)"
 
     @classmethod
     def create(cls, key, account, **kwargs):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When characters are created using CmdCharCreate or Character.create(), a delete() lock is now set to explicitly let account owners delete characters.

#### Motivation for adding to Evennia
Inconsistent handling; see #1729

#### Other info (issues closed, discussion etc)
