### PR TITLE
Add a check for timezone-naive settings

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -1262,7 +1262,10 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                 ]
             except Exception:
                 logger.log_trace()
-        now = timezone.localtime()
+        if settings.USE_TZ:
+            now = timezone.localtime()
+        else:
+            now = timezone.now()
         now = "%02i-%02i-%02i(%02i:%02i)" % (now.year, now.month, now.day, now.hour, now.minute)
         if _MUDINFO_CHANNEL:
             _MUDINFO_CHANNEL.tempmsg(f"[{_MUDINFO_CHANNEL.key}, {now}]: {message}")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When a game uses naïve datetime settings, an error occurs as `.localtime()` is called. The error prevents users from logging out, as the server attempts to announce the event. This fix checks server settings first and substitutes `.now()` accordingly.
#### Motivation for adding to Evennia
Adding a check will prevent this error on timezone-naive games: 
```
  File "d:\arxdev\evennia\evennia\server\sessionhandler.py", line 527, in login
    account.at_post_login(session=session)
  File "d:\arxdev\evennia\evennia\accounts\accounts.py", line 1297, in at_post_login
    self._send_to_connect_channel(_("|G{key} connected|n").format(key=self.key))
  File "d:\arxdev\evennia\evennia\accounts\accounts.py", line 1265, in _send_to_connect_channel
    now = timezone.localtime()
  File "d:\arxdev\venv\Lib\site-packages\django\utils\timezone.py", line 207, in localtime
    raise ValueError("localtime() cannot be applied to a naive datetime")
ValueError: localtime() cannot be applied to a naive datetime
```
#### Other info (issues closed, discussion etc)
Don't know of any Issues mentioning this. Happy Hacktoberfest!