### PR TITLE
Replaceable networking guts!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - New `utils.format_grid` for easily displaying long lists of items in a block.
 - Using `lunr` search indexing for better `help` matching and suggestions. Also improve
   the main help command's default listing output.
+- Made most of the networking classes such as Protocols and the SessionHandlers replaceable via `settings.py` for modding enthusiasts.
 
 
 ### Already in master

--- a/evennia/server/amp_client.py
+++ b/evennia/server/amp_client.py
@@ -5,9 +5,11 @@ Portal. This module sets up the Client-side communication.
 """
 
 import os
+from django.conf import settings
 from evennia.server.portal import amp
 from twisted.internet import protocol
 from evennia.utils import logger
+from evennia.utils.utils import class_from_module
 
 
 class AMPClientFactory(protocol.ReconnectingClientFactory):
@@ -33,7 +35,7 @@ class AMPClientFactory(protocol.ReconnectingClientFactory):
 
         """
         self.server = server
-        self.protocol = AMPServerClientProtocol
+        self.protocol = class_from_module(settings.AMP_CLIENT_PROTOCOL_CLASS)
         self.maxDelay = 10
         # not really used unless connecting to multiple servers, but
         # avoids having to check for its existence on the protocol

--- a/evennia/server/portal/amp.py
+++ b/evennia/server/portal/amp.py
@@ -15,7 +15,7 @@ import zlib  # Used in Compressed class
 import pickle
 
 from twisted.internet.defer import DeferredList, Deferred
-from evennia.utils.utils import to_str, variable_from_module
+from evennia.utils.utils import variable_from_module
 
 # delayed import
 _LOGGER = None

--- a/evennia/server/portal/amp_server.py
+++ b/evennia/server/portal/amp_server.py
@@ -11,6 +11,7 @@ from evennia.server.portal import amp
 from django.conf import settings
 from subprocess import Popen, STDOUT
 from evennia.utils import logger
+from evennia.utils.utils import class_from_module
 
 
 def _is_windows():
@@ -56,7 +57,7 @@ class AMPServerFactory(protocol.ServerFactory):
 
         """
         self.portal = portal
-        self.protocol = AMPServerProtocol
+        self.protocol = class_from_module(settings.AMP_SERVER_PROTOCOL_CLASS)
         self.broadcasts = []
         self.server_connection = None
         self.launcher_connection = None
@@ -74,7 +75,7 @@ class AMPServerFactory(protocol.ServerFactory):
             protocol (Protocol): The created protocol.
 
         """
-        self.portal.amp_protocol = AMPServerProtocol()
+        self.portal.amp_protocol = self.protocol()
         self.portal.amp_protocol.factory = self
         return self.portal.amp_protocol
 

--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -25,7 +25,7 @@ import evennia
 
 evennia._init()
 
-from evennia.utils.utils import get_evennia_version, mod_import, make_iter
+from evennia.utils.utils import get_evennia_version, mod_import, make_iter, class_from_module
 from evennia.server.portal.portalsessionhandler import PORTAL_SESSIONS
 from evennia.utils import logger
 from evennia.server.webserver import EvenniaReverseProxyResource
@@ -261,6 +261,7 @@ if TELNET_ENABLED:
     # Start telnet game connections
 
     from evennia.server.portal import telnet
+    _telnet_protocol = class_from_module(settings.TELNET_PROTOCOL_CLASS)
 
     for interface in TELNET_INTERFACES:
         ifacestr = ""
@@ -270,7 +271,7 @@ if TELNET_ENABLED:
             pstring = "%s:%s" % (ifacestr, port)
             factory = telnet.TelnetServerFactory()
             factory.noisy = False
-            factory.protocol = telnet.TelnetProtocol
+            factory.protocol = _telnet_protocol
             factory.sessionhandler = PORTAL_SESSIONS
             telnet_service = internet.TCPServer(port, factory, interface=interface)
             telnet_service.setName("EvenniaTelnet%s" % pstring)
