### PR TITLE
bugfix: barrel(rack_barrel) description before the barrel is even created

### DIFF
--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -420,10 +420,6 @@ north
 
  (to get a weapon from the barrel, use |wget weapon|n)
 #
-@desc barrel =
- This barrel has the air of leftovers - it contains an assorted
- mess of random weaponry in various states and qualities.
-#
 @detail barkeep;man;landlord =
  The landlord is a cheerful fellow, always ready to supply you with
  more beer. He mentions doing some sort of arcane magic known as
@@ -438,6 +434,10 @@ north
 # Create the weapon rack (the barrel)
 #
 @create/drop barrel: tutorial_world.objects.WeaponRack
+#
+@desc barrel =
+ This barrel has the air of leftovers - it contains an assorted
+ mess of random weaponry in various states and qualities.
 #
 @lock barrel = get:false()
 #


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Bugfix: barrel description `@desc barrel =` was executed in tutorial batch file build.ev before the barrel was even created with `@create/drop barrel:`.
Now the sequence is fixed and tested working properly with @batchcommand/interactive tutorial_world.build.