### PR TITLE
On-Creation + Creator Signals

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -29,7 +29,7 @@ from evennia.utils import class_from_module, create, logger
 from evennia.utils.utils import (lazy_property, to_str,
                                  make_iter, is_iter,
                                  variable_from_module)
-from evennia.server.signals import (SIGNAL_OBJECT_POST_PUPPET,
+from evennia.server.signals import (SIGNAL_OBJECT_POST_PUPPET, SIGNAL_ACCOUNT_POST_CREATE,
                                     SIGNAL_OBJECT_POST_UNPUPPET)
 from evennia.typeclasses.attributes import NickHandler
 from evennia.scripts.scripthandler import ScriptHandler

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -29,7 +29,7 @@ from evennia.utils import class_from_module, create, logger
 from evennia.utils.utils import (lazy_property, to_str,
                                  make_iter, is_iter,
                                  variable_from_module)
-from evennia.server.signals import (SIGNAL_ACCOUNT_POST_CREATE, SIGNAL_OBJECT_POST_PUPPET,
+from evennia.server.signals import (SIGNAL_OBJECT_POST_PUPPET,
                                     SIGNAL_OBJECT_POST_UNPUPPET)
 from evennia.typeclasses.attributes import NickHandler
 from evennia.scripts.scripthandler import ScriptHandler
@@ -644,6 +644,9 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
             typeclass (str, optional): Typeclass to use for new Account
             character_typeclass (str, optional): Typeclass to use for new char
                 when applicable.
+            creator (TypedObj or session): The enactor of this creation, if any.
+            session (ServerSession): The creating session, if any. Used for
+                signaling.
 
         Returns:
             account (Account): Account if successfully created; None if not
@@ -753,7 +756,8 @@ class DefaultAccount(with_metaclass(TypeclassBase, AccountDB)):
         # Update the throttle to indicate a new account was created from this IP
         if ip and not guest:
             CREATION_THROTTLE.update(ip, 'Too many accounts being created.')
-        SIGNAL_ACCOUNT_POST_CREATE.send(sender=account, ip=ip)
+        SIGNAL_ACCOUNT_POST_CREATE.send(sender=account, ip=ip, creator=kwargs.get('creator', None),
+                                        session=kwargs.get('session', None))
         return account, errors
 
     def delete(self, *args, **kwargs):

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -521,7 +521,8 @@ class CmdCreate(ObjManipCommand):
             lockstring = self.new_obj_lockstring.format(id=caller.id)
             obj = create.create_object(typeclass, name, caller,
                                        home=caller, aliases=aliases,
-                                       locks=lockstring, report_to=caller)
+                                       locks=lockstring, report_to=caller,
+                                       creator=caller)
             if not obj:
                 continue
             if aliases:
@@ -815,7 +816,7 @@ class CmdDig(ObjManipCommand):
         # create room
         new_room = create.create_object(typeclass, room["name"],
                                         aliases=room["aliases"],
-                                        report_to=caller)
+                                        report_to=caller, creator=caller)
         lockstring = self.new_room_lockstring.format(id=caller.id)
         new_room.locks.add(lockstring)
         alias_string = ""
@@ -846,7 +847,7 @@ class CmdDig(ObjManipCommand):
                                                    aliases=to_exit["aliases"],
                                                    locks=lockstring,
                                                    destination=new_room,
-                                                   report_to=caller)
+                                                   report_to=caller, creator=caller)
                 alias_string = ""
                 if new_to_exit.aliases.all():
                     alias_string = " (%s)" % ", ".join(new_to_exit.aliases.all())
@@ -876,7 +877,7 @@ class CmdDig(ObjManipCommand):
                                                      aliases=back_exit["aliases"],
                                                      locks=lockstring,
                                                      destination=location,
-                                                     report_to=caller)
+                                                     report_to=caller, creator=caller)
                 alias_string = ""
                 if new_back_exit.aliases.all():
                     alias_string = " (%s)" % ", ".join(new_back_exit.aliases.all())
@@ -1345,7 +1346,7 @@ class CmdOpen(ObjManipCommand):
                                             key=exit_name,
                                             location=location,
                                             aliases=exit_aliases,
-                                            report_to=caller)
+                                            report_to=caller, creator=caller)
             if exit_obj:
                 # storing a destination is what makes it an exit!
                 exit_obj.destination = destination

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -570,7 +570,7 @@ class CmdChannelCreate(COMMAND_DEFAULT_CLASS):
         new_chan = create.create_channel(channame.strip(),
                                          aliases,
                                          description,
-                                         locks=lockstring)
+                                         locks=lockstring, creator=caller)
         new_chan.connect(caller)
         CHANNELHANDLER.update()
         self.msg("Created channel %s and connected to it." % new_chan.key)
@@ -924,7 +924,7 @@ class CmdIRC2Chan(COMMAND_DEFAULT_CLASS):
         else:
             password = hashlib.md5(bytes(str(time.time()), 'utf-8')).hexdigest()[:11]
             try:
-                bot = create.create_account(botname, None, password, typeclass=botclass)
+                bot = create.create_account(botname, None, password, typeclass=botclass, creator=caller)
             except Exception as err:
                 self.msg("|rError, could not create the bot:|n '%s'." % err)
                 return
@@ -1090,6 +1090,6 @@ class CmdRSS2Chan(COMMAND_DEFAULT_CLASS):
                 self.msg("Account '%s' already exists and is not a bot." % botname)
                 return
         else:
