### PR TITLE
Replacing deprecated method from cgi with html.escape()

### DIFF
--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -9,7 +9,7 @@ snippet #577349 on http://code.activestate.com.
 """
 
 import re
-import cgi
+from html import escape as html_escape
 from .ansi import *
 
 
@@ -304,7 +304,7 @@ class TextToHTMLparser(object):
         """
         cdict = match.groupdict()
         if cdict["htmlchars"]:
-            return cgi.escape(cdict["htmlchars"])
+            return html_escape(cdict["htmlchars"])
         elif cdict["lineend"]:
             return "<br>"
         elif cdict["firstspace"]:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Replacing deprecated escape function from the cgi module with escape function from the html module (new since Python 3.2). 
https://docs.python.org/3.5/library/html.html#html.escape

#### Motivation for adding to Evennia

Fixes errors printing messages to the web console.

#### Other info (issues closed, discussion etc)
