### PR TITLE
Fix settings.START_LOCATION behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ twistd.bat
 
 # never commit docs/build
 docs/build
-pip-wheel-metadata/evennia.dist-info/LICENSE.txt
-pip-wheel-metadata/evennia.dist-info/METADATA
-pip-wheel-metadata/evennia.dist-info/top_level.txt

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ twistd.bat
 
 # never commit docs/build
 docs/build
+pip-wheel-metadata/evennia.dist-info/LICENSE.txt
+pip-wheel-metadata/evennia.dist-info/METADATA
+pip-wheel-metadata/evennia.dist-info/top_level.txt

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -687,6 +687,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             ip=character_ip,
             typeclass=character_typeclass,
             permissions=character_permissions,
+            location=ObjectDB.objects.get_id(settings.START_LOCATION),
             **kwargs,
         )
         if character:

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -184,7 +184,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
      - at_server_reload()
      - at_server_shutdown()
 
-     """
+    """
 
     objects = AccountManager()
 
@@ -680,6 +680,9 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
         )
         Character = class_from_module(character_typeclass)
 
+        if "location" not in kwargs:
+            kwargs["location"] = ObjectDB.objects.get_id(settings.START_LOCATION)
+
         # Create the character
         character, errs = Character.create(
             character_key,
@@ -687,7 +690,6 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             ip=character_ip,
             typeclass=character_typeclass,
             permissions=character_permissions,
-            location=ObjectDB.objects.get_id(settings.START_LOCATION),
             **kwargs,
         )
         if character:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes START_LOCATION behavior for default account creation (ie from the connection screen). Current behavior is to start new characters in the Void, even when START_LOCATION is overridden in settings.

#### Motivation for adding to Evennia

Bug fix.
