### PR TITLE
Fix a bug that script whose db_interval is 0 will be run when call its start method twice.

### DIFF
--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -437,7 +437,7 @@ class DefaultScript(ScriptBase):
         if self.is_active and not force_restart:
             # The script is already running, but make sure we have a _task if
             # this is after a cache flush
-            if not self.ndb._task and self.db_interval >= 0:
+            if not self.ndb._task and self.db_interval > 0:
                 self.ndb._task = ExtendedLoopingCall(self._step_task)
                 try:
                     start_delay, callcount = SCRIPT_FLUSH_TIMERS[self.id]


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix a bug that script whose `db_interval` is 0 will be run when call its `start` method twice.

#### Other info (issues closed, discussion etc)
A script whose db_interval is 0 should not call self._start_task and self._step_task. Because of line 482 in the script.py: 
```
        if self.db_interval > 0:
            self._start_task()
```
So the `ExtendedLoopingCall(self._step_task)` will not be called.

But if its start method is called twice, codes in line 440 will run self._step_task:
```
            if not self.ndb._task and self.db_interval >= 0:
                self.ndb._task = ExtendedLoopingCall(self._step_task)
``` 

In my case, when a new session connects to the server, the `portal_connect` of the sessionhandler will be called. It will call `_ScriptDB.objects.validate()`, then the `validate` method of the script's manage.py will be called and it will call `script.start`.
