### PR TITLE
Adds appropriate object checking to objtag lockfunc

### DIFF
--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -539,6 +539,8 @@ def objtag(accessing_obj, accessed_obj, *args, **kwargs):
     Only true if accessed_obj has the specified tag and optional
     category.
     """
+    if hasattr(accessed_obj, "obj"):
+        accessed_obj = accessed_obj.obj
     tagkey = args[0] if args else None
     category = args[1] if len(args) > 1 else None
     return bool(accessed_obj.tags.get(tagkey, category=category))

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -557,6 +557,8 @@ def inside(accessing_obj, accessed_obj, *args, **kwargs):
     want also nested objects to pass the lock, use the `insiderecursive`
     lockfunc.
     """
+    if hasattr(accessed_obj, "obj"):
+        accessed_obj = accessed_obj.obj
     return accessing_obj.location == accessed_obj
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Modifies the `objtag` and `inside` lockfuncs to perform checks on the appropriate objects.

#### Motivation for adding to Evennia
Commands locked `cmd:objtag(blah)` were checking for tags on the Command instance instead of the bound Object.
Commands locked `cmd:inside()` were checking if the Command instance was inside the bound Object instead of the caller.

#### Other info (issues closed, discussion etc)
Partial fix for #2227.