### PR TITLE
Adding prettier output to attribute examinations.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2,8 +2,6 @@
 Building and world design commands
 """
 import re
-import json
-from evennia.utils.dbserialize import SaverDictEncoder
 from django.conf import settings
 from django.db.models import Q, Min, Max
 from evennia.objects.models import ObjectDB
@@ -2310,12 +2308,10 @@ class CmdExamine(ObjManipCommand):
 
     account_mode = False
 
-    def list_attribute(self, crop, attr, category, value, indent=False):
+    def list_attribute(self, crop, attr, category, value):
         """
         Formats a single attribute line.
         """
-        if indent:
-            return "\n %s = %s" % (attr, json.dumps(value, cls=SaverDictEncoder, indent=2))
         if crop:
             if not isinstance(value, str):
                 value = utils.to_str(value)
@@ -2326,7 +2322,6 @@ class CmdExamine(ObjManipCommand):
             string = "\n %s = %s" % (attr, value)
         string = raw(string)
         return string
-
 
     def format_attributes(self, obj, attrname=None, crop=True):
         """
@@ -2347,15 +2342,14 @@ class CmdExamine(ObjManipCommand):
             except Exception:
                 ndb_attr = None
         string = ""
-        indented = attrname is not None
         if db_attr and db_attr[0]:
             string += "\n|wPersistent attributes|n:"
             for attr, value, category in db_attr:
-                string += self.list_attribute(crop, attr, category, value, indented)
+                string += self.list_attribute(crop, attr, category, value)
         if ndb_attr and ndb_attr[0]:
             string += "\n|wNon-Persistent attributes|n:"
             for attr, value in ndb_attr:
-                string += self.list_attribute(crop, attr, None, value, indented)
+                string += self.list_attribute(crop, attr, None, value)
         return string
 
     def format_output(self, obj, avail_cmdset):

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2310,7 +2310,7 @@ class CmdExamine(ObjManipCommand):
 
     account_mode = False
 
-    def list_attribute(self, crop, attr, category, value, indent=False):
+    def list_attribute(self, crop, attr, category, value, indent):
         """
         Formats a single attribute line.
         """

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2310,7 +2310,7 @@ class CmdExamine(ObjManipCommand):
 
     account_mode = False
 
-    def list_attribute(self, crop, attr, category, value, indent):
+    def list_attribute(self, crop, attr, category, value, indent=False):
         """
         Formats a single attribute line.
         """

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2,6 +2,8 @@
 Building and world design commands
 """
 import re
+import json
+from evennia.utils.dbserialize import SaverDictEncoder
 from django.conf import settings
 from django.db.models import Q, Min, Max
 from evennia.objects.models import ObjectDB
@@ -2308,10 +2310,12 @@ class CmdExamine(ObjManipCommand):
 
     account_mode = False
 
-    def list_attribute(self, crop, attr, category, value):
+    def list_attribute(self, crop, attr, category, value, indent=False):
         """
         Formats a single attribute line.
         """
+        if indent:
+            return "\n %s = %s" % (attr, json.dumps(value, cls=SaverDictEncoder, indent=2))
         if crop:
             if not isinstance(value, str):
                 value = utils.to_str(value)
@@ -2322,6 +2326,7 @@ class CmdExamine(ObjManipCommand):
             string = "\n %s = %s" % (attr, value)
         string = raw(string)
         return string
+
 
     def format_attributes(self, obj, attrname=None, crop=True):
         """
@@ -2342,14 +2347,15 @@ class CmdExamine(ObjManipCommand):
             except Exception:
                 ndb_attr = None
         string = ""
+        indented = attrname is not None
         if db_attr and db_attr[0]:
             string += "\n|wPersistent attributes|n:"
             for attr, value, category in db_attr:
-                string += self.list_attribute(crop, attr, category, value)
+                string += self.list_attribute(crop, attr, category, value, indented)
         if ndb_attr and ndb_attr[0]:
             string += "\n|wNon-Persistent attributes|n:"
             for attr, value in ndb_attr:
-                string += self.list_attribute(crop, attr, None, value)
+                string += self.list_attribute(crop, attr, None, value, indented)
         return string
 
     def format_output(self, obj, avail_cmdset):

--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -31,7 +31,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.safestring import SafeString
 from evennia.utils.utils import uses_database, is_iter, to_str, to_bytes
 from evennia.utils import logger
-import json
 
 __all__ = ("to_pickle", "from_pickle", "do_pickle", "do_unpickle", "dbserialize", "dbunserialize")
 
@@ -289,15 +288,6 @@ class _SaverDict(_SaverMutable, MutableMapping):
         return key in self._data
 
 
-class SaverDictEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, _SaverMutable) or isinstance(o, _SaverDict):
-            return o._data
-        if hasattr(o, 'db_key') and hasattr(o, 'dbref'):
-            return "(ref) %s [%s]" % (o.db_key, o.dbref)
-        return json.JSONEncoder.default(self, o)
-
-
 class _SaverSet(_SaverMutable, MutableSet):
     """
     A set that saves to an Attribute when updated
@@ -317,9 +307,6 @@ class _SaverSet(_SaverMutable, MutableSet):
     @_save
     def discard(self, value):
         self._data.discard(value)
-
-    def default(self, o):
-        return self._data
 
 
 class _SaverOrderedDict(_SaverMutable, MutableMapping):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Examining specific attributes will produce a JSON-indented output of attributes broken down to a human readable output.

#### Motivation for adding to Evennia
I wanted the output to be indented to be easier to read. When you start using some pretty large dicts as db persistent attributes, it can be difficult to parse. 

#### Other info (issues closed, discussion etc)
