### PR TITLE
Make single input window the default instead of dual inputs

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/goldenlayout_default_config.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/goldenlayout_default_config.js
@@ -37,17 +37,17 @@ var goldenlayout_config = { // Global Variable used in goldenlayout.js init()
 //          id: "inputComponent", // mark 'ignore this component during output message processing'
 //          height: 6,
 //          isClosable: false,
+//      }, {
+//            type: "component",
+//            componentName: "input",
+//            id: "inputComponent", // mark for ignore
+//            height: 12,  // percentage
+//            tooltip: "Input - The last input in the layout is always the default.",
         }, {
             type: "component",
             componentName: "input",
             id: "inputComponent", // mark for ignore
-            height: 12,  // percentage
-            tooltip: "Input - The last input in the layout is always the default.",
-        }, {
-            type: "component",
-            componentName: "input",
-            id: "inputComponent", // mark for ignore
-            height: 12,  // percentage
+            height: 20,  // percentage
             isClosable: false, // remove the 'x' control to close this
             tooltip: "Input - The last input in the layout is always the default.",
         }]


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR switches the webclient back to a single input pane by default.

#### Motivation for adding to Evennia
Griatch asked to for this to avoid confusing new users

#### Other info (issues closed, discussion etc)