@@ -284,6 +285,7 @@ if SSL_ENABLED:
     # Start Telnet+SSL game connection (requires PyOpenSSL).
 
     from evennia.server.portal import telnet_ssl
+    _ssl_protocol = class_from_module(settings.SSL_PROTOCOL_CLASS)
 
     for interface in SSL_INTERFACES:
         ifacestr = ""
@@ -294,7 +296,7 @@ if SSL_ENABLED:
             factory = protocol.ServerFactory()
             factory.noisy = False
             factory.sessionhandler = PORTAL_SESSIONS
-            factory.protocol = telnet_ssl.SSLProtocol
+            factory.protocol = _ssl_protocol
 
             ssl_context = telnet_ssl.getSSLContext()
             if ssl_context:
@@ -317,6 +319,7 @@ if SSH_ENABLED:
     # evennia/game if necessary.
 
     from evennia.server.portal import ssh
+    _ssh_protocol = class_from_module(settings.SSH_PROTOCOL_CLASS)
 
     for interface in SSH_INTERFACES:
         ifacestr = ""
@@ -326,7 +329,7 @@ if SSH_ENABLED:
             pstring = "%s:%s" % (ifacestr, port)
             factory = ssh.makeFactory(
                 {
-                    "protocolFactory": ssh.SshProtocol,
+                    "protocolFactory": _ssh_protocol,
                     "protocolArgs": (),
                     "sessions": PORTAL_SESSIONS,
                 }
@@ -345,6 +348,7 @@ if WEBSERVER_ENABLED:
     # Start a reverse proxy to relay data to the Server-side webserver
 
     websocket_started = False
+    _websocket_protocol = class_from_module(settings.WEBSOCKET_PROTOCOL_CLASS)
     for interface in WEBSERVER_INTERFACES:
         ifacestr = ""
         if interface not in ("0.0.0.0", "::") or len(WEBSERVER_INTERFACES) > 1:
@@ -379,7 +383,7 @@ if WEBSERVER_ENABLED:
 
                     factory = Websocket()
                     factory.noisy = False
-                    factory.protocol = webclient.WebSocketClient
+                    factory.protocol = _websocket_protocol
                     factory.sessionhandler = PORTAL_SESSIONS
                     websocket_service = internet.TCPServer(port, factory, interface=w_interface)
                     websocket_service.setName("EvenniaWebSocket%s:%s" % (w_ifacestr, port))

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -9,6 +9,7 @@ from twisted.internet import reactor
 from django.conf import settings
 from evennia.server.sessionhandler import SessionHandler, PCONN, PDISCONN, PCONNSYNC, PDISCONNALL
 from evennia.utils.logger import log_trace
+from evennia.utils.utils import class_from_module
 
 # module import
 _MOD_IMPORT = None
@@ -32,9 +33,10 @@ DUMMYSESSION = namedtuple("DummySession", ["sessid"])(0)
 # -------------------------------------------------------------
 # Portal-SessionHandler class
 # -------------------------------------------------------------
+_BASE_HANDLER_CLASS = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
 
 
-class PortalSessionHandler(SessionHandler):
+class PortalSessionHandler(_BASE_HANDLER_CLASS):
     """
     This object holds the sessions connected to the portal at any time.
     It is synced with the server's equivalent SessionHandler over the AMP
@@ -463,4 +465,6 @@ class PortalSessionHandler(SessionHandler):
                         log_trace()
 
 
-PORTAL_SESSIONS = PortalSessionHandler()
+_portal_sessionhandler_class = class_from_module(settings.PORTAL_SESSION_HANDLER_CLASS)
+
+PORTAL_SESSIONS = _portal_sessionhandler_class()

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -33,10 +33,9 @@ DUMMYSESSION = namedtuple("DummySession", ["sessid"])(0)
 # -------------------------------------------------------------
 # Portal-SessionHandler class
 # -------------------------------------------------------------
-_BASE_HANDLER_CLASS = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
 
 
-class PortalSessionHandler(_BASE_HANDLER_CLASS):
+class PortalSessionHandler(SessionHandler):
     """
     This object holds the sessions connected to the portal at any time.
     It is synced with the server's equivalent SessionHandler over the AMP

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -7,7 +7,8 @@ import time
 from collections import deque, namedtuple
 from twisted.internet import reactor
 from django.conf import settings
-from evennia.server.sessionhandler import SessionHandler, PCONN, PDISCONN, PCONNSYNC, PDISCONNALL
+from evennia.server.sessionhandler import SessionHandler
+from evennia.server.portal.amp import PCONN, PDISCONN, PCONNSYNC, PDISCONNALL
 from evennia.utils.logger import log_trace
 from evennia.utils.utils import class_from_module
 

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -464,6 +464,6 @@ class PortalSessionHandler(SessionHandler):
                         log_trace()
 
 
-_portal_sessionhandler_class = class_from_module(settings.PORTAL_SESSION_HANDLER_CLASS)
+_PORTAL_SESSION_HANDLER_CLASS = class_from_module(settings.PORTAL_SESSION_HANDLER_CLASS)
 
-PORTAL_SESSIONS = _portal_sessionhandler_class()
+PORTAL_SESSIONS = _PORTAL_SESSION_HANDLER_CLASS()

--- a/evennia/server/portal/ssh.py
+++ b/evennia/server/portal/ssh.py
@@ -73,7 +73,7 @@ and put them here:
     _PRIVATE_KEY_FILE, _PUBLIC_KEY_FILE
 )
 
