### PR TITLE
 Renamed Tutorial classes "Weapon" and "WeaponRack" to "TutorialWeapon" and "TutorialWeaponRack"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   defaults to True for backwards-compatibility in 0.9, will be False in 1.0
 
 ### Already in master
+- Renamed Tutorial classes "Weapon" and "WeaponRack" to "TutorialWeapon" and
+  "TutorialWeaponRack" to prevent collisions with classes in mygame
 - `is_typeclass(obj (Object), exact (bool))` now defaults to exact=False
 - `py` command now reroutes stdout to output results in-game client. `py`
 without arguments starts a full interactive Python console.

--- a/evennia/contrib/tests.py
+++ b/evennia/contrib/tests.py
@@ -1298,7 +1298,7 @@ class TestTutorialWorldObjects(TwistedTestCase, CommandTest):
         self.assertFalse(wall.db.exit_open)
 
     def test_weapon(self):
-        weapon = create_object(tutobjects.Weapon, key="sword", location=self.char1)
+        weapon = create_object(tutobjects.TutorialWeapon, key="sword", location=self.char1)
         self.call(
             tutobjects.CmdAttack(), "Char", "You stab with sword.", obj=weapon, cmdstring="stab"
         )
@@ -1307,7 +1307,7 @@ class TestTutorialWorldObjects(TwistedTestCase, CommandTest):
         )
 
     def test_weaponrack(self):
-        rack = create_object(tutobjects.WeaponRack, key="rack", location=self.room1)
+        rack = create_object(tutobjects.TutorialWeaponRack, key="rack", location=self.room1)
         rack.db.available_weapons = ["sword"]
         self.call(tutobjects.CmdGetWeapon(), "", "You find Rusty sword.", obj=rack)
 

--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -902,7 +902,7 @@ than the lonely cries of the cold, salty wind.
 
 # give the enemy a tentacle weapon
 #
-@create foggy tentacles;tentacles:tutorial_world.objects.Weapon
+@create foggy tentacles;tentacles:tutorial_world.objects.TutorialWeapon
 #
 # Make the enemy's weapon good - hits at 70% of attacks, but not good at parrying.
 #

--- a/evennia/contrib/tutorial_world/build.ev
+++ b/evennia/contrib/tutorial_world/build.ev
@@ -433,7 +433,7 @@ north
 #
 # Create the weapon rack (the barrel)
 #
-@create/drop barrel: tutorial_world.objects.WeaponRack
+@create/drop barrel: tutorial_world.objects.TutorialWeaponRack
 #
 @desc barrel =
  This barrel has the air of leftovers - it contains an assorted
@@ -1299,7 +1299,7 @@ Tomb of the hero
 # The sarcophagus is a "weapon rack" from which you can extract one
 # single weapon.
 #
-@create/drop Stone sarcophagus;sarcophagus;stone : tutorial_world.objects.WeaponRack
+@create/drop Stone sarcophagus;sarcophagus;stone : tutorial_world.objects.TutorialWeaponRack
 #
 @desc stone =
  The lid of the coffin is adorned with a stone statue in full size.

--- a/evennia/contrib/tutorial_world/mob.py
+++ b/evennia/contrib/tutorial_world/mob.py
@@ -69,7 +69,7 @@ class Mob(tut_objects.TutorialObject):
             stationary (idling) until attacked.
         aggressive: if set, will attack Characters in
             the same room using whatever Weapon it
-            carries (see tutorial_world.objects.Weapon).
+            carries (see tutorial_world.objects.TutorialWeapon).
             if unset, the mob will never engage in combat
             no matter what.
         hunting: if set, the mob will pursue enemies trying
@@ -168,9 +168,9 @@ class Mob(tut_objects.TutorialObject):
         be "ticked".
 
         Args:
-            interval (int): The number of seconds
+            interval (int or None): The number of seconds
                 between ticks
-            hook_key (str): The name of the method
+            hook_key (str or None): The name of the method
                 (on this mob) to call every interval
                 seconds.
             stop (bool, optional): Just stop the
@@ -372,7 +372,7 @@ class Mob(tut_objects.TutorialObject):
             return
 
         # we use the same attack commands as defined in
-        # tutorial_world.objects.Weapon, assuming that
+        # tutorial_world.objects.TutorialWeapon, assuming that
         # the mob is given a Weapon to attack with.
         attack_cmd = random.choice(("thrust", "pierce", "stab", "slash", "chop"))
         self.execute_cmd("%s %s" % (attack_cmd, target))

--- a/evennia/contrib/tutorial_world/objects.py
+++ b/evennia/contrib/tutorial_world/objects.py
@@ -14,8 +14,8 @@ TutorialClimbable
 Obelisk
 LightSource
 CrumblingWall
-Weapon
-WeaponRack
+TutorialWeapon
+TutorialWeaponRack
 
 """
 
@@ -790,7 +790,7 @@ class CrumblingWall(TutorialObject, DefaultExit):
 
 # -------------------------------------------------------------
 #
-# Weapon - object type
+# TutorialWeapon - object type
 #
 # A weapon is necessary in order to fight in the tutorial
 # world. A weapon (which here is assumed to be a bladed
@@ -929,7 +929,7 @@ class CmdSetWeapon(CmdSet):
         self.add(CmdAttack())
 
 
-class Weapon(TutorialObject):
+class TutorialWeapon(TutorialObject):
     """
     This defines a bladed weapon.
 
@@ -980,7 +980,7 @@ class Weapon(TutorialObject):
 
 WEAPON_PROTOTYPES = {
     "weapon": {
-        "typeclass": "evennia.contrib.tutorial_world.objects.Weapon",
+        "typeclass": "evennia.contrib.tutorial_world.objects.TutorialWeapon",
         "key": "Weapon",
         "hit": 0.2,
         "parry": 0.2,
@@ -1125,7 +1125,7 @@ class CmdSetWeaponRack(CmdSet):
         self.add(CmdGetWeapon())
 
 
-class WeaponRack(TutorialObject):
+class TutorialWeaponRack(TutorialObject):
     """
     This object represents a weapon store. When people use the
     "get weapon" command on this rack, it will produce one


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prefixed some tutorial classes to prevent collisions

#### Motivation for adding to Evennia
If mygame includes the colliding classes "Weapon" and "WeaponRack," evennia tests throw redundancy errors against the Tutorial-level classes.

#### Other
Resubmit of #2131