### PR TITLE
Fix accents in Evennia py3, bring compatibility with Evennia 0.8 data

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -30,7 +30,7 @@ except ImportError:
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.contenttypes.models import ContentType
 from django.utils.safestring import SafeString, SafeBytes
-from evennia.utils.utils import to_str, uses_database, is_iter
+from evennia.utils.utils import uses_database, is_iter
 from evennia.utils import logger
 
 __all__ = ("to_pickle", "from_pickle", "do_pickle", "do_unpickle",
@@ -674,7 +674,7 @@ def from_pickle(data, db_obj=None):
 
 def do_pickle(data):
     """Perform pickle to string"""
-    return to_str(dumps(data, protocol=PICKLE_PROTOCOL))
+    return dumps(data, protocol=PICKLE_PROTOCOL)
 
 
 def do_unpickle(data):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

I jsut removed yet another `to_str()` call on the `dbserializer`.  Not only did it fix my issue, but it makes old databases (generated with Evennia 0.8) completely usable now.

#### Motivation for adding to Evennia

It seems like a win-win.  Just a tiny change, Evennia works better and maintains compatibility of data, which was a concern for me, with some users having a much more important database than I.  I worried it would generate problems, but it seems more than stable and to actually fix issues.

The thing is to get used to the idea that pickle needs bytes, and to not convert these bytes to str, especially not with `to_str`.  Basically, pickle will return binary data, and using `to_str` on it will attempt encoding the binary which is dangerous and unnecessary.  So now, I let pickle do its magic and if it wants bytes, bytes it should have.  In terms of exchange with the AMP, bytes are used to transfer data, but inside these binary representation, it's plain str.  str are only converted to bytes when receiving data from the user and just before sending data to the user.

#### Other info (issues closed, discussion etc)