### PR TITLE
EvenniaLauncher 'kill' error handling

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1593,13 +1593,14 @@ def kill(pidfile, component="Server", callback=None, errback=None, killsignal=SI
                 if e.errno == errno.EACCES or e.errno == errno.EROFS:
                     print(
                         f"{component} ({pid}) cannot be stopped. "
-                        f"Evennia does not have 'write' access to the PID file '{pidfile}'."
+                        f"Evennia does not have 'write' access to the PID file '{pidfile}' "
+                        f"or process number {pid}."
                     )
                 elif e.errno == errno.ESRCH:
                     print(
                         f"{component} ({pid}) cannot be stopped. "
                         f"The PID file '{pidfile}' seems stale. "
-                        f"We will try removing it and launching anyway."
+                        f"We will try removing it."
                     )
                     os.remove(pidfile)
                 else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Improved catching and handling of OSError.
Noted that os.kill() is supported on Windows Python3 for future refactoring and Windows process handling might be immediately improved or reconsidered if the launcher breaks in the future.

#### Motivation for adding to Evennia
Just throwing stones from inside my glass house. It worked fine before, too.

#### Other info (issues closed, discussion etc)
