### PR TITLE
Add a dual_input plugin

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/default_in.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/default_in.js
@@ -8,9 +8,10 @@ let defaultin_plugin = (function () {
     //
     // handle the default <enter> key triggering onSend()
     var onKeydown = function (event) {
-	$("#inputfield").focus();
-        if ( (event.which === 13) && (!event.shiftKey) ) {  // Enter Key without shift
-            var inputfield = $("#inputfield");
+        var inputfield = $("#inputfield");
+ 
+        // Enter Key without shift
+        if ( inputfield.is(":focus") && (event.which === 13) && (!event.shiftKey) ) {
             var outtext = inputfield.val();
             var lines = outtext.trim().replace(/[\r]+/,"\n").replace(/[\n]+/, "\n").split("\n");
             for (var i = 0; i < lines.length; i++) {

--- a/evennia/web/webclient/static/webclient/js/plugins/dual_input.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/dual_input.js
@@ -1,0 +1,72 @@
+/*
+ *
+ * Dual Input Pane Plugin (Requires splithandler plugin)
+ *
+ * This adds a second input window for games that really benefit from having two separate,
+ * high-complexity commands being created at the same time.
+ *
+ * Note: Incompatible with hotbuttons plugin because both Split() the same location
+ *       Split.js doesn't seem to support adding multiple splits at the same <tag> level.
+ */
+plugin_handler.add('dual_input', (function () {
+    //
+    // onKeydown check if the second inputfield is focused.
+    // If so, send the input on '<Enter>' key.
+    var onKeydown = function () {
+        let inputfield = $("#inputfield2");
+        if ( inputfield.is(":focus") ) {
+            if( (event.which === 13) && (!event.shiftKey) ) {
+                var outtext = inputfield.val();
+                var lines = outtext.trim().replace(/[\r\n]+/,"\n").split("\n");
+
+                for (var i = 0; i < lines.length; i++) {
+                    plugin_handler.onSend( lines[i].trim() );
+                }
+
+                inputfield.val('');
+                event.preventDefault();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //
+    // Initialize me
+    var init = function() {
+        // Add buttons to the UI
+        var input2 = $( [
+              '<div id="input2" class="split split-vertical">',
+              ' <textarea id="inputfield2" type="text"></textarea>',
+              '</div>',
+            ].join("\n") );
+
+        // Add second inputform between the existing #main and #inputform,
+        // replacing the previous gutter div added by the splithandler plugin
+        $('#input').prev().replaceWith(input2);
+
+        Split(['#main','#input2','#input'], {
+            sizes: [80,10,10],
+            direction: 'vertical',
+            gutterSize: 4,
+            minSize: [150,50,50],
+        });
+
+        $('#inputfield2').css({
+            "display": "inline",
+            "height": "100%",
+            "width": "100%",
+            "background-color": "black",
+            "color": "white",
+            "padding": "0 .45rem",
+            "font-size": "1.1rem",
+            "font-family": "'DejaVu Sans Mono', Consolas, Inconsolata, 'Lucida Console', monospace"
+            });
+        console.log("Dual Input Plugin Initialized.");
+    }
+
+    return {
+        init: init,
+        onKeydown: onKeydown,
+    }
+})());

--- a/evennia/web/webclient/templates/webclient/base.html
+++ b/evennia/web/webclient/templates/webclient/base.html
@@ -72,8 +72,10 @@ JQuery available.
         <script src={% static "webclient/js/webclient_gui.js" %} language="javascript" type="text/javascript" charset="utf-8"></script>
         <script src={% static "webclient/js/plugins/popups.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/options.js" %} language="javascript" type="text/javascript"></script>
-        <script src={% static "webclient/js/plugins/history.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/splithandler.js" %} language="javascript" type="text/javascript"></script>
+<!-- <script src={% static "webclient/js/plugins/dual_input.js" %} language="javascript" type="text/javascript"></script> -->
+<!-- <script src={% static "webclient/js/plugins/hotbuttons.js" %} language="javascript" type="text/javascript"></script> -->
+        <script src={% static "webclient/js/plugins/history.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/default_in.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/oob.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/notifications.js" %} language="javascript" type="text/javascript"></script>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This set of changes alters the webclient's current plugins to allow for a second input textarea.
This requires some changes to the current default_in plugin and extensive changes to the history plugin.
To make this work, the auto-focus-on-keypress must be removed.  This is a change in default behavior.

#### Motivation for adding to Evennia
Lots of game types benefit greatly when the client supports the option for dual input text areas

#### Other info (issues closed, discussion etc)