-_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
+_BASE_SESSION_CLASS = class_from_module(settings.BASE_SESSION_CLASS)
 
 
 # not used atm
@@ -85,7 +85,7 @@ class SSHServerFactory(protocol.ServerFactory):
         return "SSH"
 
 
-class SshProtocol(Manhole, _BASE_SESSION):
+class SshProtocol(Manhole, _BASE_SESSION_CLASS):
     """
     Each account connecting over ssh gets this protocol assigned to
     them.  All communication between game and account goes through

--- a/evennia/server/portal/ssh.py
+++ b/evennia/server/portal/ssh.py
@@ -43,10 +43,9 @@ from twisted.conch import interfaces as iconch
 from twisted.python import components
 from django.conf import settings
 
-from evennia.server import session
 from evennia.accounts.models import AccountDB
 from evennia.utils import ansi
-from evennia.utils.utils import to_str
+from evennia.utils.utils import to_str, class_from_module
 
 _RE_N = re.compile(r"\|n$")
 _RE_SCREENREADER_REGEX = re.compile(
@@ -74,6 +73,8 @@ and put them here:
     _PRIVATE_KEY_FILE, _PUBLIC_KEY_FILE
 )
 
+_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
+
 
 # not used atm
 class SSHServerFactory(protocol.ServerFactory):
@@ -84,7 +85,7 @@ class SSHServerFactory(protocol.ServerFactory):
         return "SSH"
 
 
-class SshProtocol(Manhole, session.Session):
+class SshProtocol(Manhole, _BASE_SESSION):
     """
     Each account connecting over ssh gets this protocol assigned to
     them.  All communication between game and account goes through

--- a/evennia/server/portal/ssl.py
+++ b/evennia/server/portal/ssl.py
@@ -43,10 +43,10 @@ example (linux, using the openssl program):
     {exestring}
 """
 
-_TELNET_PROTOCOL = class_from_module(settings.TELNET_PROTOCOL_CLASS)
+_TELNET_PROTOCOL_CLASS = class_from_module(settings.TELNET_PROTOCOL_CLASS)
 
 
-class SSLProtocol(_TELNET_PROTOCOL):
+class SSLProtocol(_TELNET_PROTOCOL_CLASS):
     """
     Communication is the same as telnet, except data transfer
     is done with encryption.

--- a/evennia/server/portal/ssl.py
+++ b/evennia/server/portal/ssl.py
@@ -18,7 +18,7 @@ except ImportError as error:
     raise ImportError(errstr.format(err=error))
 
 from django.conf import settings
