### PR TITLE
Fixed CmdHelp's message formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - new `drop:holds()` lock default to limit dropping nonsensical things. Access check
   defaults to True for backwards-compatibility in 0.9, will be False in 1.0
+- CmdHelp now calls self.msg() properly when used with settings.HELP_MORE disabled.
 
 ### Already in master
 

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -79,7 +79,7 @@ class CmdHelp(Command):
                 evmore.msg(self.caller, text, session=self.session)
                 return
 
-        self.msg((text, {"type": "help"}))
+        self.msg(text, type="help")
 
     @staticmethod
     def format_help_entry(title, help_text, aliases=None, suggested=None):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When settings.HELP_MORE is false, CmdHelp.msg_help() would resort to an improper call signature for MuxCommand.msg(), resulting in weird formatting when \@ooc.

#### Motivation for adding to Evennia
Well, we sure can't have the above issue going on.

#### Other info (issues closed, discussion etc)
Everything looks hunky-dory to me.