### PR TITLE
Adds client_height() method to Command.

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -509,6 +509,20 @@ Command {self} has no defined `func()` - showing on-command variables:
                 "SCREENWIDTH", {0: settings.CLIENT_DEFAULT_WIDTH}
             )[0]
         return settings.CLIENT_DEFAULT_WIDTH
+        
+    def client_height(self):
+        """
+        Get the client screenheight for the session using this command.
+
+        Returns:
+            client height (int): The height (in characters) of the client window.
+
+        """
+        if self.session:
+            return self.session.protocol_flags.get(
+                "SCREENHEIGHT", {0: settings.CLIENT_DEFAULT_HEIGHT}
+            )[0]
+        return settings.CLIENT_DEFAULT_HEIGHT
 
     def styled_table(self, *args, **kwargs):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds `client_height()` method to Command.

#### Motivation for adding to Evennia
Balance; there is a `client_width()` but no simple way to get the height.

#### Other info (issues closed, discussion etc)
