### PR TITLE
Add a multimedia plugin to respond to images/audio/video server commands

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/multimedia.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/multimedia.js
@@ -1,0 +1,53 @@
+/*
+ *
+ * Evennia Webclient multimedia outputs plugin
+ *
+ *     in evennia python code:
+ *
+ *         target.msg( image="URL" )
+ *         target.msg( audio="URL" )
+ *         target.msg( video="URL" )
+ *
+ */
+let multimedia_plugin = (function () {
+    //
+    var image = function (args, kwargs) {
+        var mwin = $("#messagewindow");
+        mwin.append("<img src='"+ args[0] +"'/>");
+        mwin.scrollTop(mwin[0].scrollHeight);
+    }
+
+    var audio = function (args, kwargs) {
+        // create an HTML5 audio control (only .mp3 is fully compatible with all major browsers)
+        var mwin = $("#messagewindow");
+        mwin.append("<audio controls='' autoplay='' style='height:17px;width:175px'>" +
+                    "<source src='"+ args[0] +"'/>" +
+                    "</audio>");
+        mwin.scrollTop(mwin[0].scrollHeight);
+    }
+
+    var video = function (args, kwargs) {
+        // create an HTML5 video element (only h264 .mp4 is compatible with all major browsers)
+        var mwin = $("#messagewindow");
+        mwin.append("<video controls='' autoplay=''>" +
+                    "<source src='"+ args[0] +"'/>" +
+                    "</video>");
+        mwin.scrollTop(mwin[0].scrollHeight);
+    }
+
+    //
+    // Mandatory plugin init function
+    var init = function () {
+        Evennia = window.Evennia;
+        Evennia.emitter.on('image', image); // capture "image" commands
+        Evennia.emitter.on('audio', audio); // capture "audio" commands
+        Evennia.emitter.on('video', video); // capture "video" commands
+        console.log('Multimedia plugin initialized');
+    }
+
+    return {
+        init: init,
+    }
+})();
+plugin_handler.add('multimedia_plugin', multimedia_plugin);
+

--- a/evennia/web/webclient/templates/webclient/base.html
+++ b/evennia/web/webclient/templates/webclient/base.html
@@ -93,6 +93,7 @@ JQuery available.
 -->
         <script src={% static "webclient/js/plugins/default_in.js" %} language="javascript" type="text/javascript"></script>
         <script src={% static "webclient/js/plugins/default_out.js" %} language="javascript" type="text/javascript"></script>
+        <script src={% static "webclient/js/plugins/multimedia.js" %} language="javascript" type="text/javascript"></script>
     {% endblock %}
 
     <script src="https://cdn.rawgit.com/ejci/favico.js/master/favico-0.3.10.min.js" language="javascript" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR adds a multimedia (images, mp3 audio, mp4 video) plugin to the webclient.

#### Motivation for adding to Evennia

Some clients provide the ability to display images or play sounds, since this is one of the strengths of a webclient, this is a simple plugin to provide this feature.  It also serves as an example of how to map arbitrary .msg() content to new handlers.

#### Other info (issues closed, discussion etc)
