### PR TITLE
Fix for WebSocket failing to log the user in when the page is refreshed

### DIFF
--- a/evennia/web/utils/middleware.py
+++ b/evennia/web/utils/middleware.py
@@ -61,3 +61,10 @@ class SharedLoginMiddleware(object):
                     login(request, account)
                 except AttributeError:
                     logger.log_trace()
+
+        if csession.get("webclient_authenticated_uid", None):
+            # set a nonce to prevent the webclient from erasing the webclient_authenticated_uid value
+            csession["webclient_authenticated_nonce"] = csession.get("webclient_authenticated_nonce", 0) + 1
+            # wrap around to prevent integer overflows
+            if csession["webclient_authenticated_nonce"] > 32:
+                csession["webclient_authenticated_nonce"] = 0

--- a/evennia/web/webclient/static/webclient/js/webclient_gui.js
+++ b/evennia/web/webclient/static/webclient/js/webclient_gui.js
@@ -284,7 +284,6 @@ $(document).ready(function() {
 
     // Event when closing window (have to have Evennia initialized)
     $(window).bind("beforeunload", plugin_handler.onBeforeUnload);
-    $(window).bind("unload", Evennia.connection.close);
 
     // Event when any key is pressed
     $(document).keydown(plugin_handler.onKeydown)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR introduces a series of fixes for bugs related to WebSocket connections in various browsers.

There are a few issues:

---

* According to the spec, an exit code of `1000` means that the WebSocket connection was closed through JavaScript while an exit code of `1001` means that the WebSocket connection was closed because the user navigated away from the page. Some browsers (e.x., Firefox) seem to wrongly send code 1000 when the user navigates away or reloads the tab/window. Other browsers (e.x., Google Chrome, Mobile Safari) send code 1001 which is then considered an error.

The first change is to properly disconnect the WebSocketClient when exit code 1001 is received.

---

* Both Google Chrome and Mobile Safari end up making a new WebSocket connection _before_ the old connection is closed. The `make_shared_login` in `middleware.py` is called first (which sets "webclient_authenticated_uid"), followed by a `disconnect` in `webclient.py` (which erases the value of "webclient_authenticated_uid"). Result: You are no longer logged in when you refresh the page in these browsers.

I had originally fixed this by adding an `beforeunload` event in JavaScript that closes the WebSocket connection. Further testing revealed that Mobile Safari never calls `beforeunload` when the user refreshes the page.

The new fix is to set a "nonce value", an integer which is incremented each time the "webclient_authenticated_uid" attribute is set, and which is stored in each `WebSocketClient` object. (I'm not sure if "nonce" is the right word, in hindsight, as it seems used more often in cryptographic functions.)

When a `WebSocketClient` object's `disconnect` is called it will first check if its `nonce` is the same as the current session nonce. If it is, it'll clear the "webclient_authenticated_uid" value, otherwise, it'll leave it alone.

I've tested this by hammering the F5 button over and over on my machine, and the webclient reconnects successfully every time.

---

* Both `unload` and `beforeunload` is unreliable across various browsers. Mobile Safari seems to ignore them.

The most controversial change is the removal of the `unload` handler in `webclient_gui.js`. This should not be necessary as every browser should close the WebSocket with either an exit code 1000 or 1001.

#### Motivation for adding to Evennia
These issues have been plaguing me for a while now. It'll be good to see them officially fixed in Evennia.