### PR TITLE
Fix ga for mudlet

### DIFF
--- a/evennia/server/portal/suppress_ga.py
+++ b/evennia/server/portal/suppress_ga.py
@@ -40,6 +40,7 @@ class SuppressGA(object):
         self.protocol = protocol
 
         self.protocol.protocol_flags["NOGOAHEAD"] = True
+        self.protocol.protocol_flags["NOPROMPTGOAHEAD"] = True # Used to send a GA after a prompt line only, set in TTYPE (per client)
         # tell the client that we prefer to suppress GA ...
         self.protocol.will(SUPPRESS_GA).addCallbacks(self.will_suppress_ga, self.wont_suppress_ga)
 

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -337,7 +337,7 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         line = line.replace(b"\n", b"\r\n")
         if not line.endswith(b"\r\n") and self.protocol_flags.get("FORCEDENDLINE", True):
             line += b"\r\n"
-        if not self.protocol_flags.get("NOGOAHEAD", True) and self.protocol_flags.get("NOPROMPTGOAHEAD", True):
+        if not self.protocol_flags.get("NOGOAHEAD", True):
             line += IAC + GA
         return self.transport.write(mccp_compress(self, line))
 
@@ -440,8 +440,8 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
                     prompt = mxp_parse(prompt)
             prompt = to_bytes(prompt, self)
             prompt = prompt.replace(IAC, IAC + IAC).replace(b"\n", b"\r\n")
-            if not self.protocol_flags.get("NOGOAHEAD", True) and not self.protocol_flags.get("NOPROMPTGOAHEAD", True):
-                    prompt += IAC + GA
+            if not self.protocol_flags.get("NOPROMPTGOAHEAD", self.protocol_flags.get("NOGOAHEAD", True)):
+                prompt += IAC + GA
             self.transport.write(mccp_compress(self, prompt))
         else:
             if echo is not None:

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -337,6 +337,8 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         line = line.replace(b"\n", b"\r\n")
         if not line.endswith(b"\r\n") and self.protocol_flags.get("FORCEDENDLINE", True):
             line += b"\r\n"
+        if not self.protocol_flags.get("NOGOAHEAD", True) and self.protocol_flags.get("NOPROMPTGOAHEAD", True):
+            line += IAC + GA
         return self.transport.write(mccp_compress(self, line))
 
     # Session hooks
@@ -438,8 +440,8 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
                     prompt = mxp_parse(prompt)
             prompt = to_bytes(prompt, self)
             prompt = prompt.replace(IAC, IAC + IAC).replace(b"\n", b"\r\n")
-            if not self.protocol_flags.get("NOGOAHEAD", True):
-                prompt += IAC + GA
+            if not self.protocol_flags.get("NOGOAHEAD", True) and not self.protocol_flags.get("NOPROMPTGOAHEAD", True):
+                    prompt += IAC + GA
             self.transport.write(mccp_compress(self, prompt))
         else:
             if echo is not None:

--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -337,8 +337,6 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
         line = line.replace(b"\n", b"\r\n")
         if not line.endswith(b"\r\n") and self.protocol_flags.get("FORCEDENDLINE", True):
             line += b"\r\n"
-        if not self.protocol_flags.get("NOGOAHEAD", True):
-            line += IAC + GA
         return self.transport.write(mccp_compress(self, line))
 
     # Session hooks
@@ -440,7 +438,8 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, Session):
                     prompt = mxp_parse(prompt)
             prompt = to_bytes(prompt, self)
             prompt = prompt.replace(IAC, IAC + IAC).replace(b"\n", b"\r\n")
-            prompt += IAC + GA
+            if not self.protocol_flags.get("NOGOAHEAD", True):
+                prompt += IAC + GA
             self.transport.write(mccp_compress(self, prompt))
         else:
             if echo is not None:

--- a/evennia/server/portal/tests.py
+++ b/evennia/server/portal/tests.py
@@ -231,7 +231,6 @@ class TestTelnet(TwistedTestCase):
         self.transport.client = ["localhost"]
         self.transport.setTcpKeepAlive = Mock()
         d = self.proto.makeConnection(self.transport)
-
         # test suppress_ga
         self.assertTrue(self.proto.protocol_flags["NOGOAHEAD"])
         self.proto.dataReceived(IAC + DONT + SUPPRESS_GA)
@@ -246,13 +245,13 @@ class TestTelnet(TwistedTestCase):
         self.assertEqual(self.proto.protocol_flags["SCREENHEIGHT"][0], 45)
         self.assertEqual(self.proto.handshakes, 6)
         # test ttype
-        self.assertTrue(self.proto.protocol_flags["FORCEDENDLINE"])
         self.assertFalse(self.proto.protocol_flags["TTYPE"])
         self.assertTrue(self.proto.protocol_flags["ANSI"])
         self.proto.dataReceived(IAC + WILL + TTYPE)
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"MUDLET", IAC, SE]))
         self.assertTrue(self.proto.protocol_flags["XTERM256"])
         self.assertEqual(self.proto.protocol_flags["CLIENTNAME"], "MUDLET")
