### PR TITLE
Update utils.latinify to support Python 3

### DIFF
--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -223,3 +223,36 @@ class TestImportFunctions(TestCase):
         test_path = self._t_dir_file("invalid_filename.py")
         loaded_mod = utils.mod_import_from_path(test_path)
         self.assertIsNone(loaded_mod)
+
+
+class LatinifyTest(TestCase):
+    """
+    utils._UNICODE_MAP may need some additional entries to resolve these tests--
+
+        LEFT DOUBLE QUOTATION MARK: "
+        RIGHT DOUBLE QUOTATION MARK: "
+
+    """
+    def setUp(self):
+        super().setUp()
+
+        self.example_str = 'It says, “plugh.”'
+        self.example_ustr = u'It says, “plugh.”'
+
+        self.expected_output = 'It says, "plugh."'
+
+    def test_plain_string(self):
+        result = utils.latinify(self.example_str)
+        self.assertEqual(result, self.expected_output)
+
+    def test_unicode_string(self):
+        result = utils.latinify(self.example_ustr)
+        self.assertEqual(result, self.expected_output)
+
+    def test_encoded_string(self):
+        result = utils.latinify(self.example_str.encode('utf8'))
+        self.assertEqual(result, self.expected_output)
+
+    def test_byte_string(self):
+        result = utils.latinify(utils.to_bytes(self.example_str))
+        self.assertEqual(result, self.expected_output)

--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -226,13 +226,6 @@ class TestImportFunctions(TestCase):
 
 
 class LatinifyTest(TestCase):
-    """
-    utils._UNICODE_MAP may need some additional entries to resolve these tests--
-
-        LEFT DOUBLE QUOTATION MARK: "
-        RIGHT DOUBLE QUOTATION MARK: "
-
-    """
     def setUp(self):
         super().setUp()
 

--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -229,23 +229,14 @@ class LatinifyTest(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.example_str = 'It says, “plugh.”'
-        self.example_ustr = u'It says, “plugh.”'
-
-        self.expected_output = 'It says, "plugh."'
+        self.example_str = 'It naïvely says, “plugh.”'
+        self.expected_output = 'It naively says, "plugh."'
 
     def test_plain_string(self):
         result = utils.latinify(self.example_str)
         self.assertEqual(result, self.expected_output)
 
-    def test_unicode_string(self):
-        result = utils.latinify(self.example_ustr)
-        self.assertEqual(result, self.expected_output)
-
-    def test_encoded_string(self):
-        result = utils.latinify(self.example_str.encode('utf8'))
-        self.assertEqual(result, self.expected_output)
-
     def test_byte_string(self):
-        result = utils.latinify(utils.to_bytes(self.example_str))
+        byte_str = utils.to_bytes(self.example_str)
+        result = utils.latinify(byte_str)
         self.assertEqual(result, self.expected_output)

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -761,7 +761,10 @@ _UNICODE_MAP = {
     "EN DASH": "-",
     "HORIZONTAL BAR": "-",
     "HORIZONTAL ELLIPSIS": "...",
+    "LEFT SINGLE QUOTATION MARK": "'",
     "RIGHT SINGLE QUOTATION MARK": "'",
+    "LEFT DOUBLE QUOTATION MARK": '"',
+    "RIGHT DOUBLE QUOTATION MARK": '"',
 }
 
 
@@ -788,10 +791,13 @@ def latinify(string, default="?", pure_ascii=False):
 
     from unicodedata import name
 
+    if isinstance(string, bytes):
+        string = string.decode("utf8")
+
     converted = []
     for unich in iter(string):
         try:
-            ch = unich.decode("ascii")
+            ch = unich.encode("utf8").decode("ascii")
         except UnicodeDecodeError:
             # deduce a latin letter equivalent from the Unicode data
             # point name; e.g., since `name(u'á') == 'LATIN SMALL


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This updates the utils.latinify function to support Python 3 and adds a set of unit tests for that function. More details on the changes available under “Other info” below.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)

In Python 3’s string/unicode changes, `encode` is strictly string -> bytes and `decode` is strictly bytes -> string. Each still accepts similar parameters to determine how to generate or interpret the appropriate byte sequence.

As such, in order to continue to accept as many strings as possible, a first check is done to see if the input string is a sequence of bytes and, if so, it decodes that to a string. Later on, because `unich` will now always be a string, it must be encoded first before decoding. Additionally, to also support the new unit tests, I’ve extended `_UNICODE_MAP ` to have mappings for both left and right single and double quotes.

Fixes #1952 
