### PR TITLE
Remove builtins imports

### DIFF
--- a/evennia/accounts/admin.py
+++ b/evennia/accounts/admin.py
@@ -2,8 +2,6 @@
 # This sets up how models are displayed
 # in the web admin interface.
 #
-from builtins import object
-
 from django import forms
 from django.conf import settings
 from django.contrib import admin

--- a/evennia/accounts/models.py
+++ b/evennia/accounts/models.py
@@ -15,8 +15,6 @@ persistently store attributes of its own. This is ideal for extra
 account info and OOC account configuration variables etc.
 
 """
-from builtins import object
-
 from django.conf import settings
 from django.db import models
 from django.contrib.auth.models import AbstractUser

--- a/evennia/commands/cmdsethandler.py
+++ b/evennia/commands/cmdsethandler.py
@@ -63,7 +63,6 @@ can then implement separate sets for different situations. For
 example, you can have a 'On a boat' set, onto which you then tack on
 the 'Fishing' set. Fishing from a boat? No problem!
 """
-from builtins import object
 import sys
 from traceback import format_exc
 from importlib import import_module

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -4,8 +4,6 @@ The base Command class.
 All commands in Evennia inherit from the 'Command' class in this module.
 
 """
-from builtins import range
-
 import re
 import math
 

--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -18,8 +18,6 @@ self.msg() and similar methods to reroute returns to the correct
 method. Otherwise all text will be returned to all connected sessions.
 
 """
-from builtins import range
-
 import time
 from codecs import lookup as codecs_lookup
 from django.conf import settings

--- a/evennia/commands/default/batchprocess.py
+++ b/evennia/commands/default/batchprocess.py
@@ -18,7 +18,6 @@ therefore always be limited to superusers only.
 
 """
 import re
-from builtins import range
 
 from django.conf import settings
 from evennia.utils.batchprocessors import BATCHCMD, BATCHCODE

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1,8 +1,6 @@
 """
 Building and world design commands
 """
-from builtins import range
-
 import re
 from django.conf import settings
 from django.db.models import Q

--- a/evennia/comms/channelhandler.py
+++ b/evennia/comms/channelhandler.py
@@ -23,8 +23,6 @@ update() on the channelhandler. Or use Channel.objects.delete() which
 does this for you.
 
 """
-from builtins import object
-
 from django.conf import settings
 from evennia.commands import cmdset, command
 from evennia.utils.logger import tail_log_file

--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -17,8 +17,6 @@ Channels are central objects that act as targets for Msgs. Accounts can
 connect to channels by use of a ChannelConnect object (this object is
 necessary to easily be able to delete connections on the fly).
 """
-from builtins import object
-
 from django.conf import settings
 from django.utils import timezone
 from django.db import models

--- a/evennia/contrib/barter.py
+++ b/evennia/contrib/barter.py
@@ -94,8 +94,6 @@ in-game.
 
 """
 
-from builtins import object
-
 from evennia import Command, DefaultScript, CmdSet
 
 TRADE_TIMEOUT = 60  # timeout for B to accept trade

--- a/evennia/contrib/dice.py
+++ b/evennia/contrib/dice.py
@@ -29,8 +29,6 @@ at_cmdset_creation():
 After a reload the dice (or roll) command will be available in-game.
 
 """
-from builtins import range
-
 import re
 from random import randint
 from evennia import default_cmds, CmdSet

--- a/evennia/contrib/rplanguage.py
+++ b/evennia/contrib/rplanguage.py
@@ -90,8 +90,6 @@ Usage:
     that never change (if this is desired).
 
 """
-from builtins import range
-
 import re
 from random import choice, randint
 from collections import defaultdict

--- a/evennia/contrib/rpsystem.py
+++ b/evennia/contrib/rpsystem.py
@@ -94,8 +94,6 @@ Verbose Installation Instructions:
            @type/reset/force me = typeclasses.characters.Character
 
 """
-from builtins import object
-
 import re
 from re import escape as re_escape
 import itertools

--- a/evennia/help/admin.py
+++ b/evennia/help/admin.py
@@ -1,8 +1,6 @@
 """
 This defines how to edit help entries in Admin.
 """
-from builtins import object
-
 from django import forms
 from django.contrib import admin
 from evennia.help.models import HelpEntry

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -9,8 +9,6 @@ forms of help that do not concern commands, like information about the
 game world, policy info, rules and similar.
 
 """
-from builtins import object
-
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -104,8 +104,6 @@ to any other identifier you can use.
 
 """
 
-from builtins import object
-
 import re
 from django.conf import settings
 from evennia.utils import logger, utils

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -2,8 +2,6 @@
 # This sets up how models are displayed
 # in the web admin interface.
 #
-from builtins import object
-
 from django import forms
 from django.conf import settings
 from django.contrib import admin

--- a/evennia/objects/manager.py
+++ b/evennia/objects/manager.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.db.models.fields import exceptions
 from evennia.typeclasses.managers import TypedObjectManager, TypeclassManager
 from evennia.utils.utils import is_iter, make_iter, string_partial_matching
-from builtins import int
 
 __all__ = ("ObjectManager",)
 _GA = object.__getattribute__

--- a/evennia/objects/models.py
+++ b/evennia/objects/models.py
@@ -13,8 +13,6 @@ Attributes are separate objects that store values persistently onto
 the database object. Like everything else, they can be accessed
 transparently through the decorating TypeClass.
 """
