### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -10,7 +10,7 @@ on your sources.
 
 ## A quick list of code style points
 
- * 4-space indendation, NO TABS!
+ * 4-space indentation, NO TABS!
  * Unix line endings.
  * CamelCase is only used for classes, nothing else.
  * All non-global variable names and all function names are to be

--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -606,7 +606,7 @@ def cmdhandler(
             cmd.raw_string = unformatted_raw_string
             # cmd.obj  # set via on-object cmdset handler for each command,
             # since this may be different for every command when
-            # merging multuple cmdsets
+            # merging multiple cmdsets
 
             if hasattr(cmd, "obj") and hasattr(cmd.obj, "scripts"):
                 # cmd.obj is automatically made available by the cmdhandler.

--- a/evennia/commands/default/syscommands.py
+++ b/evennia/commands/default/syscommands.py
@@ -71,7 +71,7 @@ class SystemNoMatch(COMMAND_DEFAULT_CLASS):
 
 
 #
-# Command called when there were mulitple matches to the command.
+# Command called when there were multiple matches to the command.
 #
 class SystemMultimatch(COMMAND_DEFAULT_CLASS):
     """

--- a/evennia/contrib/building_menu.py
+++ b/evennia/contrib/building_menu.py
@@ -577,7 +577,7 @@ class BuildingMenu(object):
     keys_go_back = ["@"]  # The keys allowing to go back in the menu tree
     sep_keys = "."  # The key separator for menus with more than 2 levels
     joker_key = "*"  # The special key meaning "anything" in a choice key
-    min_shortcut = 1  # The minimum length of shorcuts when `key` is not set
+    min_shortcut = 1  # The minimum length of shortcuts when `key` is not set
 
     def __init__(
         self,

--- a/evennia/prototypes/prototypes.py
+++ b/evennia/prototypes/prototypes.py
@@ -653,7 +653,7 @@ def validate_prototype(
                 )
             )
 
-    # recursively traverese prototype_parent chain
+    # recursively traverse prototype_parent chain
 
     for protstring in make_iter(prototype_parent):
         protstring = protstring.lower()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

There are small typos in:
- CODING_STYLE.md
- evennia/commands/cmdhandler.py
- evennia/commands/default/syscommands.py
- evennia/contrib/building_menu.py
- evennia/prototypes/prototypes.py

Fixes:
- Should read `traverse` rather than `traverese`.
- Should read `shortcuts` rather than `shorcuts`.
- Should read `multiple` rather than `multuple`.
- Should read `multiple` rather than `mulitple`.
- Should read `indentation` rather than `indendation`.

#### Motivation for adding to Evennia

Avoids ambiguity and confusion in the documentation.

#### Other info (issues closed, discussion etc)

Closes #2420
