### PR TITLE
[On hold] Making ObjectSessionHandler easier to subclass with a different backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Made most of the networking classes such as Protocols and the SessionHandlers 
   replaceable via `settings.py` for modding enthusiasts. (volund)
 
+- `ObjectSessionHandler` now easier to sub-class.
 
 ### Already in master
 - `is_typeclass(obj (Object), exact (bool))` now defaults to exact=False

--- a/evennia/accounts/tests.py
+++ b/evennia/accounts/tests.py
@@ -216,15 +216,53 @@ class TestDefaultAccount(TestCase):
     "Check DefaultAccount class"
 
     def setUp(self):
-        self.s1 = MagicMock()
-        self.s1.puppet = None
+        from evennia.server.sessionhandler import SESSION_HANDLER
+        from evennia.server.serversession import ServerSession
+
+        self.s1 = ServerSession()
+        self.s1.sessionhandler = SESSION_HANDLER
         self.s1.sessid = 0
+        SESSION_HANDLER[self.s1.sessid] = self.s1
+
+        self.s2 = ServerSession()
+        self.s2.sessionhandler = SESSION_HANDLER
+        self.s2.sessid = 1
+        SESSION_HANDLER[self.s2.sessid] = self.s2
+
+        self.a1 = create.create_account(
+            f"TestAccount{randint(100000, 999999)}",
+            email="test@test.com",
+            password="testpassword",
+            typeclass=DefaultAccount,
+        )
+
+        self.a2 = create.create_account(
+            f"TestAccount{randint(100000, 999999)}",
+            email="test2@test.com",
+            password="testpassword",
+            typeclass=DefaultAccount,
+        )
+
+        self.o0 = create.create_object(key='TestRoom1', typeclass='evennia.objects.objects.DefaultRoom', nohome=True)
+        self.o1 = create.create_object(key="TestCharacter1", typeclass='evennia.objects.objects.DefaultCharacter',
+                                       home=self.o0, location=self.o0)
+        self.o2 = create.create_object(key="TestCharacter2", typeclass='evennia.objects.objects.DefaultCharacter',
+                                       home=self.o0, location=self.o0)
+
+    def tearDown(self):
+        self.o2.delete()
+        self.o1.delete()
+        self.o0.delete()
+        self.a2.delete()
+        self.a1.delete()
+        self.s2.sessionhandler.disconnect(self.s2, sync_portal=False)
+        self.s1.sessionhandler.disconnect(self.s1, sync_portal=False)
 
     def test_puppet_object_no_object(self):
         "Check puppet_object method called with no object param"
 
         try:
-            DefaultAccount().puppet_object(self.s1, None)
+            self.a1.puppet_object(self.s1, None)
             self.fail("Expected error: 'Object not found'")
         except RuntimeError as re:
             self.assertEqual("Object not found", str(re))
@@ -233,7 +271,7 @@ class TestDefaultAccount(TestCase):
         "Check puppet_object method called with no session param"
 
         try:
-            DefaultAccount().puppet_object(None, Mock())
+            self.a1.puppet_object(None, Mock())
             self.fail("Expected error: 'Session not found'")
         except RuntimeError as re:
             self.assertEqual("Session not found", str(re))
@@ -241,28 +279,18 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_already_puppeting(self):
         "Check puppet_object method called, already puppeting this"
 
-        from evennia.server.sessionhandler import SESSION_HANDLER
 
-        account = create.create_account(
-            f"TestAccount{randint(0, 999999)}",
-            email="test@test.com",
-            password="testpassword",
-            typeclass=DefaultAccount,
-        )
-        self.s1.uid = account.uid
-        SESSION_HANDLER[self.s1.uid] = self.s1
-        account.sessions.add(self.s1)
-
-        self.s1.logged_in = True
+        self.s1.link('account', self.a1)
         self.s1.data_out = Mock(return_value=None)
 
