### PR TITLE
Encoding and Python 3

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -638,7 +638,7 @@ class AMPLauncherProtocol(amp.AMP):
         else:
             status = pickle.loads(status)
             callback(status)
-        return {b"status": b""}
+        return {"status": pickle.dumps(b"")}
 
 
 def send_instruction(operation, arguments, callback=None, errback=None):

--- a/evennia/server/portal/amp.py
+++ b/evennia/server/portal/amp.py
@@ -73,11 +73,11 @@ Content-Type: text/html
 # Helper functions for pickling.
 
 def dumps(data):
-    return to_str(pickle.dumps(to_str(data), pickle.HIGHEST_PROTOCOL))
+    return pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
 
 
 def loads(data):
-    return pickle.loads(to_str(data))
+    return pickle.loads(data)
 
 
 @wraps

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -243,7 +243,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
             line (str): Line to send.
 
         """
-        line = bytes(line, 'utf-8')
+        line = self.try_encode(line)
         # escape IAC in line mode, and correctly add \r\n (the TELNET end-of-line)
         line = line.replace(IAC, IAC + IAC)
         line = line.replace(b'\n', b'\r\n')
@@ -343,7 +343,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
                                          strip_ansi=nocolor, xterm256=xterm256)
                 if mxp:
                     prompt = mxp_parse(prompt)
-            prompt = prompt.encode()
+            prompt = self.try_encode(prompt)
             prompt = prompt.replace(IAC, IAC + IAC).replace(b'\n', b'\r\n')
             prompt += IAC + GA
             self.transport.write(mccp_compress(self, prompt))

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -243,7 +243,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
             line (str): Line to send.
 
         """
-        line = self.try_encode(line)
+        line = self.encode_output(line)
         # escape IAC in line mode, and correctly add \r\n (the TELNET end-of-line)
         line = line.replace(IAC, IAC + IAC)
         line = line.replace(b'\n', b'\r\n')
@@ -343,7 +343,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
                                          strip_ansi=nocolor, xterm256=xterm256)
                 if mxp:
                     prompt = mxp_parse(prompt)
-            prompt = self.try_encode(prompt)
+            prompt = self.encode_output(prompt)
             prompt = prompt.replace(IAC, IAC + IAC).replace(b'\n', b'\r\n')
             prompt += IAC + GA
             self.transport.write(mccp_compress(self, prompt))

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -137,9 +137,9 @@ class Session(object):
 
     # helpers
 
-    def try_encode(self, text):
+    def encode_output(self, text):
         """
-        Try to encode the given text, following the session's protocol flag.
+        Encode the given text for output, following the session's protocol flag.
 
         Args:
             text (str or bytes): the text to encode to bytes.

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -135,6 +135,41 @@ class Session(object):
         if self.account:
             self.protocol_flags.update(self.account.attributes.get("_saved_protocol_flags", {}))
 
+    # helpers
+
+    def try_encode(self, text):
+        """
+        Try to encode the given text, following the session's protocol flag.
+
+        Args:
+            text (str or bytes): the text to encode to bytes.
+
+        Returns:
+            encoded_text (bytes): the encoded text following the session's
+                    protocol flag.  If the converting fails, log the error
+                    and send the text with "?" in place of problematic
+                    characters.  If the specified encoding cannot be found,
+                    the protocol flag is reset to utf-8.
+                    In any case, returns bytes.
+
+        Note:
+            If the argument is bytes, return it as is.
+
+        """
+        if isinstance(text, bytes):
+            return text
+
+        try:
+            encoded = text.encode(self.protocol_flags["ENCODING"])
+        except LookupError:
+            self.protocol_flags["ENCODING"] = 'utf-8'
+            encoded = text.encode('utf-8')
+        except UnicodeEncodeError:
+            print("An error occurred during string encoding to {encoding}.  Will remove errors and try again.".format(encoding=self.protocol_flags["ENCODING"]))
+            encoded = text.encode(self.protocol_flags["ENCODING"], errors="replace")
+
+        return encoded
+
     # access hooks
 
     def disconnect(self, reason=None):


### PR DESCRIPTION
#### Brief summary of issue

The current branch running on Python 3.5 of Python has some issues with encoding that most ASCII users wouldn't notice.  Basically, it's either ASCII, or utf-8, the rest doesn't work.  And while I would be happy to have everyone using utf-8, it's clearly not a good choice, particularly with Evennia's settings.

#### Steps to reproduce the issue / Reasons for adding feature:

To see the problem:

1. Install a fresh Evennia with the develop-py3 branch.
2. In the `server/conf/connection_screens.py` file, append some utf-8 in the file (see mine below).
3. With a client that uses a different encoding (mine uses latin-1 for instance), connect to localhost:4000.  You will see an error on the accented character, as you should (default encoding isn't changed).
4. Use the `@encoding` command to change your output encoding.  In my case: `@encoding latin-1` .
5. And type `look` to see... the exact same error.

```python
# connection_screen
CONNECTION_SCREEN = """
médor
|b==============================================================|n
 Welcome to |g{}|n, version {}!

 If you have an existing account, connect to it by typing:
      |wconnect <username> <password>|n
 If you need to create an account, type (without the <>'s):
      |wcreate <username> <password>|n

 If you have spaces in your username, enclose it in quotes.
 Enter |whelp|n for more info. |wlook|n will re-show this screen.
|b==============================================================|n""" \
    .format(settings.SERVERNAME, utils.get_evennia_version())
```

(Yes, it's the é in "médor", which is a beautiful dog name).

#### Error output / Expected result of feature

What happens?  I would like to know.  It's not just an error of the `@encoding` command, it's the encoding system that's a bit broken.  Full debugging didn't allow me to find the proper solution... but I identified some possible root causes and here's my thinking:

1. `to_str` is called A LOT.  This is probably a very bad idea for encoding support.  In Python 3, every string within the program should be utf-8 (str type).  Converting to other encoding (bytes) should only happen before every evennia-related processing (input), and just before submitting to the client (output).  Some functions (like `pickle.dumps` which is used by `amp.dumps`) return bytes.  Is that where the encoding should be handled?  Turning this bytes into a string afterward (look at the `server.portal.amp.dumps` function) might break some things.
2. The only point where I found the ENCODING protocol flag being used is in `server/sessionhandler.py`.  It converts bytes to string following the encoding.  Again, I would think the other way around would be preferable: converting string to bytes before sending them... but I don't know enough of Evennia's structure to be sure.  And since there's the AMP to consider between them, I don't feel like coming up with a solution by myself, without guidance.

In my opinion, the greatest problem is the excessive `to_str` calls, but again, that might not be the reason for the problem.  If anyone wants additional debugging and can orient me in the right direction, I'll take it.

#### Extra information, such as Evennia revision/repo/branch, operating system and ideas for how to solve / implement:

* Evennia branch: develop-py3
