### PR TITLE
Fixing error with Command.client_width()

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -502,13 +502,13 @@ Command {self} has no defined `func()` - showing on-command variables:
         Get the client screenwidth for the session using this command.
 
         Returns:
-            client width (int or None): The width (in characters) of the client window. None
-                if this command is run without a Session (such as by an NPC).
+            client width (int): The width (in characters) of the client window.
 
         """
         if self.session:
             return self.session.protocol_flags.get(
-                "SCREENWIDTH", (settings.CLIENT_DEFAULT_WIDTH, ))[0]
+                "SCREENWIDTH", {0: settings.CLIENT_DEFAULT_WIDTH})[0]
+        return settings.CLIENT_DEFAULT_WIDTH
 
     def styled_table(self, *args, **kwargs):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Command.client_width() doesn't use its fallback properly when dealing with strange NAWS issues or the WebClient. Fixing that by making some adjustments to client_width()

#### Motivation for adding to Evennia
Stuff's gotta work, man.

#### Other info (issues closed, discussion etc)
I changed it to always return the default width for more consistency. If returning a None would cause formatting to fail and traceback when a command's run by an NPC, then it's a problem. Yes, it's better if the command never creates a message to send in the first place if there's nobody listening, but...