-        obj = Mock()
-        self.s1.puppet = obj
-        account.puppet_object(self.s1, obj)
+        self.o1.at_post_puppet = Mock()
+
+        self.s1.puppet = self.o1
+        self.a1.puppet_object(self.s1, self.o1)
         self.s1.data_out.assert_called_with(
             options=None, text="You are already puppeting this object."
         )
-        self.assertIsNone(obj.at_post_puppet.call_args)
+        self.assertIsNone(self.o1.at_post_puppet.call_args)
 
     def test_puppet_object_no_permission(self):
         "Check puppet_object method called, no permission"
@@ -324,8 +352,6 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_already_puppeted(self):
         "Check puppet_object method called, already puppeted"
 
-        from evennia.server.sessionhandler import SESSION_HANDLER
-
         account = create.create_account(
             f"TestAccount{randint(0, 999999)}",
             email="test@test.com",
@@ -333,13 +359,9 @@ class TestDefaultAccount(TestCase):
             typeclass=DefaultAccount,
         )
         self.account = account
-        self.s1.uid = account.uid
-        account.sessions.add(self.s1)
-        SESSION_HANDLER[self.s1.uid] = self.s1
 
-        self.s1.puppet = None
-        self.s1.logged_in = True
         self.s1.data_out = Mock(return_value=None)
+        self.s1.link('account', account)
 
         obj = Mock()
         obj.access = Mock(return_value=True)

--- a/evennia/contrib/tests.py
+++ b/evennia/contrib/tests.py
@@ -608,9 +608,13 @@ class TestWilderness(EvenniaTest):
             self.assertTrue(any([e for e in exits if e.key == each_exit]))
 
     def test_room_creation(self):
-        # Pretend that both char1 and char2 are connected...
-        self.char1.sessions.add(1)
-        self.char2.sessions.add(1)
+        # Pretend that both char1 and char2 are connected via the same Account.
+        s1 = MagicMock()
+        s2 = MagicMock()
+        self.account.sessions.add(s1)
+        self.account.sessions.add(s2)
+        self.char1.sessions.add(s1)
+        self.char2.sessions.add(s2)
         self.assertTrue(self.char1.has_account)
         self.assertTrue(self.char2.has_account)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -19,7 +19,7 @@ from evennia.scripts.scripthandler import ScriptHandler
 from evennia.commands import cmdset, command
 from evennia.commands.cmdsethandler import CmdSetHandler
 from evennia.commands import cmdhandler
-from evennia.server.serversession import EntitySessionHandler
+from evennia.server.linksessionhandler import ObjectSessionHandler
 from evennia.utils import create
 from evennia.utils import search
 from evennia.utils import logger
