### PR TITLE
Fixes TypeError with Account characters property if unset

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -216,13 +216,16 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
     @property
     def characters(self):
         # Get playable characters list
-        objs = self.db._playable_characters
-        if not objs: objs = ()
+        objs = self.db._playable_characters or []
 
         # Rebuild the list if legacy code left null values after deletion
-        if None in objs:
-            objs = [x for x in self.db._playable_characters if x]
-            self.db._playable_characters = objs
+        try:
+            if None in objs:
+                objs = [x for x in self.db._playable_characters if x]
+                self.db._playable_characters = objs
+        except Exception as e:
+            logger.log_trace(e)
+            logger.log_err(e)
 
         return objs
 

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -217,6 +217,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
     def characters(self):
         # Get playable characters list
         objs = self.db._playable_characters
+        if not objs: objs = ()
 
         # Rebuild the list if legacy code left null values after deletion
         if None in objs:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The account.characters property was treated as an iterable, even if None. I suspect this was causing some problems on the web frontend during account creation.

#### Other info (issues closed, discussion etc)
Possible resolution to #1905