### PR TITLE
Maintenance time calculations should be done in minutes, not seconds.

### DIFF
--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -119,7 +119,7 @@ def _portal_maintenance():
 
     _MAINTENANCE_COUNT += 1
 
-    if _MAINTENANCE_COUNT % (3600 * 7) == 0:
+    if _MAINTENANCE_COUNT % (60 * 7) == 0:
         # drop database connection every 7 hrs to avoid default timeouts on MySQL
         # (see https://github.com/evennia/evennia/issues/1376)
         connection.close()

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -140,16 +140,16 @@ def _server_maintenance():
     _GAMETIME_MODULE.SERVER_RUNTIME_LAST_UPDATED = now
     ServerConfig.objects.conf("runtime", _GAMETIME_MODULE.SERVER_RUNTIME)
 
-    if _MAINTENANCE_COUNT % 300 == 0:
+    if _MAINTENANCE_COUNT % 5 == 0:
         # check cache size every 5 minutes
         _FLUSH_CACHE(_IDMAPPER_CACHE_MAXSIZE)
-    if _MAINTENANCE_COUNT % 3600 == 0:
+    if _MAINTENANCE_COUNT % 60 == 0:
         # validate scripts every hour
         evennia.ScriptDB.objects.validate()
-    if _MAINTENANCE_COUNT % 3700 == 0:
+    if _MAINTENANCE_COUNT % 61 == 0:
         # validate channels off-sync with scripts
         evennia.CHANNEL_HANDLER.update()
-    if _MAINTENANCE_COUNT % (3600 * 7) == 0:
+    if _MAINTENANCE_COUNT % (60 * 7) == 0:
         # drop database connection every 7 hrs to avoid default timeouts on MySQL
         # (see https://github.com/evennia/evennia/issues/1376)
         connection.close()

--- a/evennia/server/tests/test_server.py
+++ b/evennia/server/tests/test_server.py
@@ -84,7 +84,7 @@ class TestServer(TestCase):
             _FLUSH_CACHE=DEFAULT,
             connection=DEFAULT,
             _IDMAPPER_CACHE_MAXSIZE=1000,
-            _MAINTENANCE_COUNT=3700 - 1,
+            _MAINTENANCE_COUNT=62 - 1,
             _LAST_SERVER_TIME_SNAPSHOT=0,
             ServerConfig=DEFAULT,
         ) as mocks:

--- a/evennia/server/tests/test_server.py
+++ b/evennia/server/tests/test_server.py
@@ -47,7 +47,7 @@ class TestServer(TestCase):
             _FLUSH_CACHE=DEFAULT,
             connection=DEFAULT,
             _IDMAPPER_CACHE_MAXSIZE=1000,
-            _MAINTENANCE_COUNT=600 - 1,
+            _MAINTENANCE_COUNT=5 - 1,
             ServerConfig=DEFAULT,
         ) as mocks:
             mocks["connection"].close = MagicMock()
@@ -65,7 +65,7 @@ class TestServer(TestCase):
             _FLUSH_CACHE=DEFAULT,
             connection=DEFAULT,
             _IDMAPPER_CACHE_MAXSIZE=1000,
-            _MAINTENANCE_COUNT=3600 - 1,
+            _MAINTENANCE_COUNT=60 - 1,
             _LAST_SERVER_TIME_SNAPSHOT=0,
             ServerConfig=DEFAULT,
         ) as mocks:
@@ -84,7 +84,7 @@ class TestServer(TestCase):
             _FLUSH_CACHE=DEFAULT,
             connection=DEFAULT,
             _IDMAPPER_CACHE_MAXSIZE=1000,
-            _MAINTENANCE_COUNT=62 - 1,
+            _MAINTENANCE_COUNT=61 - 1,
             _LAST_SERVER_TIME_SNAPSHOT=0,
             ServerConfig=DEFAULT,
         ) as mocks:
@@ -102,7 +102,7 @@ class TestServer(TestCase):
             _FLUSH_CACHE=DEFAULT,
             connection=DEFAULT,
             _IDMAPPER_CACHE_MAXSIZE=1000,
-            _MAINTENANCE_COUNT=(3600 * 7) - 1,
+            _MAINTENANCE_COUNT=(60 * 7) - 1,
             _LAST_SERVER_TIME_SNAPSHOT=0,
             ServerConfig=DEFAULT,
         ) as mocks:


### PR DESCRIPTION
Should resolve #2336

#### Brief overview of PR changes/additions

Adjusts maintenance time calculations from seconds to minutes, as maintenance is run every minute.

#### Motivation for adding to Evennia

Fixes stale DB connection issues when running MySQL, and does these maintenance items in the time frames that are expected.

#### Other info (issues closed, discussion etc)