@@ -43,22 +43,6 @@ _AT_SEARCH_RESULT = variable_from_module(*settings.SEARCH_AT_RESULT.rsplit(".", 
 # the sessid_max is based on the length of the db_sessid csv field (excluding commas)
 _SESSID_MAX = 16 if _MULTISESSION_MODE in (1, 3) else 1
 
-
-class ObjectSessionHandler(EntitySessionHandler):
-    """
-    Handles the get/setting of the sessid
-    comma-separated integer field
-    """
-    def _save(self):
-        """
-        Saves sessids to persistent storage.
-
-        Args:
-            sessids (list of int): A list of session ids.
-
-        """
-        self.obj.db_sessid = ",".join(str(session.sessid) for session in self._sessions if session)
-        self.obj.save(update_fields=["db_sessid"])
 #
 # Base class to inherit from.
 
@@ -79,6 +63,10 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     # Used for sorting / filtering in inventories / room contents.
     _content_types = ("object",)
+
+    # Link sort is used for the Session Link. This value, by default, puts Objects at #3 after
+    # Sessions and Accounts.
+    _link_sort = 0
 
     # lockstring of newly created objects, for easy overloading.
     # Will be formatted with the appropriate attributes.

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -66,9 +66,7 @@ class ObjectSessionHandler(object):
         global _SESSIONS
         if not _SESSIONS:
             from evennia.server.sessionhandler import SESSIONS as _SESSIONS
-        self._sessid_cache = list(
-            set(int(val) for val in self._load().split(",") if val)
-        )
+        self._sessid_cache = self.load()
         if any(sessid for sessid in self._sessid_cache if sessid not in _SESSIONS):
             # cache is out of sync with sessionhandler! Only retain the ones in the handler.
             self._sessid_cache = [sessid for sessid in self._sessid_cache if sessid in _SESSIONS]
@@ -79,9 +77,10 @@ class ObjectSessionHandler(object):
         Retrieves data from object owner for sessids.
 
         Returns:
-            csessids (comma-separated session ids)
+            sessids (list of ints): A list of session ids.
         """
-        return self.obj.db_sessid if self.obj.db_sessid else ""
+        storage = self.obj.db_sessid if self.obj.db_sessid else ""
+        return list(set(int(val) for val in storage.split(",") if val))
 
     def _save(self, sessids):
         """

--- a/evennia/server/linksessionhandler.py
+++ b/evennia/server/linksessionhandler.py
@@ -1,0 +1,402 @@
+import time
+from django.utils import timezone
+from django.conf import settings
+
+from evennia.commands.cmdsethandler import CmdSetHandler
+from evennia import MONITOR_HANDLER
+
+from evennia.server.signals import SIGNAL_ACCOUNT_POST_LOGIN, SIGNAL_ACCOUNT_POST_LOGOUT
+from evennia.server.signals import SIGNAL_ACCOUNT_POST_FIRST_LOGIN, SIGNAL_ACCOUNT_POST_LAST_LOGOUT
+
+
+class EntitySessionHandler:
+    """
+    Handles adding/removing session references to an Account, Puppet, or perhaps
+    stranger things down the line. This is an Abstract Class - inherit from it and
+    implement the lower methods. Do not instantiate this directly, it'll error.
+    """
+
+    def __init__(self, obj):
+        """
+        Initializes the handler.
+        Args:
+            obj (Object): The object on which the handler is defined.
+        """
+        self.obj = obj
+        self._sessions = list()
+        self._sessids = dict()
+
+    def all(self, sessid=None):
+        """
+        Returns all sessions.
+
+        Args:
+            sessid (int, optional): Specify a given session by
+                session id.
+        Returns:
+            sessions (list): A list of Session objects. If `sessid`
+                is given, this is a list with one (or zero) elements.
+        """
+        if sessid is None:
+            return list(self._sessions)
+        found = self._sessids.get(sessid, None)
+        if found:
+            return [found]
+        return []
+
+    # Compatability hack.
+    get = all
+
+    def save(self):
+        """
+        Doesn't do anything on its own. Some things might want to store session ids in the database or something.
+        There is no load. There will not be a load.
+        """
+        pass
+
+    def add(self, session, force=False, sync=False, **kwargs):
+        """
+        Add session to handler. Do not call this directly - it is meant to be called from
+        ServerSession.link(). If this is called directly, ServerSession will not set import attributes.
+
+        Args:
+            session (Session or int): Session or session id to add.
+            force (bool): Don't stop for anything. Mainly used for Unexpected Disconnects
+            sync (bool):
+
+        Returns:
+            result (bool): True if success, false if fail.
+
+        Notes:
+            We will only add a session/sessid if this actually also exists
+            in the core sessionhandler.
+        """
+        try:
+            if session in self._sessions:
+                raise ValueError("Session is already linked to this entity!")
+            self.validate_link_request(session, force=force, sync=sync, **kwargs)
+        except ValueError as e:
+            session.msg(e)
+            return False
+        self.at_before_link_session(session, force=force, sync=sync, **kwargs)
+        self._sessions.append(session)
+        self._sessids[session.sessid] = session
+        self.at_link_session(session, force=force, sync=sync, **kwargs)
+        self.at_after_link_session(session, force=force, sync=sync, **kwargs)
+
+        # I really don't know why, but ObjectDB loves to save stuff.
+        self.save()
+        return True
+
+    def remove(self, session, force=False, reason=None, **kwargs):
+        """
+        Remove session from handler. As with add(), it must be called by ServerSession.unlink().
+
+        Args:
+            session (Session or int): Session or session id to remove.
+            force (bool): Don't stop for anything. Mainly used for Unexpected Disconnects
+            reason (str or None): A reason that might be displayed down the chain.
+        """
+        try:
+            if session not in self._sessions:
+                raise ValueError("Cannot remove session: it is not linked to this object.")
+            self.validate_unlink_request(session, force=force, reason=reason, **kwargs)
+        except ValueError as e:
+            self.obj.msg(e)
+            return
+        self.at_before_unlink_session(session, force=force, reason=reason, **kwargs)
+        self._sessions.remove(session)
+        del self._sessids[session.sessid]
+        self.at_unlink_session(session, force=force, reason=reason, **kwargs)
+        self.at_after_unlink_session(session, force=force, reason=reason, **kwargs)
+
+        # I really don't know why, but ObjectDB loves to save stuff.
+        self.save()
+        return True
+
+    def count(self):
+        """
+        Get amount of sessions connected.
+        Returns:
+            sesslen (int): Number of sessions handled.
+        """
+        return len(self._sessions)
+
+    def validate_link_request(self, session, force=False, sync=False, **kwargs):
+        """
+        This is called to check if a Session should be allowed to link this entity.
+
+        Args:
+            session (ServerSession): The Session in question.
+            force (bool): Bypass most checks for some reason? Usually admin overrides.
+            sync (bool): Whether this is operating in sync-after-reload mode.
+                In general, nothing should stop it if this is true.
+
+        Raises:
+            ValueError(str): An error condition which will prevent the linking.
+        """
+        raise NotImplementedError()
+
+    def at_before_link_session(self, session, force=False, sync=False, **kwargs):
+        """
+        This is called to ready an entity for linking. This might do cleanups, kick
+        off other Sessions, whatever it needs to do.
+
+        Args:
+            session (ServerSession): The Session in question.
+            force (bool): Bypass most checks for some reason? Usually admin overrides.
+            sync (bool): Whether this is operating in sync-after-reload mode.
+                In general, nothing should stop it if this is true.
+        """
+        raise NotImplementedError()
+
+    def at_link_session(self, session, force=False, sync=False, **kwargs):
+        """"
+        Sets up our Session connection.
+        Args:
+            session (ServerSession): The Session in question.
+            force (bool): Bypass most checks for some reason? Usually admin overrides.
+            sync (bool): Whether this is operating in sync-after-reload mode.
+                In general, nothing should stop it if this is true.
+        """
+        raise NotImplementedError()
+
+    def at_after_link_session(self, session, force=False, sync=False, **kwargs):
+        """
+        Called just after puppeting has been completed and all
+        Account<->Object links have been established.
+        Args:
+            session (ServerSession): The Session in question.
+            force (bool): Bypass most checks for some reason? Usually admin overrides.
+            sync (bool): Whether this is operating in sync-after-reload mode.
+                In general, nothing should stop it if this is true.
+        Note:
+            You can use `self.account` and `self.sessions.get()` to get
+            account and sessions at this point; the last entry in the
+            list from `self.sessions.get()` is the latest Session
+            puppeting this Object.
+        """
+        raise NotImplementedError()
+
+    def validate_unlink_request(self, session, force=False, reason=None, **kwargs):
+        """
+        Validates an unlink. This can halt an unlink for whatever reason.
+
+        Args:
+            session (ServerSession): The session that will be leaving us.
+            force (bool): Don't stop for anything. Mainly used for Unexpected Disconnects
+            reason (str or None): A reason that might be displayed down the chain.
+
+        Raises:
+            ValueError(str): If anything is amiss, raising ValueError will block the
+                unlink.
+        """
+        raise NotImplementedError()
+
+    def at_before_unlink_session(self, session, force=False, reason=None, **kwargs):
+        """
+        Called just before beginning to un-connect a puppeting from
+        this Account.
+        Args:
+            **kwargs (dict): Arbitrary, optional arguments for users
+                overriding the call (unused by default).
+        Note:
+            You can use `self.account` and `self.sessions.get()` to get
+            account and sessions at this point; the last entry in the
+            list from `self.sessions.get()` is the latest Session
+            puppeting this Object.
+        """
+        raise NotImplementedError()
+
+    def at_unlink_session(self, session, force=False, reason=None, **kwargs):
+        """
+        That's all folks. Disconnect session from this object.
+
+        Args:
+            session (ServerSession): The session that will be leaving us.
+            force (bool): Don't stop for anything. Mainly used for Unexpected Disconnects
+            reason (str or None): A reason that might be displayed down the chain.
+        """
+        raise NotImplementedError()
+
+    def at_after_unlink_session(self, session, force=False, reason=None, **kwargs):
+        """
+        Called just after the Account successfully disconnected from
+        this object, severing all connections.
+        Args:
+            account (Account): The account object that just disconnected
+                from this object.
+            session (Session): Session id controlling the connection that
+                just disconnected.
+            **kwargs (dict): Arbitrary, optional arguments for users
+                overriding the call (unused by default).
+        """
+        raise NotImplementedError()
+
+
+class AccountSessionHandler(EntitySessionHandler):
+
+    def validate_link_request(self, session, force=False, sync=False, **kwargs):
+        """
+        Nothing really to do here. Accounts are validated through their password. That's .authenticate().
+        """
+        pass
+
+    def at_before_link_session(self, session, force=False, sync=False, **kwargs):
+        """
+        Implements the Multisession checks. If any conflicting sessions are logged in,
+        here we shall force them off.
+        """
+        existing = self.all()
+        self.obj.at_init()
+        # Check if this is the first time the *account* logs in
+        if self.obj.db.FIRST_LOGIN:
+            self.obj.at_first_login()
+            del self.obj.db.FIRST_LOGIN
+
+        self.obj.at_pre_login()
+        if settings.MULTISESSION_MODE == 0:
+            # disconnect all previous sessions.
+            session.sessionhandler.disconnect_duplicate_sessions(session)
+
+
+    def at_link_session(self, session, force=False, sync=False, **kwargs):
+        """
+        Sets all properties on the Session relevant to this Account.
+        """
+        session.logged_in = True
+        session.account = self.obj
+        session.uname = self.obj.username
+        session.uid = self.obj.pk
+        session.conn_time = time.time()
+        session.cmdset_storage = settings.CMDSET_SESSION
+        session.cmdset = CmdSetHandler(self.obj, True)
+
+    def at_after_link_session(self, session, force=False, sync=False, **kwargs):
+        self.obj.last_login = timezone.now()
+        self.obj.save()
+        nsess = self.count()
+        session.log(f"Logged in: {self.obj} {session.address} ({nsess} session(s) total)")
+        self.obj.at_post_login(session=session)
+        if nsess < 2:
+            SIGNAL_ACCOUNT_POST_FIRST_LOGIN.send(sender=self.obj, session=session)
+        SIGNAL_ACCOUNT_POST_LOGIN.send(sender=self.obj, session=session)
+
+    def validate_unlink_request(self, session, force=False, reason=None, **kwargs):
+        pass
+
+    def at_before_unlink_session(self, session, force=False, reason=None, **kwargs):
+        pass
+
+    def at_unlink_session(self, session, force=False, reason=None, **kwargs):
+        session.logged_in = False
+        session.uid = None
+        session.uname = None
+        session.cmdset.add(settings.CMDSET_UNLOGGEDIN, permanent=True, default_cmdset=True)
+
+    def at_after_unlink_session(self, session, force=False, reason=None, **kwargs):
+        remaining = self.all()
+        if not remaining:
+            self.obj.attributes.add(key="last_active_datetime", category="system", value=timezone.now())
+            self.obj.is_connected = False
+        MONITOR_HANDLER.remove(self.obj, "_saved_webclient_options", session.sessid)
+
+        session.log(f"Logged out: {self.obj} {session.address} ({len(remaining)} sessions(s) remaining)"
+                    f"{reason if reason else ''}")
+
+        if not remaining:
+            SIGNAL_ACCOUNT_POST_LAST_LOGOUT.send(sender=session.account, session=session)
+        SIGNAL_ACCOUNT_POST_LOGOUT.send(sender=session.account, session=session)
+
+
+class ObjectSessionHandler(EntitySessionHandler):
+
+    def validate_link_request(self, session, force=False, sync=False, **kwargs):
+        # We only want to allow puppeting if it's by an authenticated Session
+        # that has authority to puppet us!
+        if not session.account:
+            # not logged in. How did this even happen?
+            raise ValueError("You are not logged in to an account!")
+        if session.get_puppet() == self:
+            # already puppeting this object
+            raise ValueError("You are already puppeting this object.")
+        if not self.obj.access(session.account, "puppet"):
+            # no access
+            raise ValueError(f"You don't have permission to puppet '{self.obj.key}'.")
+        if self.obj.account and self.obj.account != session.account:
+            raise ValueError(f"|c{self.obj.key}|R is already puppeted by another Account.")
+
+    def at_before_link_session_multisession(self, session, force=False, sync=False, **kwargs):
+        """
+        Multisession logic is performed here. This should not stop the link process.
+        """
+        # object already puppeted
+        # we check for whether it's the same account in a _validate_puppet_request.
+        # if we reach here, assume that it's either no account or the same account
+        others = self.all()
+        if others:
+            # we may take over another of our sessions
+            # output messages to the affected sessions
+            if settings.MULTISESSION_MODE in (1, 3):
+                txt1 = f"Sharing |c{self.obj.name}|n with another of your sessions."
+                txt2 = f"|c{self.obj.name}|n|G is now shared from another of your sessions.|n"
+                session.msg(txt1)
+                self.obj.msg(txt2, session=others)
+            else:
+                txt1 = f"Taking over |c{self.obj.name}|n from another of your sessions."
+                txt2 = f"|c{self.obj.name}|n|R is now acted from another of your sessions.|n"
+                session.msg(txt1)
+                self.obj.msg(txt2, session=others)
+                for other in others:
+                    other.unlink('puppet', self, force=True, reason="Taken over by another session")
+
+    def at_before_link_session(self, session, force=False, sync=False, **kwargs):
+        # First, check multisession status. Kick off anyone as necessary.
+        self.at_before_link_session_multisession(session, force, sync, **kwargs)
+
+        if session.puppet:
+            # cleanly unpuppet eventual previous object puppeted by this session
+            session.unlink('puppet', session.puppet)
+
+        # Call the object at_pre_puppet hook for compatability.
+        self.obj.at_pre_puppet(session.account, session, **kwargs)
+
+    def at_link_session(self, session, force=False, sync=False, **kwargs):
+        session.puid = self.obj.pk
+        session.puppet = self.obj
+        self.obj.account = session.account
+
+        # Don't need to validate scripts if there already were sessions attached.
+        if not self.count() > 1:
+            self.obj.scripts.validate()
+
+        if sync:
+            self.obj.locks.cache_lock_bypass(self)
+
+    def at_after_link_session(self, session, force=False, sync=False, **kwargs):
+        session.account.db._last_puppet = self.obj
+
+        # call the obj.at_post_puppet hook for compatability.
+        self.obj.at_post_puppet(**kwargs)
+
+    def validate_unlink_request(self, session, force=False, reason=None, **kwargs):
+        pass
+
+    def at_before_unlink_session(self, session, force=False, reason=None, **kwargs):
+        # Calling obj.at_pre_unpuppet() for compatability.
+        self.obj.at_pre_unpuppet()
+
+    def at_unlink_session(self, session, force=False, reason=None, **kwargs):
+        session.puid = None
+        session.puppet = None
+
+        if not self.count():
+            self.obj.account = None
+
+    def at_after_unlink_session(self, session, force=False, reason=None, **kwargs):
+        # calling obj.at_post_unpuppet() for compatability.
+        self.obj.at_post_unpuppet(session.account, session=session, **kwargs)
+
+    def save(self):
+        self.obj.db_sessid = ",".join(str(session.sessid) for session in self._sessions if session)
+        self.obj.save(update_fields=["db_sessid"])

--- a/evennia/server/linksessionhandler.py
+++ b/evennia/server/linksessionhandler.py
@@ -137,7 +137,7 @@ class EntitySessionHandler:
                 In general, nothing should stop it if this is true.
 
         Raises:
-            ValueError(str): An error condition which will prevent the linking.
+            SessionLinkError: An error condition which will prevent the linking.
         """
         raise NotImplementedError()
 

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -238,6 +238,7 @@ class ServerSession(Session):
         """
         if self.logged_in:
             account = self.account
+            account.sessions.remove(self)
             if self.puppet:
                 account.unpuppet_object(self)
             uaccount = account

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -179,11 +179,12 @@ class ServerSession(Session):
         self.account = None
         self.linked = dict()
         self.linked_sort = list()
+        self.linked_state = list()
         self.cmdset_storage_string = ""
         self.cmdset = CmdSetHandler(self, True)
-        self._find_map = self._generate_find_map()
 
-    def _generate_find_map(self):
+    @lazy_property
+    def find_map(self):
         """
         The find map is a dictionary of methods that are used to locate link-kinds.
         Such as 'account' and 'puppet'. These methods will be called by _find_entity.
@@ -236,7 +237,7 @@ class ServerSession(Session):
 
     def find_entity(self, kind, entity):
         if isinstance(entity, int):
-            find_method = self._find_map.get(kind)
+            find_method = self.find_map.get(kind)
             entity = find_method(entity)
             if not entity:
                 raise ValueError("Cannot link to a non-existent entity!")

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -22,9 +22,6 @@ _SA = object.__setattr__
 _ObjectDB = None
 _ANSI = None
 
-# i18n
-from django.utils.translation import gettext as _
-
 # Handlers for Session.db/ndb operation
 
 

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -92,6 +92,9 @@ class Session(object):
         # session is stored in.
         self.sessionhandler = sessionhandler
 
+        # Used to re-create Session Links.
+        self.linked_state = list()
+
     def get_sync_data(self):
         """
         Get all data relevant to sync the session.

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -104,7 +104,7 @@ class Session(object):
                 the keys given by self._attrs_to_sync.
 
         """
-        return {attr: getattr(self, attr, None) for attr in settings.SESSION_SYNC_ATTRS}
+        return {attr: getattr(self, attr) for attr in settings.SESSION_SYNC_ATTRS if hasattr(self, attr)}
 
     def load_sync_data(self, sessdata):
         """

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -1055,7 +1055,8 @@ SESSION_SYNC_ATTRS = (
         "cmd_total",
         "protocol_flags",
         "server_data",
-        "cmdset_storage_string"
+        "cmdset_storage_string",
+        "linked_state"
     )
 
 # The following are used for the communications between the Portal and Server.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just making a few adjustments to ObjectSessionHandler so it can load/save data from/to an overloadable location.

EDIT: Actually, let's change that. Making massive overhaul to Sessions and Account/Puppet linking infrastructure to reorganize and streamlined code for future expansion/moddability.

#### Motivation for adding to Evennia
Evennia's fine on its own without it, but with this little tweak, ObjectSessionHandler becomes easier to refactor in the future, and easier for me to sub-class and re-purpose in the present.

EDIT: Actually, let's change that. As usual, I feel that these kinds of refactors lead to cleaner, more extendable and maintainable code.

#### Other info (issues closed, discussion etc)
All tests passed with flying colors. This is pretty painless.