### PR TITLE
Fixing unintended consequences of proxy_plugins

### DIFF
--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -388,8 +388,7 @@ if WEBSERVER_ENABLED:
                     webclientstr = "webclient-websocket%s: %s" % (w_ifacestr, port)
                 INFO_DICT["webclient"].append(webclientstr)
 
-            web_root = Website(web_root, logPath=settings.HTTP_LOG_FILE)
-            web_root.is_portal = True
+
 
             if WEB_PLUGINS_MODULE:
                 try:
@@ -399,7 +398,8 @@ if WEBSERVER_ENABLED:
                         "WARNING: WEB_PLUGINS_MODULE is enabled but at_webproxy_root_creation() not found - "
                         "copy 'evennia/game_template/server/conf/web_plugins.py to mygame/server/conf."
                     )
-
+            web_root = Website(web_root, logPath=settings.HTTP_LOG_FILE)
+            web_root.is_portal = True
             proxy_service = internet.TCPServer(proxyport, web_root, interface=interface)
             proxy_service.setName("EvenniaWebProxy%s:%s" % (ifacestr, proxyport))
             PORTAL.services.addService(proxy_service)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Django returns a 404 for any putChild inside the proxy plugin module.

As written, this actually isn't putting the child into the Evennia Proxy, it's putting it into Webserver, which is explicitly not the point.

These two lines have to go down below the proxy resources are loaded.
