### PR TITLE
Separate User IP from Proxy when webclient uses AJAX

### DIFF
--- a/evennia/server/portal/webclient_ajax.py
+++ b/evennia/server/portal/webclient_ajax.py
@@ -182,6 +182,16 @@ class AjaxWebClient(resource.Resource):
         csessid = self.get_client_sessid(request)
 
         remote_addr = request.getClientIP()
+
+        if remote_addr in settings.UPSTREAM_IPS and request.getHeader("x-forwarded-for"):
+            addresses = [x.strip() for x in request.getHeader("x-forwarded-for").split(",")]
+            addresses.reverse()
+
+            for addr in addresses:
+                if addr not in settings.UPSTREAM_IPS:
+                    remote_addr = addr
+                    break
+
         host_string = "%s (%s:%s)" % (
             _SERVERNAME,
             request.getRequestHostname(),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This change will make it possible to see user IP addresses even while behind a proxy, similar to the websockets implementation.
#### Motivation for adding to Evennia
Keeps expectations similar regardless of which technology is used by the webclient.
#### Other info (issues closed, discussion etc)
Unsure of relevant Issues. Happy Hacktoberfest - inspired me to try fixing some bugs or helping out!