### PR TITLE
Update Dockerfile to use Python3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,13 @@
 # as a base for creating your own custom containerized Evennia game. For more
 # info, see https://github.com/evennia/evennia/wiki/Running%20Evennia%20in%20Docker .
 #
-FROM alpine
+FROM python:3.7-alpine
 
 LABEL maintainer="www.evennia.com"
 
 # install compilation environment
-RUN apk update && apk add bash gcc jpeg-dev musl-dev procps py-pip \
-py-setuptools py2-openssl python python-dev zlib-dev gettext
+RUN apk update && apk add bash gcc jpeg-dev musl-dev procps \
+libffi-dev openssl-dev zlib-dev gettext
 
 # add the files required for pip installation
 COPY ./setup.py /usr/src/evennia/

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1295,18 +1295,6 @@ def check_main_evennia_dependencies():
     if error:
         sys.exit()
 
-    # fix a common zope issue with a missing __init__ file
-    zope_interface = importlib.import_module("zope.interface")
-    expected_init_path = os.path.join(
-        os.path.dirname(os.path.dirname(zope_interface.__file__)), "__init__.py")
-    if not os.path.exists(expected_init_path):
-        # add an empty missing __init__.py file to fix the problem
-        with open(expected_init_path, 'w') as zope_init_file:
-            zope_init_file.write("")
-        print("Note: zope_interface.__init__.py not found. This is a known issue with that package."
-              "\nEvennia auto-created it at {}.".format(
-                    expected_init_path))
-
     # return True/False if error was reported or not
     return not error
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Switched the Dockerfile to python3

#### Motivation for adding to Evennia

**evennia/evennia:develop** is still on python2 and can't actually run evennia any more!

#### Other info (issues closed, discussion etc)

- Changed the base image from `alpine` -> `python:3.7-alpine` due to alpine only having python3.6 in repos. Some packages have changed as a result.
- I had to remove the zope `__init__.py` workaround because evennia was trying to alter zope files in the container which were owned by `root`. I don't think this will cause any problems since [python hasn't required a blank `__init__.py` since 3.3](https://stackoverflow.com/questions/37139786/is-init-py-not-required-for-packages-in-python-3).

**There hasn't been much testing on this!** You may prefer to wait until the vanilla alpine container ships python3.7.