-from builtins import object
-
 from django.conf import settings
 from django.db import models
 from django.core.exceptions import ObjectDoesNotExist

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -7,7 +7,6 @@ entities.
 """
 import time
 import inflect
-from builtins import object
 from collections import defaultdict
 
 from django.conf import settings

--- a/evennia/scripts/models.py
+++ b/evennia/scripts/models.py
@@ -24,8 +24,6 @@ Common examples of uses of Scripts:
 - Give the account/object a time-limited bonus/effect
 
 """
-from builtins import object
-
 from django.conf import settings
 from django.db import models
 from django.core.exceptions import ObjectDoesNotExist

--- a/evennia/scripts/monitorhandler.py
+++ b/evennia/scripts/monitorhandler.py
@@ -11,7 +11,6 @@ functionality:
 
 """
 import inspect
-from builtins import object
 
 from collections import defaultdict
 from evennia.server.models import ServerConfig

--- a/evennia/scripts/scripthandler.py
+++ b/evennia/scripts/scripthandler.py
@@ -5,8 +5,6 @@ added to all game objects. You access it through the property
 `scripts` on the game object.
 
 """
-from builtins import object
-
 from evennia.scripts.models import ScriptDB
 from evennia.utils import create
 from evennia.utils import logger

--- a/evennia/scripts/tickerhandler.py
+++ b/evennia/scripts/tickerhandler.py
@@ -66,7 +66,6 @@ call the handler's `save()` and `restore()` methods when the server reboots.
 
 """
 import inspect
-from builtins import object
 
 from twisted.internet.defer import inlineCallbacks
 from django.core.exceptions import ObjectDoesNotExist

--- a/evennia/server/portal/mccp.py
+++ b/evennia/server/portal/mccp.py
@@ -14,7 +14,6 @@ terribly slow connection.
 This protocol is implemented by the telnet protocol importing
 mccp_compress and calling it from its write methods.
 """
-from builtins import object
 import zlib
 
 # negotiations for v1 and v2 of the protocol

--- a/evennia/server/portal/mssp.py
+++ b/evennia/server/portal/mssp.py
@@ -10,7 +10,6 @@ active players and so on.
 
 
 """
-from builtins import object
 from django.conf import settings
 from evennia.utils import utils
 

--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -13,7 +13,6 @@ http://www.mushclient.com/mushclient/mxp.htm
 http://www.gammon.com.au/mushclient/addingservermxp.htm
 
 """
-from builtins import object
 import re
 
 LINKS_SUB = re.compile(r'\|lc(.*?)\|lt(.*?)\|le', re.DOTALL)

--- a/evennia/server/portal/naws.py
+++ b/evennia/server/portal/naws.py
@@ -10,7 +10,6 @@ client and update it when the size changes
 
 """
 from codecs import encode as codecs_encode
-from builtins import object
 from django.conf import settings
 
 NAWS = b'\x1f'

--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -7,8 +7,6 @@ sets up all the networking features.  (this is done automatically
 by game/evennia.py).
 
 """
-from builtins import object
-
 import sys
 import os
 import time

--- a/evennia/server/portal/rss.py
+++ b/evennia/server/portal/rss.py
@@ -5,8 +5,6 @@ This connects an RSS feed to an in-game Evennia channel, sending messages
 to the channel whenever the feed updates.
 
 """
-from builtins import object
-
 from twisted.internet import task, threads
 from django.conf import settings
 from evennia.server.session import Session

--- a/evennia/server/portal/ssh.py
+++ b/evennia/server/portal/ssh.py
@@ -9,7 +9,6 @@ Using standard ssh client,
 
 """
 
-from builtins import object
 import os
 import re
 

--- a/evennia/server/portal/suppress_ga.py
+++ b/evennia/server/portal/suppress_ga.py
@@ -13,7 +13,6 @@ It is set as the NOGOAHEAD protocol_flag option.
 http://www.faqs.org/rfcs/rfc858.html
 
 """
-from builtins import object
 SUPPRESS_GA = b'\x03'
 
 # default taken from telnet specification

--- a/evennia/server/portal/telnet_oob.py
+++ b/evennia/server/portal/telnet_oob.py
@@ -25,7 +25,6 @@ client supports MSDP and if not, we fallback to GMCP with a MSDP
 header where applicable.
 
 """
-from builtins import object
 import re
 import json
 from evennia.utils.utils import is_iter

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -10,7 +10,6 @@ etc. If the client does not support TTYPE, this will be ignored.
 All data will be stored on the protocol's protocol_flags dictionary,
 under the 'TTYPE' key.
 """
-from builtins import object
 
 # telnet option codes
 TTYPE = b'\x18'

--- a/evennia/server/profiling/dummyrunner.py
+++ b/evennia/server/profiling/dummyrunner.py
@@ -32,8 +32,6 @@ for instructions on how to define this module.
 """
 
 
