### PR TITLE
BugFix - Delete Prototypes using spawn command

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3041,7 +3041,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
                     caller.msg("|rDeletion cancelled.|n")
                     return
                 try:
-                    success = protlib.delete_db_prototype(caller, self.args)
+                    success = protlib.delete_prototype(self.args)
                 except protlib.PermissionError as err:
                     caller.msg("|rError deleting:|R {}|n".format(err))
                 caller.msg("Deletion {}.".format(


### PR DESCRIPTION
Spawn/delete <prototypekey> was not actually deleting anything.  This enables the command to work as expected.

#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
