### PR TITLE
Attribute refactor

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -32,7 +32,7 @@ from evennia.server.signals import (
     SIGNAL_OBJECT_POST_PUPPET,
     SIGNAL_OBJECT_POST_UNPUPPET,
 )
-from evennia.typeclasses.attributes import NickHandler
+from evennia.typeclasses.attributes import NickHandler, ModelAttributeBackend
 from evennia.scripts.scripthandler import ScriptHandler
 from evennia.commands.cmdsethandler import CmdSetHandler
 from evennia.utils.optionhandler import OptionHandler
@@ -199,7 +199,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
 
     @lazy_property
     def nicks(self):
-        return NickHandler(self)
+        return NickHandler(self, ModelAttributeBackend)
 
     @lazy_property
     def sessions(self):

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from django.conf import settings
 
 from evennia.typeclasses.models import TypeclassBase
-from evennia.typeclasses.attributes import NickHandler
+from evennia.typeclasses.attributes import NickHandler, ModelAttributeBackend
 from evennia.objects.manager import ObjectManager
 from evennia.objects.models import ObjectDB
 from evennia.scripts.scripthandler import ScriptHandler
@@ -225,7 +225,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     @lazy_property
     def nicks(self):
-        return NickHandler(self)
+        return NickHandler(self, ModelAttributeBackend)
 
     @lazy_property
     def sessions(self):

--- a/evennia/typeclasses/tests.py
+++ b/evennia/typeclasses/tests.py
@@ -26,12 +26,12 @@ class TestAttributes(EvenniaTest):
         key = "testattr"
         value = "test attr value "
         self.obj1.attributes.add(key, value)
-        self.assertFalse(self.obj1.attributes._cache)
+        self.assertFalse(self.obj1.attributes.backend._cache)
 
         self.assertEqual(self.obj1.attributes.get(key), value)
         self.obj1.db.testattr = value
         self.assertEqual(self.obj1.db.testattr, value)
-        self.assertFalse(self.obj1.attributes._cache)
+        self.assertFalse(self.obj1.attributes.backend._cache)
 
     def test_weird_text_save(self):
         "test 'weird' text type (different in py2 vs py3)"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Almost completely refactors the Attribute system to introduce swappable "Backends" for AttributeHandler, and a proper In-memory Attribute used by the NAttribute system. This means that the .attributes and .nattributes API are now identical - .nattributes can do everything that Attributes can do.

#### Motivation for adding to Evennia
 This opens the doorway for more advanced shenanigans; my goal is allowing session.ndb (or perhaps a special session.pdb ? ) to save data over AMP to the PortalSession which can survive a reload. This is now easily possible using a subclass of the InMemoryAttributeBackend and InMemoryAttribute.

#### Other info (issues closed, discussion etc)
Strangely, a few contribs fail tests with these changes. I am not sure why. Hoping someone can help me figure it out.