-from evennia.server.portal.telnet import TelnetProtocol
+from evennia.utils.utils import class_from_module
 
 _GAME_DIR = settings.GAME_DIR
 
@@ -43,8 +43,10 @@ example (linux, using the openssl program):
     {exestring}
 """
 
+_TELNET_PROTOCOL = class_from_module(settings.TELNET_PROTOCOL_CLASS)
 
-class SSLProtocol(TelnetProtocol):
+
+class SSLProtocol(_TELNET_PROTOCOL):
     """
     Communication is the same as telnet, except data transfer
     is done with encryption.

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -25,12 +25,11 @@ from twisted.conch.telnet import (
     LINEMODE_TRAPSIG,
 )
 from django.conf import settings
-from evennia.server.session import Session
 from evennia.server.portal import ttype, mssp, telnet_oob, naws, suppress_ga
 from evennia.server.portal.mccp import Mccp, mccp_compress, MCCP
 from evennia.server.portal.mxp import Mxp, mxp_parse
 from evennia.utils import ansi
-from evennia.utils.utils import to_bytes
+from evennia.utils.utils import to_bytes, class_from_module
 
 _RE_N = re.compile(r"\|n$")
 _RE_LEND = re.compile(br"\n$|\r$|\r\n$|\r\x00$|", re.MULTILINE)
@@ -56,6 +55,10 @@ _HTTP_WARNING = bytes(
 )
 
 
+_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
+
+
+
 class TelnetServerFactory(protocol.ServerFactory):
     "This is only to name this better in logs"
     noisy = False
@@ -64,7 +67,7 @@ class TelnetServerFactory(protocol.ServerFactory):
         return "Telnet"
 
 
-class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
+class TelnetProtocol(Telnet, StatefulTelnetProtocol, _BASE_SESSION):
     """
     Each player connecting over telnet (ie using most traditional mud
     clients) gets a telnet protocol instance assigned to them.  All

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -55,7 +55,7 @@ _HTTP_WARNING = bytes(
 )
 
 
-_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
+_BASE_SESSION_CLASS = class_from_module(settings.BASE_SESSION_CLASS)
 
 
 
@@ -67,7 +67,7 @@ class TelnetServerFactory(protocol.ServerFactory):
         return "Telnet"
 
 
-class TelnetProtocol(Telnet, StatefulTelnetProtocol, _BASE_SESSION):
+class TelnetProtocol(Telnet, StatefulTelnetProtocol, _BASE_SESSION_CLASS):
     """
     Each player connecting over telnet (ie using most traditional mud
     clients) gets a telnet protocol instance assigned to them.  All

--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -37,10 +37,10 @@ CLOSE_NORMAL = WebSocketServerProtocol.CLOSE_STATUS_CODE_NORMAL
 #   called when the browser is navigating away from the page
 GOING_AWAY = WebSocketServerProtocol.CLOSE_STATUS_CODE_GOING_AWAY
 
-_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
+_BASE_SESSION_CLASS = class_from_module(settings.BASE_SESSION_CLASS)
 
 
-class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION):
+class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
     """
     Implements the server-side of the Websocket connection.
     """

