### PR TITLE
Fix sync

### DIFF
--- a/evennia/server/session.py
+++ b/evennia/server/session.py
@@ -101,7 +101,7 @@ class Session(object):
                 the keys given by self._attrs_to_sync.
 
         """
-        return {attr: getattr(self, attr, None) for attr in settings.SESSION_SYNC_ATTRS}
+        return {attr: getattr(self, attr) for attr in settings.SESSION_SYNC_ATTRS if hasattr(self, attr)}
 
     def load_sync_data(self, sessdata):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just a single line in base Sessions for get_sync_data changed.

I made it so that instead of returning a dictionary that will always have ALL those attributes - even if some are None - it will return only a dictionary of attributes that the object actually HAS. This will prevent the accidental overwriting of attributes with None.

#### Motivation for adding to Evennia
Well, I realized that between Sessions having both an __init__ and an init_session() method, it was difficult to ensure that an attr to sync was existing on both sides before getting grabbed...

#### Other info (issues closed, discussion etc)
Meh.