### PR TITLE
Trying to pickup 'locked barrel', player now receives hint to 'get we…

### DIFF
--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -444,7 +444,7 @@ north
 # Players trying to pickup barrel will receive hint to 'get weapon' instead
 #
 @set barrel/get_err_msg =
-    The barkeep shakes his head. He says: 'Get weapon, not the barrel.'
+ The barkeep shakes his head. He says: 'Get weapon, not the barrel.'
 #
 # This id makes sure that we cannot pick more than one weapon from this rack
 #

--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -442,6 +442,7 @@ north
 @lock barrel = get:false()
 #
 # Players trying to pickup barrel will receive hint to 'get weapon' instead
+#
 @set barrel/get_err_msg =
     The barkeep shakes his head. He says: 'Get weapon, not the barrel.'
 #

--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -177,7 +177,7 @@ start
 #
 # This room inherits from a Typeclass called WeatherRoom. It regularly
 # and randomly shows some weather effects. Note how we can spread the
-# command's arguments over more than one line for easy reading.  we
+# command's arguments over more than one line for easy reading.  We
 # also make sure to create plenty of aliases for the room and
 # exits. Note the alias tut#02: this unique identifier can be used
 # later in the script to always find the way back to this room (for

--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -441,6 +441,10 @@ north
 #
 @lock barrel = get:false()
 #
+# Players trying to pickup barrel will receive hint to 'get weapon' instead
+@set barrel/get_err_msg =
+    The barkeep shakes his head. He says: 'Get weapon, not the barrel.'
+#
 # This id makes sure that we cannot pick more than one weapon from this rack
 #
 @set barrel/rack_id = "rack_barrel"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Tutorial build.ev batch file.
Added custom message for player trying to pickup weapon barrel with `get:false()` lock on.

#### Motivation for adding to Evennia
I had trouble to figure syntax to get weapon from barrel. Now barkeep will suggest 'get weapon'
on picking weapon barrel. Plus of course there was no custom message on trying to pickup
this barrel like with other items. 
(suggested by CloudKeeper)
