### PR TITLE
Stops Attribute/Tag handlers from caching when TYPECLASS_AGGRESSIVE_CACHE is disabled

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -237,6 +237,7 @@ class AttributeHandler(object):
 
     def _fullcache(self):
         """Cache all attributes of this object"""
+        if not _TYPECLASS_AGGRESSIVE_CACHE: return
         query = {
             "%s__id" % self._model: self._objid,
             "attribute__db_model__iexact": self._model,
@@ -298,7 +299,7 @@ class AttributeHandler(object):
                 attr = None
                 cachefound = False
                 del self._cache[cachekey]
-            if cachefound:
+            if cachefound and _TYPECLASS_AGGRESSIVE_CACHE:
                 if attr:
                     return [attr]  # return cached entity
                 else:
@@ -316,13 +317,15 @@ class AttributeHandler(object):
                 conn = getattr(self.obj, self._m2m_fieldname).through.objects.filter(**query)
                 if conn:
                     attr = conn[0].attribute
-                    self._cache[cachekey] = attr
+                    if _TYPECLASS_AGGRESSIVE_CACHE: 
+                        self._cache[cachekey] = attr
                     return [attr] if attr.pk else []
                 else:
                     # There is no such attribute. We will explicitly save that
                     # in our cache to avoid firing another query if we try to
                     # retrieve that (non-existent) attribute again.
-                    self._cache[cachekey] = None
+                    if _TYPECLASS_AGGRESSIVE_CACHE:
+                        self._cache[cachekey] = None
                     return []
         else:
             # only category given (even if it's None) - we can't
@@ -345,12 +348,13 @@ class AttributeHandler(object):
                         **query
                     )
                 ]
-                for attr in attrs:
-                    if attr.pk:
-                        cachekey = "%s-%s" % (attr.db_key, category)
-                        self._cache[cachekey] = attr
-                # mark category cache as up-to-date
-                self._catcache[catkey] = True
+                if _TYPECLASS_AGGRESSIVE_CACHE:
+                    for attr in attrs:
+                        if attr.pk:
+                            cachekey = "%s-%s" % (attr.db_key, category)
+                            self._cache[cachekey] = attr
+                    # mark category cache as up-to-date
+                    self._catcache[catkey] = True
                 return attrs
 
     def _setcache(self, key, category, attr_obj):
@@ -363,6 +367,7 @@ class AttributeHandler(object):
             attr_obj (Attribute): The newly saved attribute
 
         """
+        if not _TYPECLASS_AGGRESSIVE_CACHE: return
         if not key:  # don't allow an empty key in cache
             return
         cachekey = "%s-%s" % (key, category)

--- a/evennia/typeclasses/tags.py
+++ b/evennia/typeclasses/tags.py
@@ -121,6 +121,7 @@ class TagHandler(object):
 
     def _fullcache(self):
         "Cache all tags of this object"
+        if not _TYPECLASS_AGGRESSIVE_CACHE: return
         query = {
             "%s__id" % self._model: self._objid,
             "tag__db_model": self._model,
@@ -188,7 +189,8 @@ class TagHandler(object):
                 conn = getattr(self.obj, self._m2m_fieldname).through.objects.filter(**query)
                 if conn:
                     tag = conn[0].tag
-                    self._cache[cachekey] = tag
+                    if _TYPECLASS_AGGRESSIVE_CACHE:
+                        self._cache[cachekey] = tag
                     return [tag]
         else:
             # only category given (even if it's None) - we can't
@@ -211,11 +213,12 @@ class TagHandler(object):
                         **query
                     )
                 ]
-                for tag in tags:
-                    cachekey = "%s-%s" % (tag.db_key, category)
-                    self._cache[cachekey] = tag
-                # mark category cache as up-to-date
-                self._catcache[catkey] = True
+                if _TYPECLASS_AGGRESSIVE_CACHE:
+                    for tag in tags:
+                        cachekey = "%s-%s" % (tag.db_key, category)
+                        self._cache[cachekey] = tag
+                    # mark category cache as up-to-date
+                    self._catcache[catkey] = True
                 return tags
         return []
 
@@ -229,6 +232,7 @@ class TagHandler(object):
             tag_obj (tag): The newly saved tag
 
         """
+        if not _TYPECLASS_AGGRESSIVE_CACHE: return
         if not key:  # don't allow an empty key in cache
             return
         key, category = key.strip().lower(), category.strip().lower() if category else category

--- a/evennia/typeclasses/tests.py
+++ b/evennia/typeclasses/tests.py
@@ -2,8 +2,9 @@
 Unit tests for typeclass base system
 
 """
-
+from django.test import override_settings
 from evennia.utils.test_resources import EvenniaTest
+from mock import patch
 
 # ------------------------------------------------------------
 # Manager tests
@@ -18,6 +19,19 @@ class TestAttributes(EvenniaTest):
         self.assertEqual(self.obj1.attributes.get(key), value)
         self.obj1.db.testattr = value
         self.assertEqual(self.obj1.db.testattr, value)
+        
+    @override_settings(TYPECLASS_AGGRESSIVE_CACHE=False)
+    @patch('evennia.typeclasses.attributes._TYPECLASS_AGGRESSIVE_CACHE', False)
+    def test_attrhandler_nocache(self):
+        key = "testattr"
+        value = "test attr value "
+        self.obj1.attributes.add(key, value)
+        self.assertFalse(self.obj1.attributes._cache)
+        
+        self.assertEqual(self.obj1.attributes.get(key), value)
+        self.obj1.db.testattr = value
+        self.assertEqual(self.obj1.db.testattr, value)
+        self.assertFalse(self.obj1.attributes._cache)
 
     def test_weird_text_save(self):
         "test 'weird' text type (different in py2 vs py3)"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When TYPECLASS_AGGRESSIVE_CACHE is disabled, the Attribute and Tag handlers will both continue to write/update the cache, but not read from it. This might be manageable under normal conditions but was causing a memory leak when I attempted to export the contents of my database.

#### Other info (issues closed, discussion etc)
Closes #1996 and #1997 