### PR TITLE
Fix test_gametime.py for non-UTC servers

### DIFF
--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -8,7 +8,7 @@ total runtime of the server and the current uptime.
 
 import time
 from calendar import monthrange
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
 from evennia import DefaultScript
@@ -180,14 +180,14 @@ def real_seconds_until(sec=None, min=None, hour=None, day=None, month=None, year
 
 
     """
-    current = datetime.fromtimestamp(gametime(absolute=True))
+    current = datetime.fromtimestamp(gametime(absolute=True), timezone.utc)
     s_sec = sec if sec is not None else current.second
     s_min = min if min is not None else current.minute
     s_hour = hour if hour is not None else current.hour
     s_day = day if day is not None else current.day
     s_month = month if month is not None else current.month
     s_year = year if year is not None else current.year
-    projected = datetime(s_year, s_month, s_day, s_hour, s_min, s_sec)
+    projected = datetime(s_year, s_month, s_day, s_hour, s_min, s_sec, tzinfo=timezone.utc)
 
     if projected <= current:
         # We increase one unit of time depending on parameters

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -8,7 +8,7 @@ total runtime of the server and the current uptime.
 
 import time
 from calendar import monthrange
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from evennia import DefaultScript
@@ -180,14 +180,14 @@ def real_seconds_until(sec=None, min=None, hour=None, day=None, month=None, year
 
 
     """
-    current = datetime.fromtimestamp(gametime(absolute=True), timezone.utc)
+    current = datetime.fromtimestamp(gametime(absolute=True))
     s_sec = sec if sec is not None else current.second
     s_min = min if min is not None else current.minute
     s_hour = hour if hour is not None else current.hour
     s_day = day if day is not None else current.day
     s_month = month if month is not None else current.month
     s_year = year if year is not None else current.year
-    projected = datetime(s_year, s_month, s_day, s_hour, s_min, s_sec, tzinfo=timezone.utc)
+    projected = datetime(s_year, s_month, s_day, s_hour, s_min, s_sec)
 
     if projected <= current:
         # We increase one unit of time depending on parameters

--- a/evennia/utils/tests/test_gametime.py
+++ b/evennia/utils/tests/test_gametime.py
@@ -2,6 +2,7 @@
 Unit tests for the utilities of the evennia.utils.gametime module.
 """
 
+from datetime import datetime
 import time
 import unittest
 from unittest.mock import Mock
@@ -16,7 +17,7 @@ class TestGametime(TestCase):
     def setUp(self) -> None:
         self.time = time.time
         self._SERVER_EPOCH = gametime._SERVER_EPOCH
-        time.time = Mock(return_value=1555595378.0)
+        time.time = Mock(return_value=datetime(2019, 4, 18, 13, 49, 38).timestamp())
         gametime._SERVER_EPOCH = None
         gametime.SERVER_RUNTIME = 600.0
         gametime.SERVER_START_TIME = time.time() - 300
@@ -54,7 +55,9 @@ class TestGametime(TestCase):
         self.assertAlmostEqual(gametime.gametime(), 630.0 * 5)
 
     def test_gametime_absolute(self):
-        self.assertAlmostEqual(gametime.gametime(absolute=True), 1555597898.0)
+        self.assertAlmostEqual(
+            gametime.gametime(absolute=True), datetime(2019, 4, 18, 14, 31, 38).timestamp()
+        )
 
     def test_gametime_downtimes(self):
         gametime.IGNORE_DOWNTIMES = True


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This fixes evennia.utils.tests.test_gametime; datetime.fromtimestamp assumes the current system's timezone, so some of the unit tests currently fail if the system's timezone is set to EST (on Windows).

#### Motivation for adding to Evennia

Bug fix.

#### Other info (issues closed, discussion etc)
