### PR TITLE
text2html lines starting with a space need nbsp

### DIFF
--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -97,8 +97,8 @@ class TextToHTMLparser(object):
     re_blink = re.compile("(?:%s)(.*?)(?=%s|%s)" % (blink.replace("[", r"\["), fgstop, bgstop))
     re_inverse = re.compile("(?:%s)(.*?)(?=%s|%s)" % (inverse.replace("[", r"\["), fgstop, bgstop))
     re_string = re.compile(
-        r"(?P<htmlchars>[<&>])|(?P<tab>[\t]+)|(?P<space> +)|"
-        r"(?P<spacestart>^ )|(?P<lineend>\r\n|\r|\n)",
+        r"(?P<htmlchars>[<&>])|(?P<tab>[\t]+)|(?P<spacestart>^ +)|(?P<newlinespace>\|/ +)|"
+        r"(?P<space> +)|(?P<lineend>\r\n|\r|\n)",
         re.S | re.M | re.I,
     )
     re_dblspace = re.compile(r" {2,}", re.M)
@@ -308,9 +308,17 @@ class TextToHTMLparser(object):
         elif cdict["lineend"]:
             return "<br>"
         elif cdict["tab"]:
-            text = cdict["tab"].replace("\t", " " + "&nbsp;" * (self.tabstop - 1))
+            text = cdict["tab"].replace("\t", "&nbsp;" + "&nbsp;" * (self.tabstop - 1))
             return text
-        elif cdict["space"] or cdict["spacestart"]:
+        elif cdict["spacestart"]:
+            text = cdict["spacestart"]
+            text = "&nbsp;" if len(text) == 1 else "&nbsp;" + text[1:].replace(" ", "&nbsp;")
+            return text
+        elif cdict["newlinespace"]:
+            text = cdict["newlinespace"]
+            text = "&nbsp;" if len(text) == 1 else "&nbsp;" + text[1:].replace(" ", "&nbsp;")
+            return text
+        elif cdict["space"]:
             text = cdict["space"]
             text = " " if len(text) == 1 else " " + text[1:].replace(" ", "&nbsp;")
             return text


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This update corrects the generated HTML where an input string or new line of text (via |/) begins with a space.
Browsers will ignore leading whitespace for new HTML "blocks", so this requires leading non-breaking spaces to fix.

#### Motivation for adding to Evennia

Evennia 0.9.5 introduced this issue as part of the TAB and other text2html updates.

#### Other info (issues closed, discussion etc)
Fixes #2254 

Also, fixes what I believe is a spacing bug with leading TAB characters (normal space + 3 non-breaking spaces yields incorrect indents of only 3 character widths).