--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -17,10 +17,8 @@ from the command line and interprets it as an Evennia Command: `["text", ["look"
 import re
 import json
 import html
-from twisted.internet.protocol import Protocol
 from django.conf import settings
-from evennia.server.session import Session
-from evennia.utils.utils import to_str, mod_import
+from evennia.utils.utils import mod_import, class_from_module
 from evennia.utils.ansi import parse_ansi
 from evennia.utils.text2html import parse_html
 from autobahn.twisted.websocket import WebSocketServerProtocol
@@ -39,8 +37,10 @@ CLOSE_NORMAL = WebSocketServerProtocol.CLOSE_STATUS_CODE_NORMAL
 #   called when the browser is navigating away from the page
 GOING_AWAY = WebSocketServerProtocol.CLOSE_STATUS_CODE_GOING_AWAY
 
+_BASE_SESSION = class_from_module(settings.BASE_SESSION_CLASS)
 
-class WebSocketClient(WebSocketServerProtocol, Session):
+
+class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION):
     """
     Implements the server-side of the Websocket connection.
     """

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -35,9 +35,6 @@ class Session(object):
 
     """
 
-    # names of attributes that should be affected by syncing.
-    _attrs_to_sync = settings.SESSION_SYNC_ATTRS
-
     def init_session(self, protocol_key, address, sessionhandler):
         """
         Initialize the Session. This should be called by the protocol when
@@ -104,9 +101,7 @@ class Session(object):
                 the keys given by self._attrs_to_sync.
 
         """
-        return dict(
-            (key, value) for key, value in self.__dict__.items() if key in self._attrs_to_sync
-        )
+        return {attr: getattr(self, attr, None) for attr in settings.SESSION_SYNC_ATTRS}
 
     def load_sync_data(self, sessdata):
         """

--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -36,24 +36,7 @@ class Session(object):
     """
 
     # names of attributes that should be affected by syncing.
-    _attrs_to_sync = (
-        "protocol_key",
-        "address",
-        "suid",
-        "sessid",
-        "uid",
-        "csessid",
-        "uname",
-        "logged_in",
-        "puid",
-        "conn_time",
-        "cmd_last",
-        "cmd_last_visible",
-        "cmd_total",
-        "protocol_flags",
-        "server_data",
-        "cmdset_storage_string",
-    )
+    _attrs_to_sync = settings.SESSION_SYNC_ATTRS
 
     def init_session(self, protocol_key, address, sessionhandler):
         """

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -23,6 +23,7 @@ from evennia.utils.utils import (
     make_iter,
     delay,
     callables_from_module,
+    class_from_module
 )
 from evennia.server.signals import SIGNAL_ACCOUNT_POST_LOGIN, SIGNAL_ACCOUNT_POST_LOGOUT
 from evennia.server.signals import SIGNAL_ACCOUNT_POST_FIRST_LOGIN, SIGNAL_ACCOUNT_POST_LAST_LOGOUT
@@ -857,5 +858,9 @@ class ServerSessionHandler(SessionHandler):
                     log_trace()
 
 
-SESSION_HANDLER = ServerSessionHandler()
+# import class from settings
+_session_handler_class = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
+
+# Instantiate class. These globals are used to provide singleton-like behavior.
+SESSION_HANDLER = _session_handler_class()
 SESSIONS = SESSION_HANDLER  # legacy

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -859,8 +859,8 @@ class ServerSessionHandler(SessionHandler):
 
 
 # import class from settings
-_session_handler_class = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
+_SESSION_HANDLER_CLASS = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
 
 # Instantiate class. These globals are used to provide singleton-like behavior.
-SESSION_HANDLER = _session_handler_class()
+SESSION_HANDLER = _SESSION_HANDLER_CLASS()
 SESSIONS = SESSION_HANDLER  # legacy

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -465,9 +465,6 @@ CHANNEL_COMMAND_CLASS = "evennia.comms.channelhandler.ChannelCommand"
 # Typeclasses and other paths
 ######################################################################
 
-# Server-side session class used.
-SERVER_SESSION_CLASS = "evennia.server.serversession.ServerSession"
-
 # These are paths that will be prefixed to the paths given if the
 # immediately entered path fail to find a typeclass. It allows for
 # shorter input strings. They must either base off the game directory
@@ -510,6 +507,70 @@ START_LOCATION = "#2"
 # out of sync between the processes. Keep on unless you face such
 # issues.
 TYPECLASS_AGGRESSIVE_CACHE = True
+
+######################################################################
+# Networking Replaceable Guts
+######################################################################
+# Modify the things below at your own risk. This is here be dragons territory.
+
+# The Base Session Class is used as a parent class for all Protocols such as
+# Telnet and SSH.) Changing this could be really dangerous. It will cascade
+# to tons of classes. You generally shouldn't need to touch protocols.
+BASE_SESSION_CLASS = "evennia.server.session.Session"
+
+# Telnet Protocol inherits from whatever above BASE_SESSION_CLASS is specified.
+# It is used for all telnet connections, and is also inherited by the SSL Protocol
+# (which is just TLS + Telnet).
+TELNET_PROTOCOL_CLASS = "evennia.server.portal.telnet.TelnetProtocol"
+SSL_PROTOCOL_CLASS = "evennia.server.portal.ssl.SSLProtocol"
+
+# Websocket Client Protocol. This inherits from BASE_SESSION_CLASS. It is used
+# for all webclient connections.
+WEBSOCKET_PROTOCOL_CLASS = "evennia.server.portal.webclient.WebSocketClient"
+
+# Protocol for the SSH interface. This inherits from BASE_SESSION_CLASS.
+SSH_PROTOCOL_CLASS = "evennia.server.portal.ssh.SshProtocol"
+
+# Server-side session class used. This will inherit from BASE_SESSION_CLASS.
+# This one isn't as dangerous to replace.
+SERVER_SESSION_CLASS = "evennia.server.serversession.ServerSession"
+
+# The Server SessionHandler manages all ServerSessions, handling logins,
+# ensuring the login process happens smoothly, handling expected and
+# unexpected disconnects. You shouldn't need to touch it, but you can.
+# Replace it to implement altered game logic.
+SERVER_SESSION_HANDLER_CLASS = "evennia.server.sessionhandler.ServerSessionHandler"
+
+# The Portal SessionHandler manages all incoming connections regardless of
+# the protocol in use. It is responsible for keeping them going and informing
+# the Server Session Handler of the connections and synchronizing them across the
+# AMP connection. You shouldn't ever need to change this. But you can.
+PORTAL_SESSION_HANDLER_CLASS = "evennia.server.portal.portalsessionhandler.PortalSessionHandler"
+
+
+# These are members / properties / attributes kept on both Server and
+# Portal Sessions. They are sync'd at various points, such as logins and
+# reloads. If you add to this, you may need to adjust the class __init__
+# so the additions have somewhere to go. These must be simple things that
+# can be pickled - stuff you could serialize to JSON is best.
+SESSION_SYNC_ATTRS = (
+        "protocol_key",
+        "address",
+        "suid",
+        "sessid",
+        "uid",
+        "csessid",
+        "uname",
+        "logged_in",
+        "puid",
+        "conn_time",
+        "cmd_last",
+        "cmd_last_visible",
+        "cmd_total",
+        "protocol_flags",
+        "server_data",
+        "cmdset_storage_string"
+    )
 
 ######################################################################
 # Options and validators

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -572,6 +572,11 @@ SESSION_SYNC_ATTRS = (
         "cmdset_storage_string"
     )
 
+# The following are used for the communications between the Portal and Server.
+# Very dragons territory.
+AMP_SERVER_PROTOCOL_CLASS = 'evennia.server.portal.amp_server.AMPServerProtocol'
+AMP_CLIENT_PROTOCOL_CLASS = 'evennia.server.amp_client.AMPServerClientProtocol'
+
 ######################################################################
 # Options and validators
 ######################################################################


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Made it so that the hierarchy of networking-based classes (SessionHandlers, Protocols, ServerSession) and bits and pieces related to it (such as session._attrs_to_sync) are components that can be swapped out / altered via settings.py configuration.

#### Motivation for adding to Evennia
You know me well enough by now! I want to replace / update things smoothly. It proved difficult to do things such as 'change how reload and logins works', so I'm adding in more hooks where things can be ripped out and replaced with alternate code.

#### Other info (issues closed, discussion etc)
All tests pass. Am able to login and boogie just fine. Some new stuff from other branches is failing - stuff that has to do with the REST framework. evennia.server, server.portal, .objects, .scripts, .typeclasses, etc, all of that's working nicely.