### PR TITLE
LocalEvenniaTest - uses settings-defined typeclasses

### DIFF
--- a/evennia/utils/test_resources.py
+++ b/evennia/utils/test_resources.py
@@ -159,6 +159,10 @@ class EvenniaTest(TestCase):
         super().tearDown()
 
 class LocalEvenniaTest(EvenniaTest):
+    """
+    This test class is intended for inheriting in mygame tests.
+    It helps ensure your tests are run with your own objects.
+    """
     account_typeclass = settings.BASE_ACCOUNT_TYPECLASS
     object_typeclass = settings.BASE_OBJECT_TYPECLASS
     character_typeclass = settings.BASE_CHARACTER_TYPECLASS

--- a/evennia/utils/test_resources.py
+++ b/evennia/utils/test_resources.py
@@ -157,3 +157,11 @@ class EvenniaTest(TestCase):
         self.account.delete()
         self.account2.delete()
         super().tearDown()
+
+class LocalEvenniaTest(EvenniaTest):
+    account_typeclass = settings.BASE_ACCOUNT_TYPECLASS
+    object_typeclass = settings.BASE_OBJECT_TYPECLASS
+    character_typeclass = settings.BASE_CHARACTER_TYPECLASS
+    exit_typeclass = settings.BASE_EXIT_TYPECLASS
+    room_typeclass = settings.BASE_ROOM_TYPECLASS
+    script_typeclass = settings.BASE_SCRIPT_TYPECLASS


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The EvenniaTest class hardcodes in DefaultObject, DefaultCharacter, etc as the spawned typeclasses. This inherited class uses the defaults as defined by settings.py

#### Motivation for adding to Evennia
Tests shouldn't break because my hooks don't run when objects are created. This could probably be extended further as a proper 'mygame tester'

#### Other
I know this is all perfectly doable without a core contrib, but anything that reminds people "hey, you can actually use unit tests by yourself even if you don't intend to contribute" is a good thing.