### PR TITLE
Add id, other core fields to ObjectDB search_fields

### DIFF
--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -95,7 +95,7 @@ class ObjectDBAdmin(admin.ModelAdmin):
     list_display = ("id", "db_key", "db_account", "db_typeclass_path")
     list_display_links = ("id", "db_key")
     ordering = ["db_account", "db_typeclass_path", "id"]
-    search_fields = ["^db_key", "db_typeclass_path"]
+    search_fields = ["^db_key", "db_typeclass_path", "id", "db_account__id"]
     raw_id_fields = ("db_destination", "db_location", "db_home")
 
     save_as = True

--- a/evennia/objects/admin.py
+++ b/evennia/objects/admin.py
@@ -95,7 +95,7 @@ class ObjectDBAdmin(admin.ModelAdmin):
     list_display = ("id", "db_key", "db_account", "db_typeclass_path")
     list_display_links = ("id", "db_key")
     ordering = ["db_account", "db_typeclass_path", "id"]
-    search_fields = ["^db_key", "db_typeclass_path", "id", "db_account__id"]
+    search_fields = ["=id", "^db_key", "db_typeclass_path", "^db_account__db_key"]
     raw_id_fields = ("db_destination", "db_location", "db_home")
 
     save_as = True


### PR DESCRIPTION
Add id, other core fields to ObjectDB search_fields

#### Add the ability to search by Object Id and DB account on the objects page of admin

#### Motivation for adding to Evennia
HactoberFest. This is my first PR on github for an open source project. Please guide me if I made a mistake.

#### Issues Referenced
Issue #1951 
