### PR TITLE
Bug: Puzzles do not survive server reload (because their scripts aren't persisted)

### DIFF
--- a/evennia/contrib/puzzles.py
+++ b/evennia/contrib/puzzles.py
@@ -289,7 +289,7 @@ class CmdCreatePuzzleRecipe(MuxCommand):
         proto_parts = [proto_def(obj) for obj in parts]
         proto_results = [proto_def(obj) for obj in results]
 
-        puzzle = create_script(PuzzleRecipe, key=puzzle_name)
+        puzzle = create_script(PuzzleRecipe, key=puzzle_name, persistent=True)
         puzzle.save_recipe(puzzle_name, proto_parts, proto_results)
         puzzle.locks.add("control:id(%s) or perm(Builder)" % caller.dbref[1:])
 
@@ -488,7 +488,7 @@ class CmdArmPuzzle(MuxCommand):
 
     Notes:
         Create puzzles with `@puzzle`; get list of
-        defined puzzles using `@lspuzlerecipies`.
+        defined puzzles using `@lspuzzlerecipes`.
 
     """
 


### PR DESCRIPTION
## BUG:

Puzzles do not survive server reload (because their scripts aren't persisted).

## STR:

As builder

1. Create puzzle
```
@create/drop flint
@create/drop steel
@create/drop fire
@puzzle fire, flint, steel = flint, steel, fire
```
2. List puzzle
```
@lspuzzlerecipes 
[Alternatively ...]
@scripts
...
```
3. Reload server
```
@reload
```
4. List puzzle

### Expected result:

Puzzle should be displayed

### Actual result:

Zero puzzles. Puzzle won't appear in the list of puzzles nor in the list of scripts.


#### Brief overview of PR changes/additions
When a puzzle gets created, it's not persisted. Hence, after a server reload, puzzle is lost. 

Puzzle should survive server reload.
