### PR TITLE
[refactor] CmdHelp.format_help_entry for up-to-date formatting and string concatenation

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -168,18 +168,28 @@ class CmdHelp(Command):
         Returns the formatted string, ready to be sent.
 
         """
-        string = _SEP + "\n"
-        if title:
-            string += "|CHelp for |w%s|n" % title
-        if aliases:
-            string += " |C(aliases: %s|C)|n" % ("|C,|n ".join("|w%s|n" % ali for ali in aliases))
-        if help_text:
-            string += "\n%s" % dedent(help_text.rstrip())
-        if suggested:
-            string += "\n\n|CSuggested:|n "
-            string += "%s" % fill("|C,|n ".join("|w%s|n" % sug for sug in suggested))
-        string.strip()
-        string += "\n" + _SEP
+        start_chunk = f"{_SEP}\n"
+        title_chunk = f"|CHelp for |w{title}|n" if title else ""
+        aliases_chunk = " |C(aliases: {}|C)|n" \
+            .format("|C,|n ".join(f"|w{ali}|n" for ali in aliases)) \
+            if aliases else ""
+        help_text_chunk = f"\n{dedent(help_text.rstrip())}" \
+            if help_text else ""
+        suggested_chunk = \
+            "\n\n|CSuggested:|n {}" \
+            .format(fill("|C,|n ".join(f"|w{sug}|n" for sug in suggested))) \
+            if suggested else ""
+        end_chunk = f"\n{_SEP}"
+
+        help_entry_chunks = [
+            start_chunk,
+            title_chunk,
+            aliases_chunk,
+            help_text_chunk,
+            suggested_chunk,
+            end_chunk,
+        ]
+        string = "".join(help_entry_chunks)
         return string
 
     def format_help_list(self, hdict_cmds, hdict_db):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
```python
"%s" % string
# to
"{}".format(string)  # since python 2.6
f"{string}"  # since python 3.6
```
and remove the the form a += b because it rely on CPython's efficient implementation of in-place string concatenation for statements in the form a += b or a = a + b. This optimization is fragile even in CPython. Used "".join() instead.

#### Motivation for adding to Evennia
Up-to-date formatting and less string update.

#### Other info (issues closed, discussion etc)
