### PR TITLE
validatorfuncs.duration() returns incorrect datetime.timedelta() Closes #1970

### DIFF
--- a/evennia/utils/tests/test_validatorfuncs.py
+++ b/evennia/utils/tests/test_validatorfuncs.py
@@ -44,10 +44,13 @@ class TestValidatorFuncs(TestCase):
             self.assertTrue(
                 isinstance(validatorfuncs.duration(d), datetime.timedelta))
 
-        # THE FOLLOWING FAILS, year calculation seems to be incorrect
-        # self.assertEqual(
-        #     datetime.timedelta(1+5*365, 2, 0, 0, 3, 4, 5),
-        #     validatorfuncs.duration('1d 2s 3m 4h 5w 5y'))
+        self.assertEqual(
+            datetime.timedelta(1+6*365, 2, 0, 0, 3, 4, 5),
+            validatorfuncs.duration('1d 2s 3m 4h 5w 6y'))
+        # values may be duplicated
+        self.assertEqual(
+            datetime.timedelta((1+7)+(6+12)*365, 2+8, 0, 0, 3+9, 4+10, 5+11),
+            validatorfuncs.duration('1d 2s 3m 4h 5w 6y 7d 8s 9m 10h 11w 12y'))
 
     def test_duration_raises_ValueError(self):
         for d in ['', '1', '5days', '1Week']:

--- a/evennia/utils/validatorfuncs.py
+++ b/evennia/utils/validatorfuncs.py
@@ -102,17 +102,17 @@ def duration(entry, option_key="Duration", **kwargs):
 
     for interval in time_string:
         if _re.match(r"^[\d]+s$", interval):
-            seconds = +int(interval.rstrip("s"))
+            seconds += int(interval.rstrip("s"))
         elif _re.match(r"^[\d]+m$", interval):
-            minutes = +int(interval.rstrip("m"))
+            minutes += int(interval.rstrip("m"))
         elif _re.match(r"^[\d]+h$", interval):
-            hours = +int(interval.rstrip("h"))
+            hours += int(interval.rstrip("h"))
         elif _re.match(r"^[\d]+d$", interval):
-            days = +int(interval.rstrip("d"))
+            days += int(interval.rstrip("d"))
         elif _re.match(r"^[\d]+w$", interval):
-            weeks = +int(interval.rstrip("w"))
+            weeks += int(interval.rstrip("w"))
         elif _re.match(r"^[\d]+y$", interval):
-            days = +int(interval.rstrip("y")) * 365
+            days += int(interval.rstrip("y")) * 365
         else:
             raise ValueError(f"Could not convert section '{interval}' to a {option_key}.")
 


### PR DESCRIPTION
#1970 

Fixed calculation of days (from days and years) and allow for any `\d+[smhwyd]` to appear more than once.

(found during #1967)