### PR TITLE
Fix for the interval=0 bug in the restart script function

### DIFF
--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -566,7 +566,7 @@ class DefaultScript(ScriptBase):
         first call the stop hooks, and then the start hooks again.
         Args:
             interval (int, optional): Allows for changing the interval
-                of the Script. Given in seconds.  if `None`, will use the
+                of the Script. Given in seconds.  if `None`, will use the already stored interval.
             repeats (int, optional): The number of repeats. If unset, will
                 use the previous setting.
             start_delay (bool, optional): If we should wait `interval` seconds

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -136,12 +136,9 @@ class ExtendedLoopingCall(LoopingCall):
                 the task is not running.
 
         """
-        if self.running:
+        if self.running and self.interval > 0:
             total_runtime = self.clock.seconds() - self.starttime
             interval = self.start_delay or self.interval
-            # Fairly naive ZeroDivision error bug workaround, see ticket: https://github.com/evennia/evennia/issues/2039#issue-555828740
-            if self.interval == 0:
-                self.interval = 1
             return interval - (total_runtime % self.interval)
         return None
 
@@ -586,7 +583,6 @@ it should not accept 0 at alln seconds.  if `None`, will use the
         del self.db._manual_pause
         del self.db._paused_callcount
         # set new flags and start over
-        # Avoid intervals lower than zero
         if interval is not None and interval >= 0:
             self.interval = interval
         if repeats is not None:

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -583,7 +583,9 @@ it should not accept 0 at alln seconds.  if `None`, will use the
         del self.db._manual_pause
         del self.db._paused_callcount
         # set new flags and start over
-        if interval is not None and interval >= 0:
+        if interval is not None:
+            if interval < 0:
+                interval = 0
             self.interval = interval
         if repeats is not None:
             self.repeats = repeats

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -564,8 +564,9 @@ class DefaultScript(ScriptBase):
         Restarts an already existing/running Script from the
         beginning, optionally using different settings. This will
         first call the stop hooks, and then the start hooks again.
-it should not accept 0 at alln seconds.  if `None`, will use the
-                already stored interval.
+        Args:
+            interval (int, optional): Allows for changing the interval
+                of the Script. Given in seconds.  if `None`, will use the
             repeats (int, optional): The number of repeats. If unset, will
                 use the previous setting.
             start_delay (bool, optional): If we should wait `interval` seconds


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This should fix the issue with passing 0 as the `interval` parameter for the `restart` function in evennia/evennia/scripts/scripts.py.

#### Other info (issues closed, discussion etc)
Issue reference: https://github.com/evennia/evennia/issues/2039