### PR TITLE
correct the prototype parent keyword in the examples

### DIFF
--- a/evennia/game_template/world/prototypes.py
+++ b/evennia/game_template/world/prototypes.py
@@ -18,7 +18,7 @@ Each prototype should be a dictionary. Use the same name as the
 variable to refer to other prototypes.
 
 Possible keywords are:
-    prototype - string pointing to parent prototype of this structure.
+    prototype_parent - string pointing to parent prototype of this structure.
     key - string, the main object identifier.
     typeclass - string, if not set, will use `settings.BASE_OBJECT_TYPECLASS`.
     location - this should be a valid object or #dbref.
@@ -47,13 +47,13 @@ See the `@spawn` command and `evennia.utils.spawner` for more info.
 # }
 #
 # GOBLIN_WIZARD = {
-# "prototype": "GOBLIN",
+# "prototype_parent": "GOBLIN",
 # "key": "goblin wizard",
 # "spells": ["fire ball", "lighting bolt"]
 # }
 #
 # GOBLIN_ARCHER = {
-# "prototype": "GOBLIN",
+# "prototype_parent": "GOBLIN",
 # "key": "goblin archer",
 # "attacks": ["short bow"]
 #}
@@ -69,5 +69,5 @@ See the `@spawn` command and `evennia.utils.spawner` for more info.
 #
 # GOBLIN_ARCHWIZARD = {
 # "key": "goblin archwizard",
-# "prototype" : ("GOBLIN_WIZARD", "ARCHWIZARD_MIXIN")
+# "prototype_parent" : ("GOBLIN_WIZARD", "ARCHWIZARD_MIXIN")
 #}


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The examples in the game template world prototypes say to use "prototype" when specifying a parent for a prototype, but that currently should be "prototype_parent". I suspect something changed in the code and the these docstrings were missed in the update.