### PR TITLE
Add null checking when getting puppet from session

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -373,7 +373,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             puppet (Object): The matching puppeted object, if any.
 
         """
-        return session.puppet
+        return session.puppet if session else None
 
     def get_all_puppets(self):
         """

--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -999,7 +999,7 @@ class CmdQuell(COMMAND_DEFAULT_CLASS):
                 self.msg("Already quelling Account %s permissions." % permstr)
                 return
             account.attributes.add("_quell", True)
-            puppet = self.session.puppet
+            puppet = self.session.puppet if self.session else None
             if puppet:
                 cpermstr = "(%s)" % ", ".join(puppet.permissions.all())
                 cpermstr = "Quelling to current puppet's permissions %s." % cpermstr


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When account.execute_cmd() is called without an explicit session
argument for a server using MULTISESSION_MODE 2 or 3, it does not
know which session to use and may leave it None. Downstream, code
attempting to get the puppet from the session can fail with an
error because of the None session.

This change adds in checking for the None session, and sets the puppet
to None if there is no session defined.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)

Addresses bug #2252 