### PR TITLE
Suspect OOCLook commands are out of date

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -1500,7 +1500,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                     )
                 )
             result.append("\n\n |whelp|n - more commands")
-            result.append("\n |wooc <Text>|n - talk on public channel")
+            result.append("\n |wpublic <Text>|n - talk on public channel")
 
             charmax = _MAX_NR_CHARACTERS
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changed `ooc <message>` to `public <message>`

#### Motivation for adding to Evennia
I suspect the public channel used to be called "OOC" but was changed at some point. `ooc <message>` is no longer a valid command. This PR updates the guidance to the user to use the public channel instead, which seems to be the intention.