### PR TITLE
Fix lockcmd bug not ignoring superuser when using switches. Resolves #1796.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1972,7 +1972,7 @@ class CmdLock(ObjManipCommand):
                 caller.msg("You need 'control' access to change this type of lock.")
                 return
 
-            if not has_control_access or obj.access(caller, "edit"):
+            if not (has_control_access or obj.access(caller, "edit")):
                 caller.msg("You are not allowed to do that.")
                 return
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes bug in @lock command, where Superuser does not bypass control/edit access when attempting
to use switches per command's secondary syntax.
#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
Resolves #1796.