### PR TITLE
Opens an interactive console when using the py command with no argument

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -1263,7 +1263,7 @@ class CmdGetInput(Command):
             prompt = caller.ndb._getinput._prompt
             args = caller.ndb._getinput._args
             kwargs = caller.ndb._getinput._kwargs
-            result = self.raw_string.strip()  # we strip the ending line break caused by sending
+            result = self.raw_string.rstrip()  # we strip the ending line break caused by sending
 
             ok = not callback(caller, prompt, result, *args, **kwargs)
             if ok:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- When typing the `py` command with no argument, a Python console opens in the client.
- The `evennia.utils.evmenu.get_input` function had to be very slightly altered.

#### Motivation for adding to Evennia

This feature adds a great simplicity for Evennia debugging and administrator operations through the `py` command.  If the admin has full privilege, she can use the `py` command with no argument, open a Python console and interactively type commands in, to see the result, create variables and so on:

    > py
    Python 3.7.3 ...
    Type 'exit' to quit this console.
    >>> evennia
    <module evennia>
    >>> var = 5
    >>> if var < 8:
    ...     var = 32
    ...
    >>> var
    32
    >>> for obj in here.contents:
    ...     here.msg("You are in this location.")
    ...
    >>> # And perform more...
    ... exit
    Closing the Python console.

The advantage of this over the editor provided in `py/edit` is that you see the result of each command you type.  For users that are on good terms with the Python interpreter (that is, most of them, including beginners), this is a great way to test in a Python playground, though doing things potentially dangerous of course.

#### Implementation details

This was trivial to add.  This feature makes use of the `yield` keyword in `func()`, so the Python console isn't persistent when Evennia reloads (I believe this is actually a good thing).  The `code.InteractiveConsole` was subclassed for this purpose with a very light wrapping around sessions.  All in all, it didn't take much code and I still find this feature highly readable.

> Warning: please note that `evennia.utils.evmenu.get_input` was modified.  The old function used to `strip()` all input strings from the user.  This created some problems since you have to enter indentation manually in this mode.  So I replaced it with a simple `rstrip(*)`.  And I still find it "too broad" as it is, perhaps a narrower stripping would be appropriate (`.rstrip("\n")` perhaps)?

#### Other info (issues closed, discussion etc)

- Evennia master.