### PR TITLE
Remove pillow from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # general
 django >= 2.2.5, < 2.3
 twisted >= 19.2.1, < 20.0.0
-pillow == 5.2.0
 pytz
 django-sekizai
 inflect


### PR DESCRIPTION
This was originally suggested due to an imagefield, but that is no longer present. Since Pillow is not required to run Evennia, we should remove it and let the users opt into it if they end up wanting/needing it for their custom code.

I can follow up this merge by removing it from the install docs. That should simplify things greatly for Linux and Windows users both.