### PR TITLE
Don't allow fuzzy match on db if exact match on module prototype

### DIFF
--- a/evennia/prototypes/prototypes.py
+++ b/evennia/prototypes/prototypes.py
@@ -379,10 +379,12 @@ def search_prototype(key=None, tags=None, require_single=False, return_iterators
     else:
         mod_matches = _MODULE_PROTOTYPES
 
+    allow_fuzzy = True
     if key:
         if key in mod_matches:
             # exact match
             module_prototypes = [mod_matches[key]]
+            allow_fuzzy = False
         else:
             # fuzzy matching
             module_prototypes = [
@@ -406,7 +408,7 @@ def search_prototype(key=None, tags=None, require_single=False, return_iterators
     if key:
         # exact or partial match on key
         exact_match = db_matches.filter(Q(db_key__iexact=key)).order_by("db_key")
-        if not exact_match:
+        if not exact_match and allow_fuzzy:
             # try with partial match instead
             db_matches = db_matches.filter(Q(db_key__icontains=key)).order_by("db_key")
         else:
@@ -423,7 +425,7 @@ def search_prototype(key=None, tags=None, require_single=False, return_iterators
         nmodules = len(module_prototypes)
         ndbprots = db_matches.count()
         if nmodules + ndbprots != 1:
-            raise KeyError(f"Found {nmodules + ndbprots} matching prototypes.")
+            raise KeyError(f"Found {nmodules + ndbprots} matching prototypes {module_prototypes}.")
 
     if return_iterators:
         # trying to get the entire set of prototypes - we must paginate


### PR DESCRIPTION
#### Brief overview of PR changes/additions

If you have an exact match on a module prototype, the current logic will go on to fuzzy match on database prototypes and potentially match things from the db in addition to the exact match from the module prototype.

#### Motivation for adding to Evennia

The existing behaviour results in many matches for a spawn when there is an exact match available.

#### Other info (issues closed, discussion etc)
