### PR TITLE
Added a prototype flag to typeclass to allow setting existing objects…

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2102,7 +2102,8 @@ class CmdTypeclass(COMMAND_DEFAULT_CLASS):
 
             if "prototype" in self.switches:
                 modified = spawner.batch_update_objects_with_prototype(prototype, objects=[obj])
-                if modified == 0:
+                prototype_success = modified > 0
+                if not prototype_success:
                     caller.msg("Prototype %s failed to apply." % prototype["key"])
 
             if is_same:
@@ -2121,7 +2122,7 @@ class CmdTypeclass(COMMAND_DEFAULT_CLASS):
                 string += " All old attributes where deleted before the swap."
             else:
                 string += " Attributes set before swap were not removed."
-            if "prototype" in self.switches:
+            if "prototype" in self.switches and prototype_success:
                 string += " Prototype '%s' was successfully applied over the object type." % prototype["key"]
 
         caller.msg(string)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2101,7 +2101,9 @@ class CmdTypeclass(COMMAND_DEFAULT_CLASS):
             )
 
             if "prototype" in self.switches:
-                spawner.batch_update_objects_with_prototype(prototype, objects=[obj])
+                modified = spawner.batch_update_objects_with_prototype(prototype, objects=[obj])
+                if modified == 0:
+                    caller.msg("Prototype %s failed to apply." % prototype["key"])
 
             if is_same:
                 string = "%s updated its existing typeclass (%s).\n" % (obj.name, obj.path)
@@ -2119,6 +2121,8 @@ class CmdTypeclass(COMMAND_DEFAULT_CLASS):
                 string += " All old attributes where deleted before the swap."
             else:
                 string += " Attributes set before swap were not removed."
+            if "prototype" in self.switches:
+                string += " Prototype '%s' was successfully applied over the object type." % prototype["key"]
 
         caller.msg(string)
 


### PR DESCRIPTION
… to a new prototype.

#### Brief overview of PR changes/additions
Adding new flag to typeclass cmd for applying prototypes over existing objects.
#### Motivation for adding to Evennia
expand the prototype system to be more useful in non-test-driven iterative development environments. Where one off items may be made before they're made into prototypes and there's a desire to either:

A. Turn that one off item into a prototype and back-propagate it for organizational purposes.
B. Update prototype dicts that are provided in hardcode and reapply them to objects with a full stateless refresh.
#### Other info (issues closed, discussion etc)
Some discussion happened about this on Discord.