### PR TITLE
fix shift-up focus issue and enter-key always clearing focus

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/default_in.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/default_in.js
@@ -34,8 +34,18 @@ let defaultin_plugin = (function () {
                     }
                     inputfield.val(""); // Clear this inputfield
                     event.preventDefault();
-                }
-                inputfield.blur();
+
+                    // enter key by itself should toggle focus
+                    if( inputfield.length < 1 ) {
+                        inputfield = $(".inputfield:last");
+                        inputfield.focus();
+                        if( inputfield.length < 1 ) { // non-goldenlayout backwards compatibility
+                            $("#inputfield").focus();
+                        }
+                    } else {
+                        inputfield.blur();
+                    }
+                } // else allow building a multi-line input command
                 break;
 
             // Anything else, focus() a textarea if needed, and allow the default event

--- a/evennia/web/webclient/static/webclient/js/plugins/history.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/history.js
@@ -63,6 +63,9 @@ let history = (function () {
             // Doing a history navigation; replace the text in the input and
             // move the cursor to the end of the new value
             var inputfield = $(".inputfield:focus");
+            if( inputfield.length < 1 ) { // focus the default (last), if nothing focused
+                inputfield = $(".inputfield:last");
+            }
             if( inputfield.length < 1 ) { // pre-goldenlayout backwards compatibility
                 inputfield = $("#inputfield");
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR updates the default_in and history plugins to handle input focus a little smoother.

#### Motivation for adding to Evennia
Fixes issues with default focus handling that makes using history more frustrating than it should be

#### Other info (issues closed, discussion etc)
#1890