### PR TITLE
EvMore - Use page_formatter provided in args

### DIFF
--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -256,7 +256,7 @@ class EvMore:
 
         self._npages = 1
         self._paginator = self.paginator_index
-        self._page_formatter = str
+        self._page_formatter = page_formatter
 
         # set up individual pages for different sessions
         height = max(4, session.protocol_flags.get("SCREENHEIGHT", {0: _SCREEN_HEIGHT})[0] - 4)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The EvMore constructor was ignoring the `page_formatter` arg and hard-coding `str` for that function.

This change makes EvMore will use the formatter provided in args or default to `str` if one is not.

#### Motivation for adding to Evennia
Pagination was broken again.

#### Other info (issues closed, discussion etc)