-            bot = create.create_account(botname, None, None, typeclass=bots.RSSBot)
+            bot = create.create_account(botname, None, None, typeclass=bots.RSSBot, creator=caller)
         bot.start(ev_channel=channel, rss_url=url, rss_rate=10)
         self.msg("RSS reporter created. Fetching RSS.")

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -357,7 +357,7 @@ class CmdScripts(COMMAND_DEFAULT_CLASS):
         if args:
             if "start" in self.switches:
                 # global script-start mode
-                new_script = create.create_script(args)
+                new_script = create.create_script(args, creator=caller)
                 if new_script:
                     caller.msg("Global script %s was started successfully." % args)
                 else:

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -182,7 +182,8 @@ class CmdUnconnectedCreate(COMMAND_DEFAULT_CLASS):
         username, password = parts
 
         # everything's ok. Create the new account account.
-        account, errors = Account.create(username=username, password=password, ip=address, session=session)
+        account, errors = Account.create(username=username, password=password, ip=address, session=session,
+                                         creator=session)
         if account:
             # tell the caller everything went well.
             string = "A new account '%s' was created. Welcome!"

--- a/evennia/contrib/tutorial_examples/example_batch_code.py
+++ b/evennia/contrib/tutorial_examples/example_batch_code.py
@@ -61,7 +61,8 @@ limbo = search_object('Limbo')[0]
 
 # create a red button in limbo
 red_button = create_object(red_button.RedButton, key="Red button",
-                           location=limbo, aliases=["button"])
+                           location=limbo, aliases=["button"],
+                           creator=caller)
 
 # we take a look at what we created
 caller.msg("A %s was created." % red_button.key)
@@ -77,8 +78,8 @@ caller.msg("A %s was created." % red_button.key)
 # the Python variables we assign to must match the ones given in the
 # header for the system to be able to delete them afterwards during a
 # debugging run.
-table = create_object(DefaultObject, key="Table", location=limbo)
-chair = create_object(DefaultObject, key="Chair", location=limbo)
+table = create_object(DefaultObject, key="Table", location=limbo, creator=caller)
+chair = create_object(DefaultObject, key="Chair", location=limbo, creator=caller)
 
 string = "A %s and %s were created."
 if DEBUG:

--- a/evennia/server/signals.py
+++ b/evennia/server/signals.py
@@ -17,12 +17,17 @@ This is used on top of hooks to make certain features easier to
 add to contribs without necessitating a full takeover of hooks
 that may be in high demand.
 
+Make ABSOLUTELY CERTAIN that no receiver causes a Traceback.
+ Signals are called synchronously and could prevent further
+ events in the chain from happening. Receivers also cannot
+ return anything.
+
 """
 from django.dispatch import Signal
 
 # The sender is the created Account. This is triggered at the very end of Account.create()
 # after the Account is created.
-SIGNAL_ACCOUNT_POST_CREATE = Signal(providing_args=['ip', ])
+SIGNAL_ACCOUNT_POST_CREATE = Signal(providing_args=['creator', 'ip', 'session'])
 
 # The Sender is the renamed Account. This is triggered by the username setter in AccountDB.
 SIGNAL_ACCOUNT_POST_RENAME = Signal(providing_args=['old_name', 'new_name'])
@@ -46,6 +51,10 @@ SIGNAL_ACCOUNT_POST_LOGOUT = Signal(providing_args=['session', ])
 # from the account, regardless of how many it started with or remain.
 SIGNAL_ACCOUNT_POST_DISCONNECT = Signal(providing_args=['session', ])
 
+# The sender is the new Object. This is triggered after it's already created.
+# Creator will probably be an Account or another Object, or None.
+SIGNAL_OBJECT_POST_CREATE = Signal(providing_args=['creator'])
+
 # The sender is the Object being puppeted. This is triggered after all puppeting hooks have
 # been called. The Object has already been puppeted by this point.
 SIGNAL_OBJECT_POST_PUPPET = Signal(providing_args=['session', 'account'])
@@ -53,6 +62,12 @@ SIGNAL_OBJECT_POST_PUPPET = Signal(providing_args=['session', 'account'])
 # The sender is the Object being released. This is triggered after all hooks are called.
 # The Object is no longer puppeted by this point.
 SIGNAL_OBJECT_POST_UNPUPPET = Signal(providing_args=['session', 'account'])
+
+# The sender is the new Channel. This is triggered after all hooks are called.
+SIGNAL_CHANNEL_POST_CREATE = Signal(providing_args=['creator'])
+
+# The sender is the new Script. This is triggered after all hooks are called.
+SIGNAL_SCRIPT_POST_CREATE = Signal(providing_args=['creator'])
 
 # The sender is the Typed Object being released. This isn't necessarily an Object;
 # it could be a script. It fires whenever the value of the Typed object's 'key'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Made some hacks to utils/create.py so that Objects, Scripts, and Channels now
Signal their creation, and (optionally) pass who created them as kwargs.

#### Motivation for adding to Evennia
Turns out that some more Signals WOULD be very nice. I plan on using this for
the Zone contrib. A Receiver will respond to 'room/exit is created', check whether the
creator has 'selected' a Zone, and automatically add the new rooms/exits to the Zone (and announce said auto-adding.)

#### Other info (issues closed, discussion etc)
Nothing really comes to mind. I am disgruntled at how all-over-the-place the 'create a thing' API currently is though. Some things use utils.create and others Thing.create() and that's kinda stupid. One or the other!

No changes were made to contribs or tests or etc for fear of breaking them. The creator kwarg is
optional though so this shouldn't break anything.