### PR TITLE
Fix a slight error in search with candidates

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -427,6 +427,7 @@ class DefaultObject(with_metaclass(TypeclassBase, ObjectDB)):
             # only allow exact matching if searching the entire database
             # or unique #dbrefs
             exact = True
+            candidates = None
         elif candidates is None:
             # no custom candidates given - get them automatically
             if location:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When overriding the `search` method, and providing default candidates, search fails when using DBREF directly.  This has been fixed.

#### Motivation for adding to Evennia

The problem is a bit hard to describe.  When overriding the `search` method (say, in `Character`) and providing default candidates (not changing anything else), the search will fail.  This is due to the fact that `use_dbref` is calculated in the super method, along with `exact`.  So I made sure to place `candidates` to an empty value if the search was evaluated to an exact, global search, otherwise it created problem downstream.

#### Other info (issues closed, discussion etc)