### PR TITLE
Upgraded EvMenu

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -1173,7 +1173,8 @@ class EvMenu(object):
         """
         return dedent(helptext.strip("\n"), baseline_index=0).rstrip()
 
-    def options_formatter(self, options):
+    @staticmethod
+    def options_formatter(options):
         """
         Formats the option block.
 
@@ -1491,7 +1492,8 @@ class EvMenu(object):
 
         return nodedata
 
-    def text_format_no_bars(self, callback, field, **nodedata):
+    @staticmethod
+    def text_format_no_bars(callback, field, **nodedata):
         """
         Text formatter for new methodology. Really a dummy function that
         exists when no special formatted is being done to a field.
@@ -1508,7 +1510,8 @@ class EvMenu(object):
 
         return nodedata
 
-    def node_format_default(selfself, callback, raw_string, **nodedata):
+    @staticmethod
+    def node_format_default(callback, raw_string, **nodedata):
         """
         Node formatter for new methodology. Does the final assembly of
         the node, placing the header at the top, the general text, the
@@ -1538,7 +1541,8 @@ class EvMenu(object):
             result = result + "\n" + nodedata['footer']['contents']
         return result[1:]
 
-    def node_format_invert(selfself, callback, raw_string, **nodedata):
+    @staticmethod
+    def node_format_invert(callback, raw_string, **nodedata):
         """
         Node formatter for new methodology. Does the final assembly of
         the node, placing the header at the top, the options table, the
@@ -1568,7 +1572,8 @@ class EvMenu(object):
             result = result + "\n" + nodedata['footer']['contents']
         return result[1:]
 
-    def node_format_suppress(selfself, callback, raw_string, **nodedata):
+    @staticmethod
+    def node_format_suppress(callback, raw_string, **nodedata):
         """
         Node formatter for new methodology. Sets the resulting nodetext
         to 'suppress' which prevents it from being drawn by

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -858,6 +858,7 @@ class EvMenu(object):
             )
 
         # validation of the node return values
+        helptext = False
         if type(nodetext) == dict:
             if 'help' in nodetext:
                 helptext = nodetext['help']

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -1,7 +1,3 @@
-import textwrap
-
-from evennia.utils.ansi import ANSIString
-
 """
 EvMenu
 
@@ -1230,7 +1226,7 @@ class EvMenu(object):
         """
 
         # Determine the text, header, and footer
-        if type(nodetext) == dict:
+        if isinstance(nodetext, dict):
 
             if 'text' in nodetext:
                 text = nodetext['text']

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -903,7 +903,7 @@ class EvMenu(object):
         self.nodename = nodename
 
         # handle the helptext
-        if type(helptext) == str:
+        if helptext and type(helptext) == str:
             self.helptext = self.helptext_formatter(helptext)
         elif options:
             self.helptext = _HELP_FULL if self.auto_quit else _HELP_NO_QUIT


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Modified EvMenu so that node returns can be dict,dict instead of string,dict or tuple,dict. This allows for information to be more clearly conveyed (text is assigned to the text key and help is assigned to the help key) while also allowing for the passing of more complicated formatting instructions (the ability to hide options or to move them free of the main option  table, the ability to add a footer, and the ability to use alternate formats for display)

#### Motivation for adding to Evennia
This upgrade should make it much easier for people to make minor adjustments to how various nodes are displayed without requiring them to re-write node_formatter or options_formatter and will allow the reformatting on a node-by-node basis. 

Final display is more modular. This allows the creation of alternate layouts without affecting legacy menus. Additionally it allows the implementation of a 'suppress' format which prevents the menu from being drawn at all (which is very useful as it allows the transition from one menu to a completely separate one rather than requiring the entirety of the menu to be in a single file.

#### Other info (issues closed, discussion etc)
String and tuples are still supported to allow for backwards compatibility though tuple should be deprecated. This is mentioned in the docstring and I will update the EvMenu tutorials and documentation once the PR goes live.