### PR TITLE
Adds STAFF_CONTACT_EMAIL setting and value to unloggedin help command

### DIFF
--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -276,6 +276,9 @@ Next you can connect to the game: |wconnect Anna c67jHL8p|n
 You can use the |wlook|n command if you want to see the connect screen again.
 
 """
+
+        if settings.STAFF_CONTACT_EMAIL:
+            string += 'For support, please contact: %s' % settings.STAFF_CONTACT_EMAIL
         self.caller.msg(string)
 
 

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -670,6 +670,9 @@ DEBUG = False
 ADMINS = ()  # 'Your Name', 'your_email@domain.com'),)
 # These guys get broken link notifications when SEND_BROKEN_LINK_EMAILS is True.
 MANAGERS = ADMINS
+# This is a public point of contact for players or the public to contact
+# a staff member or administrator of the site. It is publicly posted.
+STAFF_CONTACT_EMAIL = None
 # Absolute path to the directory that holds file uploads from web apps.
 # Example: "/home/media/media.lawrence.com"
 MEDIA_ROOT = os.path.join(GAME_DIR, "web", "media")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a setting to specify the point of contact unauthenticated users should use to contact a staff/admin member.

Will display the address in the unloggedin help command text if it is set.

#### Motivation for adding to Evennia
If one can't login, they have no other support channels open to them-- no way to appeal bans, address client/auth issues, or anything.

#### Other info (issues closed, discussion etc)
Closes #1719 