### PR TITLE
Allow the 'makemessages' and 'compilemessages' commands

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1641,7 +1641,7 @@ def error_check_python_modules():
 #
 # ------------------------------------------------------------
 
-def init_game_directory(path, check_db=True):
+def init_game_directory(path, check_db=True, need_gamedir=True):
     """
     Try to analyze the given path to find settings.py - this defines
     the game directory and also sets PYTHONPATH as well as the django
@@ -1650,15 +1650,17 @@ def init_game_directory(path, check_db=True):
     Args:
         path (str): Path to new game directory, including its name.
         check_db (bool, optional): Check if the databae exists.
+        need_gamedir (bool, optional): set to False if Evennia doesn't require to be run in a valid game directory.
 
     """
     # set the GAMEDIR path
-    set_gamedir(path)
+    if need_gamedir:
+        set_gamedir(path)
 
     # Add gamedir to python path
     sys.path.insert(0, GAMEDIR)
 
-    if TEST_MODE:
+    if TEST_MODE or not need_gamedir:
         if ENFORCED_SETTING:
             print(NOTE_TEST_CUSTOM.format(settings_dotpath=SETTINGS_DOTPATH))
             os.environ['DJANGO_SETTINGS_MODULE'] = SETTINGS_DOTPATH
@@ -1684,6 +1686,10 @@ def init_game_directory(path, check_db=True):
     # this will both check the database and initialize the evennia dir.
     if check_db:
         check_database()
+
+    # if we don't have to check the game directory, return right away
+    if not need_gamedir:
+        return
 
     # set up the Evennia executables and log file locations
     global AMP_PORT, AMP_HOST, AMP_INTERFACE
@@ -2088,6 +2094,10 @@ def main():
     elif option != "noop":
         # pass-through to django manager
         check_db = False
+        need_gamedir = True
+        # some commands don't require the presence of a game directory to work
+        if option in ('makemessages', 'compilemessages'):
+            need_gamedir = False
 
         # handle special django commands
         if option in ('runserver', 'testserver'):
@@ -2100,7 +2110,7 @@ def main():
             global TEST_MODE
             TEST_MODE = True
 
-        init_game_directory(CURRENT_DIR, check_db=check_db)
+        init_game_directory(CURRENT_DIR, check_db=check_db, need_gamedir=need_gamedir)
 
         # pass on to the manager
         args = [option]
@@ -2116,6 +2126,11 @@ def main():
                     kwargs[arg.lstrip("--")] = value
                 else:
                     args.append(arg)
+
+        # makemessages needs a special syntax to not conflict with the -l option
+        if len(args) > 1 and args[0] == "makemessages":
+            args.insert(1, "-l")
+
         try:
             django.core.management.call_command(*args, **kwargs)
         except django.core.management.base.CommandError as exc:

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -115,7 +115,7 @@ AMP_INTERFACE = '127.0.0.1'
 EVENNIA_DIR = os.path.dirname(os.path.abspath(__file__))
 # Path to the game directory (containing the server/conf/settings.py file)
 # This is dynamically created- there is generally no need to change this!
-if sys.argv[1] == 'test' if len(sys.argv) > 1 else False:
+if EVENNIA_DIR.lower() == os.getcwd().lower() or (sys.argv[1] == 'test' if len(sys.argv) > 1 else False):
     # unittesting mode
     GAME_DIR = os.getcwd()
 else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Since the new evennia launcher, both `makemessages` and `compilemessages` were broken.  This offers a solution to fix it and allow both commands to work.

#### Motivation for adding to Evennia

Translation of the main Evennia server wasn't possible. Notice a few changes though, some of which may not be appropriate:

- In `settings_default`, the `GAMEDIR` can now be the `EVENNIA_DIR` if the user is running from `evennia`.  We'll let another method check whether it's a problem or not.  Having this check performed in the settings AND in the launcher was a understandable redundancy that didn't help here.  This test is still performed, however, so error messages are correctly displayed if the user isn't in a valid game directory and tries to perform a command like `evennia start`.
- In the launcher, `init_gamedir` now takes an additional optional argument to indicate whether this has to be a valid game directory or not.
- Still in the launcher, `makemessages` is handled as a special case: the `-l` option, used by `makemessages`, conflicts with the option to tail log files.  We cannot use the long option name due to the way `makemessages` handles the `-l/--locale` option (as a list, not a simple `str`).  Therefore, I had to add a tweak just for this command.  The syntax now is:

        evennia makemessages <locale-code>

    The `-l` option will be inserted in between.