+        self.assertTrue(self.proto.protocol_flags["FORCEDENDLINE"])
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"XTERM", IAC, SE]))
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"MTTS 137", IAC, SE]))
         self.assertEqual(self.proto.handshakes, 5)

--- a/evennia/server/portal/tests.py
+++ b/evennia/server/portal/tests.py
@@ -252,6 +252,7 @@ class TestTelnet(TwistedTestCase):
         self.assertTrue(self.proto.protocol_flags["XTERM256"])
         self.assertEqual(self.proto.protocol_flags["CLIENTNAME"], "MUDLET")
         self.assertTrue(self.proto.protocol_flags["FORCEDENDLINE"])
+        self.assertFalse(self.proto.protocol_flags["NOPROMPTGOAHEAD"])
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"XTERM", IAC, SE]))
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"MTTS 137", IAC, SE]))
         self.assertEqual(self.proto.handshakes, 5)

--- a/evennia/server/portal/tests.py
+++ b/evennia/server/portal/tests.py
@@ -252,6 +252,7 @@ class TestTelnet(TwistedTestCase):
         self.assertTrue(self.proto.protocol_flags["XTERM256"])
         self.assertEqual(self.proto.protocol_flags["CLIENTNAME"], "MUDLET")
         self.assertTrue(self.proto.protocol_flags["FORCEDENDLINE"])
+        self.assertTrue(self.proto.protocol_flags["NOGOAHEAD"])
         self.assertFalse(self.proto.protocol_flags["NOPROMPTGOAHEAD"])
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"XTERM", IAC, SE]))
         self.proto.dataReceived(b"".join([IAC, SB, TTYPE, IS, b"MTTS 137", IAC, SE]))

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -119,10 +119,6 @@ class Ttype(object):
             if clientname.startswith("MUDLET"):
                 # supports xterm256 stably since 1.1 (2010?)
                 xterm256 = clientname.split("MUDLET", 1)[1].strip() >= "1.1"
-                self.protocol.protocol_flags["FORCEDENDLINE"] = True
-
-            if clientname.startswith("TINTIN++"):
-                self.protocol.protocol_flags["FORCEDENDLINE"] = True
 
             if (
                 clientname.startswith("XTERM")

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -119,9 +119,10 @@ class Ttype(object):
             if clientname.startswith("MUDLET"):
                 # supports xterm256 stably since 1.1 (2010?)
                 xterm256 = clientname.split("MUDLET", 1)[1].strip() >= "1.1"
-                # Mudlet likes GA's on a prompt line for the prompt trigger to match.
-                self.protocol.protocol_flags["NOGOAHEAD"] = True
-                self.protocol.protocol_flags["NOPROMPTGOAHEAD"] = False
+                # Mudlet likes GA's on a prompt line for the prompt trigger to match, if it's not wanting NOGOAHEAD.
+                if not self.protocol.protocol_flags["NOGOAHEAD"]:
+                    self.protocol.protocol_flags["NOGOAHEAD"] = True
+                    self.protocol.protocol_flags["NOPROMPTGOAHEAD"] = False
 
             if (
                 clientname.startswith("XTERM")

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -120,6 +120,7 @@ class Ttype(object):
                 # supports xterm256 stably since 1.1 (2010?)
                 xterm256 = clientname.split("MUDLET", 1)[1].strip() >= "1.1"
                 # Mudlet likes GA's on a prompt line for the prompt trigger to match.
+                self.protocol.protocol_flags["NOGOAHEAD"] = True
                 self.protocol.protocol_flags["NOPROMPTGOAHEAD"] = False
 
             if (

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -119,7 +119,7 @@ class Ttype(object):
             if clientname.startswith("MUDLET"):
                 # supports xterm256 stably since 1.1 (2010?)
                 xterm256 = clientname.split("MUDLET", 1)[1].strip() >= "1.1"
-                self.protocol.protocol_flags["FORCEDENDLINE"] = False
+                self.protocol.protocol_flags["FORCEDENDLINE"] = True
 
             if clientname.startswith("TINTIN++"):
                 self.protocol.protocol_flags["FORCEDENDLINE"] = True

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -119,6 +119,8 @@ class Ttype(object):
             if clientname.startswith("MUDLET"):
                 # supports xterm256 stably since 1.1 (2010?)
                 xterm256 = clientname.split("MUDLET", 1)[1].strip() >= "1.1"
+                # Mudlet likes GA's on a prompt line for the prompt trigger to match.
+                self.protocol.protocol_flags["NOPROMPTGOAHEAD"] = False
 
             if (
                 clientname.startswith("XTERM")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Mudlet contains a isPrompt() function to detect prompts. This is powered by the presence of a GA on the line that sends it (most clients in 2021 suppress GA). This patch is to only send a GA if SGA is False and the line is a prompt. It also turns on FORCEDENDLINE for Mudlet as it only displays mud output if there's either a GA or a newline.

#### Motivation for adding to Evennia

Pretty sure it's broken without it.

#### Other info (issues closed, discussion etc)
