### PR TITLE
Added Base Typeclass loading to Evennia API.

### DIFF
--- a/evennia/__init__.py
+++ b/evennia/__init__.py
@@ -114,6 +114,16 @@ CHANNEL_HANDLER = None
 GLOBAL_SCRIPTS = None
 OPTION_CLASSES = None
 
+# typeclasses
+BASE_ACCOUNT_TYPECLASS = None
+BASE_OBJECT_TYPECLASS = None
+BASE_CHARACTER_TYPECLASS = None
+BASE_ROOM_TYPECLASS = None
+BASE_EXIT_TYPECLASS = None
+BASE_CHANNEL_TYPECLASS = None
+BASE_SCRIPT_TYPECLASS = None
+BASE_GUEST_TYPECLASS = None
+
 
 def _create_version():
     """
@@ -164,6 +174,10 @@ def _init():
     global GLOBAL_SCRIPTS, OPTION_CLASSES
     global EvMenu, EvTable, EvForm, EvMore, EvEditor
     global ANSIString
+
+    global BASE_ACCOUNT_TYPECLASS, BASE_OBJECT_TYPECLASS, BASE_CHARACTER_TYPECLASS
+    global BASE_ROOM_TYPECLASS, BASE_EXIT_TYPECLASS, BASE_CHANNEL_TYPECLASS
+    global BASE_SCRIPT_TYPECLASS, BASE_GUEST_TYPECLASS
 
     from .accounts.accounts import DefaultAccount
     from .accounts.accounts import DefaultGuest
@@ -226,6 +240,17 @@ def _init():
     # containers
     from .utils.containers import GLOBAL_SCRIPTS
     from .utils.containers import OPTION_CLASSES
+
+    # typeclases
+    from .utils.utils import class_from_module
+    BASE_ACCOUNT_TYPECLASS = class_from_module(settings.BASE_ACCOUNT_TYPECLASS)
+    BASE_OBJECT_TYPECLASS = class_from_module(settings.BASE_OBJECT_TYPECLASS)
+    BASE_CHARACTER_TYPECLASS = class_from_module(settings.BASE_CHARACTER_TYPECLASS)
+    BASE_ROOM_TYPECLASS = class_from_module(settings.BASE_ROOM_TYPECLASS)
+    BASE_EXIT_TYPECLASS = class_from_module(settings.BASE_EXIT_TYPECLASS)
+    BASE_CHANNEL_TYPECLASS = class_from_module(settings.BASE_CHANNEL_TYPECLASS)
+    BASE_SCRIPT_TYPECLASS = class_from_module(settings.BASE_SCRIPT_TYPECLASS)
+    BASE_GUEST_TYPECLASS = class_from_module(settings.BASE_GUEST_TYPECLASS)
 
     # initialize the doc string
     global __doc__


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add the BASE_WHATEVER_TYPECLASS properties to evennia API, containing the loaded typeclasses. EG:
evennia.BASE_CHARACTER_TYPECLASS contains the actual class, not a path to the class.

#### Motivation for adding to Evennia
I feel it's silly that these are imported over and over again all over the place using class_from_module()

Having them all in one place for an easy, direct import seems much smarter, more efficient, and cleaner.

#### Other info (issues closed, discussion etc)
Then again, I'm not sure why you haven't done this already. Because of that, I'm just proposing this at the moment instead of CHANGING ALL OF THOSE CALLS. What do you think of this idea?