### PR TITLE
Make more commands honor settings.COMMAND_DEFAULT_CLASS

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -25,7 +25,7 @@ _DEFAULT_WIDTH = settings.CLIENT_DEFAULT_WIDTH
 _SEP = "|C" + "-" * _DEFAULT_WIDTH + "|n"
 
 
-class CmdHelp(Command):
+class CmdHelp(COMMAND_DEFAULT_CLASS):
     """
     View help or a list of topics
 

--- a/evennia/comms/channelhandler.py
+++ b/evennia/comms/channelhandler.py
@@ -24,7 +24,7 @@ does this for you.
 
 """
 from django.conf import settings
-from evennia.commands import cmdset, command
+from evennia.commands import cmdset
 from evennia.utils.logger import tail_log_file
 from evennia.utils.utils import class_from_module
 from django.utils.translation import gettext as _
@@ -35,9 +35,9 @@ from django.utils.translation import gettext as _
 _CHANNEL_HANDLER_CLASS = None
 _CHANNEL_COMMAND_CLASS = None
 _CHANNELDB = None
+_COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 
-
-class ChannelCommand(command.Command):
+class ChannelCommand(_COMMAND_DEFAULT_CLASS):
     """
     {channelkey} channel
 

--- a/evennia/game_template/commands/command.py
+++ b/evennia/game_template/commands/command.py
@@ -5,7 +5,7 @@ Commands describe the input the account can do to the game.
 
 """
 
-from evennia import Command as BaseCommand
+from evennia.commands.command import Command as BaseCommand
 
 # from evennia import default_cmds
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -24,6 +24,7 @@ from evennia.utils import search
 from evennia.utils import logger
 from evennia.utils import ansi
 from evennia.utils.utils import (
+    class_from_module,
     variable_from_module,
     lazy_property,
     make_iter,
@@ -40,6 +41,7 @@ _ScriptDB = None
 _SESSIONS = None
 
 _AT_SEARCH_RESULT = variable_from_module(*settings.SEARCH_AT_RESULT.rsplit(".", 1))
+_COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 # the sessid_max is based on the length of the db_sessid csv field (excluding commas)
 _SESSID_MAX = 16 if _MULTISESSION_MODE in (1, 3) else 1
 
@@ -2344,8 +2346,7 @@ class DefaultRoom(DefaultObject):
 # Default Exit command, used by the base exit object
 #
 
-
-class ExitCommand(command.Command):
+class ExitCommand(_COMMAND_DEFAULT_CLASS):
     """
     This is a command that simply cause the caller to traverse
     the object it is attached to.

--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -48,7 +48,7 @@ import re
 
 from django.conf import settings
 from evennia import Command, CmdSet
-from evennia.utils import is_iter, fill, dedent, logger, justify, to_str
+from evennia.utils import is_iter, fill, dedent, logger, justify, to_str, utils
 from evennia.utils.ansi import raw
 from evennia.commands import cmdhandler
 
@@ -58,6 +58,7 @@ _CMD_NOMATCH = cmdhandler.CMD_NOMATCH
 _CMD_NOINPUT = cmdhandler.CMD_NOINPUT
 
 _RE_GROUP = re.compile(r"\".*?\"|\'.*?\'|\S*")
+_COMMAND_DEFAULT_CLASS = utils.class_from_module(settings.COMMAND_DEFAULT_CLASS)
 # use NAWS in the future?
 _DEFAULT_WIDTH = settings.CLIENT_DEFAULT_WIDTH
 
@@ -171,7 +172,7 @@ _MSG_REDO = "Redid one step."
 # -------------------------------------------------------------
 
 
-class CmdSaveYesNo(Command):
+class CmdSaveYesNo(_COMMAND_DEFAULT_CLASS):
     """
     Save the editor state on quit. This catches
     nomatches (defaults to Yes), and avoid saves only if
@@ -217,7 +218,7 @@ class SaveYesNoCmdSet(CmdSet):
 # -------------------------------------------------------------
 
 
-class CmdEditorBase(Command):
+class CmdEditorBase(_COMMAND_DEFAULT_CLASS):
     """
     Base parent for editor commands
     """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

As suggested in mygame\commands\command.py, I'm overriding COMMAND_DEFAULT_CLASS in settings.py to try to make sweeping changes. Having certain commands inherit directly from the base Command class thwarts this.

The only difference between Command and MuxCommand is that MuxCommand defines some custom parsing, but that's overridden by these commands anyway, so there should be no practical difference.

The import change in game_template/commands/command.py was required to fix an exception on server reload caused by the channelhandler.py change (I guess something to do with import order?)

#### Motivation for adding to Evennia

Makes it easier to edit gamewide look/feel, and brings codebase more in line with documentation that suggests all default commands inherit from COMMAND_DEFAULT_CLASS .

#### Other info (issues closed, discussion etc)
