### PR TITLE
Fixed "mobon ghost" command called during creation of tutorial world.

### DIFF
--- a/evennia/contrib/tutorial_world/mob.py
+++ b/evennia/contrib/tutorial_world/mob.py
@@ -43,12 +43,16 @@ class CmdMobOnOff(Command):
         mob = self.caller.search(args)
         if not mob:
             return
+        # checks for mob.db.is_dead help to prevent some instance of command
+        # triggered by irrelevant argument
         if self.cmdstring == "mobon":
-            mob.set_alive()
-            self.caller.msg("Mobile set alive.")
+            if mob.db.is_dead == True:
+                mob.set_alive()
+                self.caller.msg("Mobile set alive.")
         else:
-            mob.set_dead()
-            self.caller.msg("Mobile set dead.")
+            if mob.db.is_dead == False: 
+                mob.set_dead()
+                self.caller.msg("Mobile set dead.")
 
 
 class MobCmdSet(CmdSet):

--- a/evennia/contrib/tutorial_world/mob.py
+++ b/evennia/contrib/tutorial_world/mob.py
@@ -39,13 +39,16 @@ class CmdMobOnOff(Command):
         if not self.args:
             self.caller.msg("Usage: mobon||moboff <mob>")
             return
-        mob = self.caller.search(self.args)
+        args = str(self.args).lstrip()
+        mob = self.caller.search(args)
         if not mob:
             return
         if self.cmdstring == "mobon":
             mob.set_alive()
+            self.caller.msg("Mobile set alive.")
         else:
             mob.set_dead()
+            self.caller.msg("Mobile set dead.")
 
 
 class MobCmdSet(CmdSet):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Before: batchcommander executing `mobon ghost` caused error and mobile wasn't activated.
Now: Works without error. Output message confirming execution of the command.

Comment:
In self.args there was whitespace in front plus data type 'unicode' as potential sources of why self.caller.search(self.args) not worked. changing to type str and removing whitespace seem to fix it.
I also added feedback on proper command execution because there was none and it felt wrong to just guess it from mobile behavior alone.
