### PR TITLE
importing `range` no longer needed

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -12,7 +12,6 @@ value - which may change as Evennia is developed. This way you can
 always be sure of what you have changed and what is default behaviour.
 
 """
-from builtins import range
 from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 


### PR DESCRIPTION
pylint complained and indeed now that you droppped python2, importing range from builtins is no longer needed:

```py
In [1]: from builtins import range as r

In [2]: r is range
Out[2]: True
```

thanks!