### PR TITLE
Fix #1754: WindowsError is replaced with OSError

### DIFF
--- a/evennia/__init__.py
+++ b/evennia/__init__.py
@@ -105,7 +105,7 @@ def _create_version():
         print(err)
     try:
         version = "%s (rev %s)" % (version, check_output("git rev-parse --short HEAD", shell=True, cwd=root, stderr=STDOUT).strip())
-    except (IOError, CalledProcessError, WindowsError):
+    except (IOError, CalledProcessError, OSError):
         # ignore if we cannot get to git
         pass
     return version

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1217,7 +1217,7 @@ def evennia_version():
             "git rev-parse --short HEAD",
             shell=True, cwd=EVENNIA_ROOT, stderr=STDOUT).strip()
         version = "%s (rev %s)" % (version, rev)
-    except (IOError, CalledProcessError, WindowsError):
+    except (IOError, CalledProcessError, OSError):
         # move on if git is not answering
         pass
     return version


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The `WindowsError` exception was checked for compliance and is now removed to support non-Windows systems.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)