### PR TITLE
Fixes failure of copy() method to replicate categorized attributes and tags

### DIFF
--- a/evennia/objects/manager.py
+++ b/evennia/objects/manager.py
@@ -575,8 +575,8 @@ class ObjectDBManager(TypedObjectManager):
             return None
 
         # copy over all attributes from old to new.
-        for attr in original_object.attributes.all():
-            new_object.attributes.add(attr.key, attr.value)
+        attrs = ((a.key, a.value, a.category, a.lock_storage) for a in original_object.attributes.all())
+        new_object.attributes.batch_add(*attrs)
 
         # copy over all cmdsets, if any
         for icmdset, cmdset in enumerate(original_object.cmdset.all()):
@@ -590,8 +590,8 @@ class ObjectDBManager(TypedObjectManager):
             ScriptDB.objects.copy_script(script, new_obj=new_object)
 
         # copy over all tags, if any
-        for tag in original_object.tags.get(return_tagobj=True, return_list=True):
-            new_object.tags.add(tag=tag.db_key, category=tag.db_category, data=tag.db_data)
+        tags = ((t.db_key, t.db_category, t.db_data) for t in original_object.tags.all(return_objs=True))
+        new_object.tags.batch_add(*tags)
 
         return new_object
 

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -101,3 +101,27 @@ class TestObjectManager(EvenniaTest):
         self.assertEqual(list(query), [self.obj1])
         query = ObjectDB.objects.get_objs_with_attr("NotFound", candidates=[self.char1, self.obj1])
         self.assertFalse(query)
+
+    def test_copy_object(self):
+        "Test that all attributes and tags properly copy across objects"
+        
+        # Add some tags
+        self.obj1.tags.add('plugh', category='adventure')
+        self.obj1.tags.add('xyzzy')
+        
+        # Add some attributes
+        self.obj1.attributes.add('phrase', 'plugh', category='adventure')
+        self.obj1.attributes.add('phrase', 'xyzzy')
+        
+        # Create object copy
+        obj2 = self.obj1.copy()
+
+        # Make sure each of the tags were replicated
+        self.assertTrue('plugh' in obj2.tags.all())
+        self.assertTrue('plugh' in obj2.tags.get(category='adventure'))
+        self.assertTrue('xyzzy' in obj2.tags.all())
+        
+        # Make sure each of the attributes were replicated
+        self.assertEqual(obj2.attributes.get(key='phrase'), 'xyzzy')
+        self.assertEqual(self.obj1.attributes.get(key='phrase', category='adventure'), 'plugh')
+        self.assertEqual(obj2.attributes.get(key='phrase', category='adventure'), 'plugh')


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Small tweaks to the objectmanager `copy()` method to replicate categorized attributes and tags.

Problem was reportedly with tags only but the same behavior occurred with attributes as well.

#### Other info (issues closed, discussion etc)
#1972 