### PR TITLE
Adjusting the width of the output in CmdTime

### DIFF
--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -956,7 +956,7 @@ class CmdTime(COMMAND_DEFAULT_CLASS):
             "|wIn-Game time",
             "|wReal time x %g" % gametime.TIMEFACTOR,
             align="l",
-            width=77,
+            width=78,
             border_top=0,
         )
         epochtxt = "Epoch (%s)" % ("from settings" if settings.TIME_GAME_EPOCH else "server start")


### PR DESCRIPTION
CmdTime has two table outputs that are not aligned in the same width. This change aligns the tables to the same width of 78.

#### Brief overview of PR changes/additions

Just a simple fix for a simple mistake with the table outputs in CmdTime where one table was not the same width as the other.

#### Motivation for adding to Evennia

Because it was simple, yet annoying.

#### Other info (issues closed, discussion etc)