-from builtins import range
-
 import sys
 import time
 import random

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -7,7 +7,6 @@ sets up all the networking features.  (this is done automatically
 by evennia/server/server_runner.py).
 
 """
-from builtins import object
 import time
 import sys
 import os

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -6,8 +6,6 @@ connection actually happens (so it's the same for telnet, web, ssh etc).
 It is stored on the Server side (as opposed to protocol-specific sessions which
 are stored on the Portal side)
 """
-from builtins import object
-
 import weakref
 import time
 from django.utils import timezone

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -3,7 +3,6 @@ This module defines a generic session class. All connection instances
 (both on Portal and Server side) should inherit from this class.
 
 """
-from builtins import object
 from django.conf import settings
 
 import time

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -13,7 +13,6 @@ There are two similar but separate stores of sessions:
 
 """
 import time
-from builtins import object
 
 from django.conf import settings
 from evennia.commands.cmdhandler import CMD_LOGINSTART

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -8,7 +8,6 @@ which is a non-db version of Attributes.
 
 
 """
-from builtins import object
 import re
 import fnmatch
 import weakref

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -25,8 +25,6 @@ This module also contains the Managers for the respective models; inherit from
 these to create custom managers.
 
 """
-from builtins import object
-
 from django.db.models import signals
 
 from django.db.models.base import ModelBase

--- a/evennia/typeclasses/tags.py
+++ b/evennia/typeclasses/tags.py
@@ -9,7 +9,6 @@ used for storing Aliases and Permissions. This module contains the
 respective handlers.
 
 """
-from builtins import object
 from collections import defaultdict
 
 from django.conf import settings

--- a/evennia/utils/ansi.py
+++ b/evennia/utils/ansi.py
@@ -14,7 +14,6 @@ the ansi mapping.
 
 """
 import functools
-from builtins import object, range
 
 import re
 from collections import OrderedDict

--- a/evennia/utils/batchprocessors.py
+++ b/evennia/utils/batchprocessors.py
@@ -170,8 +170,6 @@ if DEBUG:
 script = create.create_script()
 ```
 """
-from builtins import object
-
 import re
 import codecs
 import traceback

--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -18,8 +18,6 @@ in-situ, e.g `obj.db.mynestedlist[3][5] = 3` would never be saved and
 be out of sync with the database.
 
 """
-from builtins import object, int
-
 from functools import update_wrapper
 from collections import defaultdict, MutableSequence, MutableSet, MutableMapping
 from collections import OrderedDict, deque

--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -42,8 +42,6 @@ In addition, the EvEditor can be used to enter Python source code,
 and offers basic handling of indentation.
 
 """
-from builtins import object
-
 import re
 
 from django.conf import settings

--- a/evennia/utils/evform.py
+++ b/evennia/utils/evform.py
@@ -129,8 +129,6 @@ form will raise an error.
 
 """
 
-from builtins import object, range
-
 import re
 import copy
 from evennia.utils.evtable import EvCell, EvTable

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -166,7 +166,6 @@ evennia.utils.evmenu`.
 
 import random
 import inspect
-from builtins import object, range
 
 from inspect import isfunction, getargspec
 from django.conf import settings

--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -27,8 +27,6 @@ of the text. The remaining **kwargs will be passed on to the
 caller.msg() construct every time the page is updated.
 
 """
-from builtins import object, range
-
 from django.conf import settings
 from evennia import Command, CmdSet
 from evennia.commands import cmdhandler

--- a/evennia/utils/idmapper/models.py
+++ b/evennia/utils/idmapper/models.py
@@ -7,8 +7,6 @@ leave caching unexpectedly (no use of WeakRefs).
 Also adds `cache_size()` for monitoring the size of the cache.
 """
 
-from builtins import object
-
 import os
 import threading
 import gc

--- a/evennia/utils/idmapper/tests.py
+++ b/evennia/utils/idmapper/tests.py
@@ -1,6 +1,4 @@
 
-from builtins import range
-
 from django.test import TestCase
 
 from .models import SharedMemoryModel

--- a/evennia/utils/picklefield.py
+++ b/evennia/utils/picklefield.py
@@ -28,7 +28,6 @@ Pickle field implementation for Django.
 Modified for Evennia by Griatch and the Evennia community.
 
 """
-from builtins import object
 from ast import literal_eval
 from datetime import datetime
 

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -9,8 +9,6 @@ snippet #577349 on http://code.activestate.com.
 (extensively modified by Griatch 2010)
 """
 
-from builtins import object
-
 import re
 import cgi
 from .ansi import *


### PR DESCRIPTION
This module is not intended to be used directly in most cases, per:
https://docs.python.org/3/library/builtins.html

None of our usages warrant the explicit import. We also avoid some
confusion as folks dig to see what we are doing to require
importing builtins directly.

Fixes #1931.