### PR TITLE
expose onTabCreate() so other plugins can create blessed goldenlayout…

### DIFF
--- a/evennia/web/webclient/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/webclient/static/webclient/js/plugins/goldenlayout.js
@@ -535,6 +535,7 @@ let goldenlayout = (function () {
         onText: onText,
         getGL: function () { return myLayout; },
         addKnownType: addKnownType,
+        onTabCreate: onTabCreate,
     }
 }());
 window.plugin_handler.add("goldenlayout", goldenlayout);


### PR DESCRIPTION
… tabs

#### Brief overview of PR changes/additions

This just exposes the goldenlayout onTabCreate function so other, user-created plugins can use it to create tabs with the
proper 'tagging' drop-downs and retitle support.

#### Motivation for adding to Evennia

Without this, other plugins would have to violate DRY principles.

#### Other info (issues closed, discussion etc)
