### PR TITLE
[clothing contrib] Allow to create new Clothing classes

### DIFF
--- a/evennia/contrib/clothing.py
+++ b/evennia/contrib/clothing.py
@@ -368,7 +368,7 @@ class CmdWear(MuxCommand):
         wearstyle = True
         if not clothing:
             return
-        if not clothing.is_typeclass("evennia.contrib.clothing.Clothing"):
+        if not clothing.is_typeclass("evennia.contrib.clothing.Clothing", exact=False):
             self.caller.msg("That's not clothes!")
             return
 
@@ -460,10 +460,10 @@ class CmdCover(MuxCommand):
         cover_with = self.caller.search(self.arglist[1], candidates=self.caller.contents)
         if not to_cover or not cover_with:
             return
-        if not to_cover.is_typeclass("evennia.contrib.clothing.Clothing"):
+        if not to_cover.is_typeclass("evennia.contrib.clothing.Clothing", exact=False):
             self.caller.msg("%s isn't clothes!" % to_cover.name)
             return
-        if not cover_with.is_typeclass("evennia.contrib.clothing.Clothing"):
+        if not cover_with.is_typeclass("evennia.contrib.clothing.Clothing", exact=False):
             self.caller.msg("%s isn't clothes!" % cover_with.name)
             return
         if cover_with.db.clothing_type:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The `clothing` contrib could be used in standalone.  If new clothing types were created (say, if you created a `Shoe` typeclass inheriting from `Clothing`), you couldn't equip objects from the `Shoe` typeclass.

#### Motivation for adding to Evennia

Knowing how a contrib is used can be hard.  But allowing for inheritance does seem important in this case.  Some users find it actually more logical to create a typeclass per equipment type and set their `db.clothing_type` in `at_object_creation`.  Although this wasn't the intended use of the contrib, where one can easily create clothes using the `Clothing` typeclass, allowing to inherit from `evennia.contrib.clothing.Clothing` while still being able to use the wear and remove commands is important, I think.

The reason why this was not possible was due to the use if `is_typeclass` in different places of the contrib.  By default, `exact` is set to `True`, which meant this only allowed object created from `evennia.contrib.clothing.Clothing`.  Inherited objects didn't work.  I had to set the `exact` flag to `False` explicitly.

By the way, is that really a good thing?  Shouldn't this flag be set to `False` by default?  It's the way `isinstance` or `issubclass` work, after all.  That being said, it's an API change and it can have problematic consequences.

#### Other info (issues closed, discussion etc)

- Evennia master.