### PR TITLE
Fixes Msg str rendering where no key attribute exists for sender

### DIFF
--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -400,9 +400,10 @@ class Msg(SharedMemoryModel):
 
     def __str__(self):
         "This handles what is shown when e.g. printing the message"
-        senders = ",".join(obj.key for obj in self.senders)
+        senders = ",".join(getattr(obj, 'key', str(obj)) for obj in self.senders)
+        
         receivers = ",".join(
-            ["[%s]" % obj.key for obj in self.channels] + [obj.key for obj in self.receivers]
+            ["[%s]" % getattr(obj, 'key', str(obj)) for obj in self.channels] + [getattr(obj, 'key', str(obj)) for obj in self.receivers]
         )
         return "%s->%s: %s" % (senders, receivers, crop(self.message, width=40))
 

--- a/evennia/comms/tests.py
+++ b/evennia/comms/tests.py
@@ -1,5 +1,6 @@
 from evennia.utils.test_resources import EvenniaTest
 from evennia import DefaultChannel
+from evennia.utils.create import create_message
 
 
 class ObjectCreationTest(EvenniaTest):
@@ -10,3 +11,8 @@ class ObjectCreationTest(EvenniaTest):
         self.assertTrue(obj, errors)
         self.assertFalse(errors, errors)
         self.assertEqual(description, obj.db.desc)
+        
+    def test_message_create(self):
+        msg = create_message('peewee herman', 'heh-heh!', header='mail time!')
+        self.assertTrue(msg)
+        self.assertEqual(str(msg), 'peewee herman->: heh-heh!')


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Not much to say. Small modification to the __str__ method for Msg objects to account for senders with no 'key' attribute.

#### Other info (issues closed, discussion etc)
Closes #1982 