### PR TITLE
do not duplicate whispers

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -574,7 +574,7 @@ class CmdWhisper(COMMAND_DEFAULT_CLASS):
 
         receivers = [recv.strip() for recv in self.lhs.split(",")]
 
-        receivers = [caller.search(receiver) for receiver in receivers]
+        receivers = [caller.search(receiver) for receiver in set(receivers)]
         receivers = [recv for recv in receivers if recv]
 
         speech = self.rhs


### PR DESCRIPTION
This PR fixes whisper behaviour when user type twice a whisper recipient, eg

```
whisper foo,foo,bar = asd
```

with a `set` repetitions no longer matter, we don't have any duplication receiver side

ciao!