### PR TITLE
Make use of environmental variables for superuser creation

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1423,7 +1423,21 @@ def create_superuser():
         "\nCreate a superuser below. The superuser is Account #1, the 'owner' "
         "account of the server. Email is optional and can be empty.\n"
     )
-    django.core.management.call_command("createsuperuser", interactive=True)
+
+    from os import environ
+    if ("DJANGO_SUPERUSER_USERNAME" in environ) and ("DJANGO_SUPERUSER_EMAIL" in environ):
+        username, email = environ["DJANGO_SUPERUSER_USERNAME"], environ["DJANGO_SUPERUSER_EMAIL"]
+        django.core.management.call_command("createsuperuser", "--noinput",
+                                            "--username=" + username,
+                                            "--email=" + email, interactive=False)
+        if "DJANGO_SUPERUSER_PASSWORD" in environ:
+            password = environ["DJANGO_SUPERUSER_PASSWORD"]
+            from evennia.accounts.models import AccountDB
+            u = AccountDB.objects.get(username=username)
+            u.set_password(password)
+            u.save()
+    else:
+        django.core.management.call_command("createsuperuser", interactive=True)
 
 
 def check_database(always_return=False):

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1425,13 +1425,13 @@ def create_superuser():
     )
 
     from os import environ
-    if ("DJANGO_SUPERUSER_USERNAME" in environ) and ("DJANGO_SUPERUSER_EMAIL" in environ):
-        username, email = environ["DJANGO_SUPERUSER_USERNAME"], environ["DJANGO_SUPERUSER_EMAIL"]
+    if ("EVENNIA_SUPERUSER_USERNAME" in environ) and ("EVENNIA_SUPERUSER_EMAIL" in environ):
+        username, email = environ["EVENNIA_SUPERUSER_USERNAME"], environ["EVENNIA_SUPERUSER_EMAIL"]
         django.core.management.call_command("createsuperuser", "--noinput",
                                             "--username=" + username,
                                             "--email=" + email, interactive=False)
-        if "DJANGO_SUPERUSER_PASSWORD" in environ:
-            password = environ["DJANGO_SUPERUSER_PASSWORD"]
+        if "EVENNIA_SUPERUSER_PASSWORD" in environ:
+            password = environ["EVENNIA_SUPERUSER_PASSWORD"]
             from evennia.accounts.models import AccountDB
             u = AccountDB.objects.get(username=username)
             u.set_password(password)

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1426,9 +1426,9 @@ def create_superuser():
     from os import environ
     if ("EVENNIA_SUPERUSER_USERNAME" in environ) and ("EVENNIA_SUPERUSER_PASSWORD" in environ):
         from evennia.accounts.models import AccountDB
-        superuser = AccountDB.objects.create_superuser(os.environ.get('EVENNIA_SUPERUSER_USERNAME'),
-                                                       os.environ.get('EVENNIA_SUPERUSER_EMAIL'),
-                                                       os.environ.get('EVENNIA_SUPERUSER_PASSWORD'))
+        superuser = AccountDB.objects.create_superuser(os.environ.get("EVENNIA_SUPERUSER_USERNAME"),
+                                                       os.environ.get("EVENNIA_SUPERUSER_EMAIL"),
+                                                       os.environ.get("EVENNIA_SUPERUSER_PASSWORD"))
         superuser.save()
     else:
         django.core.management.call_command("createsuperuser", interactive=True)

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1423,19 +1423,13 @@ def create_superuser():
         "\nCreate a superuser below. The superuser is Account #1, the 'owner' "
         "account of the server. Email is optional and can be empty.\n"
     )
-
     from os import environ
-    if ("EVENNIA_SUPERUSER_USERNAME" in environ) and ("EVENNIA_SUPERUSER_EMAIL" in environ):
-        username, email = environ["EVENNIA_SUPERUSER_USERNAME"], environ["EVENNIA_SUPERUSER_EMAIL"]
-        django.core.management.call_command("createsuperuser", "--noinput",
-                                            "--username=" + username,
-                                            "--email=" + email, interactive=False)
-        if "EVENNIA_SUPERUSER_PASSWORD" in environ:
-            password = environ["EVENNIA_SUPERUSER_PASSWORD"]
-            from evennia.accounts.models import AccountDB
-            u = AccountDB.objects.get(username=username)
-            u.set_password(password)
-            u.save()
+    if "EVENNIA_SUPERUSER_USERNAME" in environ:
+        from evennia.accounts.models import AccountDB
+        superuser = AccountDB.objects.create_superuser(os.environ.get('EVENNIA_SUPERUSER_USERNAME'),
+                                                       os.environ.get('EVENNIA_SUPERUSER_EMAIL'),
+                                                       os.environ.get('EVENNIA_SUPERUSER_PASSWORD'))
+        superuser.save()
     else:
         django.core.management.call_command("createsuperuser", interactive=True)
 

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1424,11 +1424,14 @@ def create_superuser():
         "account of the server. Email is optional and can be empty.\n"
     )
     from os import environ
-    if ("EVENNIA_SUPERUSER_USERNAME" in environ) and ("EVENNIA_SUPERUSER_PASSWORD" in environ):
+
+    username = environ.get("EVENNIA_SUPERUSER_USERNAME")
+    email = environ.get("EVENNIA_SUPERUSER_EMAIL")
+    password = environ.get("EVENNIA_SUPERUSER_PASSWORD")
+
+    if (username is not None) and (password is not None) and len(password) > 0:
         from evennia.accounts.models import AccountDB
-        superuser = AccountDB.objects.create_superuser(os.environ.get("EVENNIA_SUPERUSER_USERNAME"),
-                                                       os.environ.get("EVENNIA_SUPERUSER_EMAIL"),
-                                                       os.environ.get("EVENNIA_SUPERUSER_PASSWORD"))
+        superuser = AccountDB.objects.create_superuser(username, email, password)
         superuser.save()
     else:
         django.core.management.call_command("createsuperuser", interactive=True)

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1424,7 +1424,7 @@ def create_superuser():
         "account of the server. Email is optional and can be empty.\n"
     )
     from os import environ
-    if "EVENNIA_SUPERUSER_USERNAME" in environ:
+    if ("EVENNIA_SUPERUSER_USERNAME" in environ) and ("EVENNIA_SUPERUSER_PASSWORD" in environ):
         from evennia.accounts.models import AccountDB
         superuser = AccountDB.objects.create_superuser(os.environ.get('EVENNIA_SUPERUSER_USERNAME'),
                                                        os.environ.get('EVENNIA_SUPERUSER_EMAIL'),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When superuser is created pull details from environmental variables so that no interaction is required. If environmental variables are not present then fallback to typical behavior.

#### Motivation for adding to Evennia
Very helpful when launching via Docker (see feature request #2248).

#### Other info (issues closed, discussion etc)
I am not sure to what extent we would like this to mimic Django's support (see [here](https://docs.djangoproject.com/en/3.1/ref/django-admin/#createsuperuser)). The approach I have proposed here looks for both a username AND email address first, and then will check to see if an environmental variable for the password is present. Django's `createsuperuser` command does not allow for setting the password programmatically so I am leveraging `evennia.accounts.models.AccountDB` to perform that operation.