### PR TITLE
Correcting curly brackets colors

### DIFF
--- a/evennia/contrib/color_markups.py
+++ b/evennia/contrib/color_markups.py
@@ -125,14 +125,14 @@ CURLY_COLOR_ANSI_EXTRA_MAP = [
     (r"{c", _ANSI_HILITE + _ANSI_CYAN),
     (r"{w", _ANSI_HILITE + _ANSI_WHITE),  # pure white
     (r"{x", _ANSI_HILITE + _ANSI_BLACK),  # dark grey
-    (r"{R", _ANSI_HILITE + _ANSI_RED),
-    (r"{G", _ANSI_HILITE + _ANSI_GREEN),
-    (r"{Y", _ANSI_HILITE + _ANSI_YELLOW),
-    (r"{B", _ANSI_HILITE + _ANSI_BLUE),
-    (r"{M", _ANSI_HILITE + _ANSI_MAGENTA),
-    (r"{C", _ANSI_HILITE + _ANSI_CYAN),
-    (r"{W", _ANSI_HILITE + _ANSI_WHITE),  # light grey
-    (r"{X", _ANSI_HILITE + _ANSI_BLACK),  # pure black
+    (r"{R", _ANSI_UNHILITE + _ANSI_RED),
+    (r"{G", _ANSI_UNHILITE + _ANSI_GREEN),
+    (r"{Y", _ANSI_UNHILITE + _ANSI_YELLOW),
+    (r"{B", _ANSI_UNHILITE + _ANSI_BLUE),
+    (r"{M", _ANSI_UNHILITE + _ANSI_MAGENTA),
+    (r"{C", _ANSI_UNHILITE + _ANSI_CYAN),
+    (r"{W", _ANSI_UNHILITE + _ANSI_WHITE),  # light grey
+    (r"{X", _ANSI_UNHILITE + _ANSI_BLACK),  # pure black
     # hilight-able colors
     (r"{h", _ANSI_HILITE),
     (r"{H", _ANSI_UNHILITE),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This corrects the contrib/color_makrup.py colors to match the ones in ANSI.py, as it was both lower and uppercase resulted in the same color.

#### Motivation for adding to Evennia
This seems to be how it was intended to work, I think? 

#### Other info (issues closed, discussion etc)
