### PR TITLE
fix ssh server

### DIFF
--- a/evennia/server/portal/ssh.py
+++ b/evennia/server/portal/ssh.py
@@ -490,8 +490,8 @@ def makeFactory(configdict):
     try:
         # create/get RSA keypair
         publicKey, privateKey = getKeyPair(_PUBLIC_KEY_FILE, _PRIVATE_KEY_FILE)
-        factory.publicKeys = {'ssh-rsa': publicKey}
-        factory.privateKeys = {'ssh-rsa': privateKey}
+        factory.publicKeys = {b'ssh-rsa': publicKey}
+        factory.privateKeys = {b'ssh-rsa': privateKey}
     except Exception as err:
         print(_NO_AUTOGEN.format(err=err))
 


### PR DESCRIPTION
This trivial PR fixes an error on current SSH default setup, where if I just enable the service I then get

```
couldn't match all kex parts
```

but the twisted error there is spurious, as I can see on the logs:

```
19-08-21 15:04:50  |Portal| disabling non-fixed-group key exchange algorithms because we cannot find moduli file
19-08-21 15:04:50  |Portal| Unhandled Error
        Traceback (most recent call last):
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/python/log.py", line 86, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/python/context.py", line 122, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/python/context.py", line 85, in callWithContext
            return func(*args,**kw)
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
            why = selectable.doRead()
        --- <exception caught here> ---
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/internet/tcp.py", line 1435, in doRead
            protocol.makeConnection(transport)
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/internet/protocol.py", line 514, in makeConnection
            self.connectionMade()
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/conch/ssh/transport.py", line 497, in connectionMade
            self.sendKexInit()
          File "/home/oggei/.virtualenvs/evennia-bJd7NXTz/lib/python3.7/site-packages/twisted/conch/ssh/transport.py", line 519, in sendKexInit
            NS(b','.join(self.supportedPublicKeys)),
        builtins.TypeError: sequence item 0: expected a bytes-like object, str found
        
19-08-21 15:04:51  |Portal| Disconnecting with error, code 3
        reason: b"couldn't match all kex parts"
19-08-21 15:04:51  |Portal| connection lost
```

after a bit of investigation on twisted codebase I can confirm solutions we can find around are valid (eg. https://github.com/matrix-org/synapse/pull/4060#issue-224118414) so I've stoled them and fixed here :)

Thank you, regards!