### PR TITLE
Add a contents indexer to optimize inventory lookups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## Evennia 1.0 (2019-) (WIP)
+## Evennia 1.0 (2019-) (develop branch, WIP)
 
 - new `drop:holds()` lock default to limit dropping nonsensical things. Access check
   defaults to True for backwards-compatibility in 0.9, will be False in 1.0
 - REST API allows you external access to db objects through HTTP requests (Tehom)
+- `Object.normalize_name` and `.validate_name` added to (by default) enforce latinify
+  on character name and avoid potential exploits using clever Unicode chars (trhr)
+
 
 ### Already in master
 - `is_typeclass(obj (Object), exact (bool))` now defaults to exact=False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - REST API allows you external access to db objects through HTTP requests (Tehom)
 - `Object.normalize_name` and `.validate_name` added to (by default) enforce latinify
   on character name and avoid potential exploits using clever Unicode chars (trhr)
-
+- Added content_types indexing to DefaultObject's ContentsHandler.
 
 ### Already in master
 - `is_typeclass(obj (Object), exact (bool))` now defaults to exact=False

--- a/evennia/objects/models.py
+++ b/evennia/objects/models.py
@@ -53,7 +53,7 @@ class ContentsHandler(object):
         Re-initialize the content cache
 
         """
-        objects = [obj for obj in ObjectDB.objects.filter(db_location=self.obj) if obj.pk]
+        objects = ObjectDB.objects.filter(db_location=self.obj)
         self._pkcache = {obj.pk for obj in objects}
         for obj in objects:
             for ctype in obj._content_types:

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -203,6 +203,8 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
     without `obj.save()` having to be called explicitly.
 
     """
+    # Used for sorting / filtering.
+    _content_types = ("object")
 
     # lockstring of newly created objects, for easy overloading.
     # Will be formatted with the appropriate attributes.
@@ -257,7 +259,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             and not self.db_account.attributes.get("_quell")
         )
 
-    def contents_get(self, exclude=None):
+    def contents_get(self, exclude=None, category=None):
         """
         Returns the contents of this object, i.e. all
         objects that has this object set as its location.
@@ -266,6 +268,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         Args:
             exclude (Object): Object to exclude from returned
                 contents list
+            category (str): A category to filter by. None for no filtering.
 
         Returns:
             contents (list): List of contents of this Object.
@@ -1656,20 +1659,25 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             **kwargs (dict): Arbitrary, optional arguments for users
                 overriding the call (unused by default).
         """
+        def filter_visible(obj_list):
+            # Helper method to determine if objects are visible to the looker.
+            return [obj for obj in obj_list if obj != looker and obj.access(looker, "view")]
+
         if not looker:
             return ""
+
         # get and identify all objects
-        visible = (con for con in self.contents if con != looker and con.access(looker, "view"))
-        exits, users, things = [], [], defaultdict(list)
-        for con in visible:
-            key = con.get_display_name(looker)
-            if con.destination:
-                exits.append(key)
-            elif con.has_account:
-                users.append("|c%s|n" % key)
-            else:
-                # things can be pluralized
-                things[key].append(con)
+        exits_list = filter_visible(self.contents_get(category='exit'))
+        users_list = filter_visible(self.contents_get(category='character'))
+        things_list = filter_visible(self.contents_get(category="object"))
+
+        things = defaultdict(list)
+
+        for thing in things_list:
+            things[thing.key].append(thing)
+        users = [f"|c{user.key}|n" for user in users_list]
+        exits = [ex.key for ex in exits_list]
+
         # get description, build string
         string = "|c%s|n\n" % self.get_display_name(looker)
         desc = self.db.desc
@@ -2026,7 +2034,7 @@ class DefaultCharacter(DefaultObject):
     a character avatar controlled by an account.
 
     """
-
+    _content_types = ("character")
     # lockstring of newly created rooms, for easy overloading.
     # Will be formatted with the appropriate attributes.
     lockstring = "puppet:id({character_id}) or pid({account_id}) or perm(Developer) or pperm(Developer);delete:id({account_id}) or perm(Admin)"
@@ -2277,7 +2285,7 @@ class DefaultRoom(DefaultObject):
     This is the base room object. It's just like any Object except its
     location is always `None`.
     """
-
+    _content_types = ("room", "object")
     # lockstring of newly created rooms, for easy overloading.
     # Will be formatted with the {id} of the creating object.
     lockstring = (
@@ -2427,7 +2435,7 @@ class DefaultExit(DefaultObject):
     exits simply by giving the exit-object's name on its own.
 
     """
-
+    _content_types = ("exit")
     exit_command = ExitCommand
     priority = 101
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -279,9 +279,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             and filtering.
 
         """
-        con = self.contents_cache.get(exclude=exclude)
-        # print "contents_get:", self, con, id(self), calledby()  # DEBUG
-        return con
+        return self.contents_cache.get(exclude=exclude, content_type=content_type)
 
     def contents_set(self, *args):
         "You cannot replace this property"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds light / mild indexing to the ContentsHandler on ObjectDB, reducing the filtering and sorting that must be done for frequent operations like viewing a room description.

Also changed ContentsHandler's ._pkcache to be a set() instead of a 'Dictionary that only cares about keys and has None for values'. Because using a dictionary that way is weird.

#### Motivation for adding to Evennia
Seeing how DefaultObject.return_appearance() was constantly guessing at what it was trying to display offends my sensibilities. I'm putting this out there as a possible alternate approach.

#### Other info (issues closed, discussion etc)
I'm not 100% sure the Wilderness contrib likes this.