### PR TITLE
Allow single quotes and double quotes in lockstrings

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2250,7 +2250,6 @@ class CmdLock(ObjManipCommand):
                 caller.msg("You are not allowed to do that.")
                 return
             ok = False
-            lockdef = re.sub(r"\'|\"", "", lockdef)
             try:
                 ok = obj.locks.add(lockdef)
             except LockException as e:

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -235,8 +235,8 @@ class LockHandler(object):
                 if not callable(func):
                     elist.append(_("Lock: lock-function '%s' is not available.") % funcstring)
                     continue
-                args = list(arg.strip() for arg in utils.split_arguments(rest) if arg and "=" not in arg)
-                kwargs = dict([arg.split("=", 1) for arg in utils.split_arguments(rest) if arg and "=" in arg])
+                args = split_arguments(rest, False)
+                kwargs = split_arguments(rest, True)
                 lock_funcs.append((func, args, kwargs))
                 evalstring = evalstring.replace(funcstring, "%s")
             if len(lock_funcs) < nfuncs:

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -235,8 +235,8 @@ class LockHandler(object):
                 if not callable(func):
                     elist.append(_("Lock: lock-function '%s' is not available.") % funcstring)
                     continue
-                args = list(arg.strip() for arg in rest.split(",") if arg and "=" not in arg)
-                kwargs = dict([arg.split("=", 1) for arg in rest.split(",") if arg and "=" in arg])
+                args = list(arg.strip() for arg in utils.split_arguments(rest) if arg and "=" not in arg)
+                kwargs = dict([arg.split("=", 1) for arg in utils.split_arguments(rest) if arg and "=" in arg])
                 lock_funcs.append((func, args, kwargs))
                 evalstring = evalstring.replace(funcstring, "%s")
             if len(lock_funcs) < nfuncs:

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -235,8 +235,8 @@ class LockHandler(object):
                 if not callable(func):
                     elist.append(_("Lock: lock-function '%s' is not available.") % funcstring)
                     continue
-                args = split_arguments(rest, False)
-                kwargs = split_arguments(rest, True)
+                args = utils.split_arguments(rest, False)
+                kwargs = utils.split_arguments(rest, True)
                 lock_funcs.append((func, args, kwargs))
                 evalstring = evalstring.replace(funcstring, "%s")
             if len(lock_funcs) < nfuncs:

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2122,7 +2122,7 @@ def split_arguments(s, named = False):
     Args:
         s (str): The string to convert.
         named (bool, optional): True if "s" represents named arguments (**kwargs), False if not.
-    
+
     Returns:
         arguments (list): If "named" is False.
         arguments (dict): If "named" is True.

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2114,7 +2114,7 @@ def interactive(func):
     return decorator
 
 
-def split_arguments(s, named = False):
+def split_arguments(s, named=False):
     """
     Method to split an argument list from string format to an actual list of values.
     Supports regular arguments and named arguments.
@@ -2134,22 +2134,30 @@ def split_arguments(s, named = False):
     escape = False
     tmp = ""
     key = None
+    skip = False
 
     for c in s:
         if named and key is None:
-            if c == "=":
+            if c == ",":
+                tmp = ""
+            elif not skip and c == "=":
                 key = tmp
                 tmp = ""
+            elif c == "\"" or c == "'":
+                skip = True
             else:
                 tmp += c
         else:
-            if c == "," and not inside:
+            if not named and c == "=" and not inside:
+                skip = True
+            elif c == "," and not inside:
                 if named:
                     args[key] = tmp.strip()
                     key = None
-                else:
+                elif not skip:
                     args.append(tmp.strip())
                 tmp = ""
+                skip = False
             else:
                 if char is None and (c == "\"" or c == "'"):
                     char = c
@@ -2176,8 +2184,9 @@ def split_arguments(s, named = False):
         raise Exception("Invalid syntax.")
     else:
         if named:
-            args[key] = tmp.strip()
-        else:
+            if key is not None:
+                args[key] = tmp.strip()
+        elif not skip:
             args.append(tmp.strip())
 
     return args

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2112,3 +2112,72 @@ def interactive(func):
             return ret
 
     return decorator
+
+
+def split_arguments(s, named = False):
+    """
+    Method to split an argument list from string format to an actual list of values.
+    Supports regular arguments and named arguments.
+
+    Args:
+        s (str): The string to convert.
+        named (bool, optional): True if "s" represents named arguments (**kwargs), False if not.
+    
+    Returns:
+        arguments (list): If "named" is False.
+        arguments (dict): If "named" is True.
+
+    """
+    args = {} if named else []
+    inside = False
+    char = None
+    escape = False
+    tmp = ""
+    key = None
+
+    for c in s:
+        if named and key is None:
+            if c == "=":
+                key = tmp
+                tmp = ""
+            else:
+                tmp += c
+        else:
+            if c == "," and not inside:
+                if named:
+                    args[key] = tmp.strip()
+                    key = None
+                else:
+                    args.append(tmp.strip())
+                tmp = ""
+            else:
+                if char is None and (c == "\"" or c == "'"):
+                    char = c
+                    inside = True
+                    continue
+                elif char is not None:
+                    if c == "\\":
+                        escape = True
+                    elif c == char:
+                        if escape:
+                            escape = False
+                        else:
+                            inside = False
+                            char = None
+                            continue
+                    elif escape:
+                        escape = False
+                        tmp += "\\"
+
+                if not escape:
+                    tmp += c
+
+    if inside:
+        raise Exception("Invalid syntax.")
+    else:
+        if named:
+            args[key] = tmp.strip()
+        else:
+            args.append(tmp.strip())
+
+    return args


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR should (if I didn't mess this up, it's my first PR after all) change the way lockstrings are parsed so that single quotes and double quotes can be used to avoid an issue where comma's can't be used in lockstrings. It will also allow single quotes and double quotes to be used if you escape them correctly with a backslash.

#### Motivation for adding to Evennia
I have made my own "trigger functions" which is a lame copy of lock functions to run when certain events occur in the game.

While developing this, I came across an annoying quirk: you can't use single or double quotes in lockstrings. Because of this, you can't use comma's in lockstrings either because the parser will think it's a new argument.

#### Other info (issues closed, discussion etc)
This is my first PR and I'm not sure how this works. I looked at the wiki pages for contributors but I'm not sure if there are guidelines I should follow here. Please advise.