### PR TITLE
file and command help web support, proof of concept

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -551,6 +551,18 @@ Command {self} has no defined `func()` - showing on-command variables:
         except Exception as e:
             return "#"
 
+    def web_get_admin_url(self):
+        """
+        Returns the URI path for the Django Admin page for this object.
+
+        ex. Account#1 = '/admin/accounts/accountdb/1/change/'
+
+        Returns:
+            path (str): URI path to Django Admin page for object.
+
+        """
+        return False
+
     def client_width(self):
         """
         Get the client screenwidth for the session using this command.

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -16,7 +16,6 @@ from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import is_iter, fill, lazy_property, make_iter
 from evennia.utils.evtable import EvTable
 from evennia.utils.ansi import ANSIString
-from evennia.utils.logger import log_info
 
 
 class InterruptCommand(Exception):
@@ -550,7 +549,6 @@ Command {self} has no defined `func()` - showing on-command variables:
                 kwargs={"category": slugify(self.help_category), "topic": slugify(self.key)},
             )
         except Exception as e:
-            log_info(f'Exception: {getattr(e, "message", repr(e))}')
             return "#"
 
     def client_width(self):

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -9,11 +9,14 @@ import math
 import inspect
 
 from django.conf import settings
+from django.urls import reverse
+from django.utils.text import slugify
 
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import is_iter, fill, lazy_property, make_iter
 from evennia.utils.evtable import EvTable
 from evennia.utils.ansi import ANSIString
+from evennia.utils.logger import log_info
 
 
 class InterruptCommand(Exception):
@@ -513,6 +516,42 @@ Command {self} has no defined `func()` - showing on-command variables:
 
         """
         return self.__doc__
+
+    def web_get_detail_url(self):
+        """
+        Returns the URI path for a View that allows users to view details for
+        this object.
+
+        ex. Oscar (Character) = '/characters/oscar/1/'
+
+        For this to work, the developer must have defined a named view somewhere
+        in urls.py that follows the format 'modelname-action', so in this case
+        a named view of 'character-detail' would be referenced by this method.
+
+        ex.
+        ::
+            url(r'characters/(?P<slug>[\w\d\-]+)/(?P<pk>[0-9]+)/$',
+                CharDetailView.as_view(), name='character-detail')
+
+        If no View has been created and defined in urls.py, returns an
+        HTML anchor.
+
+        This method is naive and simply returns a path. Securing access to
+        the actual view and limiting who can view this object is the developer's
+        responsibility.
+
+        Returns:
+            path (str): URI path to object detail page, if defined.
+
+        """
+        try:
+            return reverse(
+                'help-entry-detail',
+                kwargs={"category": slugify(self.help_category), "topic": slugify(self.key)},
+            )
+        except Exception as e:
+            log_info(f'Exception: {getattr(e, "message", repr(e))}')
+            return "#"
 
     def client_width(self):
         """

--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -244,5 +244,3 @@ class FileHelpStorageHandler:
 
 # singleton to hold the loaded help entries
 FILE_HELP_ENTRIES = FileHelpStorageHandler()
-# Used by Django Sites/Admin
-#get_absolute_url = web_get_detail_url

--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -152,6 +152,18 @@ class FileHelpEntry:
         except Exception:
             return "#"
 
+    def web_get_admin_url(self):
+        """
+        Returns the URI path for the Django Admin page for this object.
+
+        ex. Account#1 = '/admin/accounts/accountdb/1/change/'
+
+        Returns:
+            path (str): URI path to Django Admin page for object.
+
+        """
+        return False
+
     def access(self, accessing_obj, access_type="view", default=True):
         """
         Determines if another object has permission to access this help entry.

--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -74,7 +74,6 @@ from evennia.utils.utils import (
 from evennia.utils import logger
 from evennia.utils.utils import lazy_property
 from evennia.locks.lockhandler import LockHandler
-from evennia.utils.logger import log_info
 
 _DEFAULT_HELP_CATEGORY = settings.DEFAULT_HELP_CATEGORY
 
@@ -145,14 +144,12 @@ class FileHelpEntry:
             path (str): URI path to object detail page, if defined.
 
         """
-        # log_info('filehelp web_get_detail_url start')
         try:
             return reverse(
                 'help-entry-detail',
                 kwargs={"category": slugify(self.help_category), "topic": slugify(self.key)},
             )
-        except Exception as e:
-            log_info(f'Exception: {getattr(e, "message", repr(e))}')
+        except Exception:
             return "#"
 
     def access(self, accessing_obj, access_type="view", default=True):

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -57,6 +57,9 @@ class HelpEntry(SharedMemoryModel):
     db_key = models.CharField(
         "help key", max_length=255, unique=True, help_text="key to search for"
     )
+    @lazy_property
+    def key(self):
+        return self.db_key
     # help category
     db_help_category = models.CharField(
         "help category",
@@ -64,6 +67,9 @@ class HelpEntry(SharedMemoryModel):
         default="General",
         help_text="organizes help entries in lists",
     )
+    @lazy_property
+    def help_category(self):
+        return self.db_help_category
     # the actual help entry text, in any formatting.
     db_entrytext = models.TextField(
         "help entry", blank=True, help_text="the main body of help text"

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -19,6 +19,7 @@ from evennia.help.manager import HelpEntryManager
 from evennia.typeclasses.models import Tag, TagHandler, AliasHandler
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import lazy_property
+from evennia.utils.logger import log_info
 
 __all__ = ("HelpEntry",)
 
@@ -221,11 +222,14 @@ class HelpEntry(SharedMemoryModel):
             path (str): URI path to object detail page, if defined.
 
         """
+
         try:
-            return reverse(
+            url = reverse(
                 "%s-detail" % slugify(self._meta.verbose_name),
                 kwargs={"category": slugify(self.db_help_category), "topic": slugify(self.db_key)},
             )
+            # log_info(f'HelpEntry web_get_detail_url url: {url}')
+            return url
         except Exception:
             return "#"
 

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -57,10 +57,6 @@ class HelpEntry(SharedMemoryModel):
         "help key", max_length=255, unique=True, help_text="key to search for"
     )
 
-    @lazy_property
-    def key(self):
-        return self.db_key
-
     # help category
     db_help_category = models.CharField(
         "help category",
@@ -68,10 +64,6 @@ class HelpEntry(SharedMemoryModel):
         default="General",
         help_text="organizes help entries in lists",
     )
-
-    @lazy_property
-    def help_category(self):
-        return self.db_help_category
 
     # the actual help entry text, in any formatting.
     db_entrytext = models.TextField(
@@ -233,11 +225,10 @@ class HelpEntry(SharedMemoryModel):
         """
 
         try:
-            url = reverse(
+            return reverse(
                 "%s-detail" % slugify(self._meta.verbose_name),
                 kwargs={"category": slugify(self.db_help_category), "topic": slugify(self.db_key)},
             )
-            return url
         except Exception:
             return "#"
 

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -19,7 +19,6 @@ from evennia.help.manager import HelpEntryManager
 from evennia.typeclasses.models import Tag, TagHandler, AliasHandler
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.utils import lazy_property
-from evennia.utils.logger import log_info
 
 __all__ = ("HelpEntry",)
 
@@ -57,9 +56,11 @@ class HelpEntry(SharedMemoryModel):
     db_key = models.CharField(
         "help key", max_length=255, unique=True, help_text="key to search for"
     )
+
     @lazy_property
     def key(self):
         return self.db_key
+
     # help category
     db_help_category = models.CharField(
         "help category",
@@ -67,9 +68,11 @@ class HelpEntry(SharedMemoryModel):
         default="General",
         help_text="organizes help entries in lists",
     )
+
     @lazy_property
     def help_category(self):
         return self.db_help_category
+
     # the actual help entry text, in any formatting.
     db_entrytext = models.TextField(
         "help entry", blank=True, help_text="the main body of help text"

--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -237,7 +237,6 @@ class HelpEntry(SharedMemoryModel):
                 "%s-detail" % slugify(self._meta.verbose_name),
                 kwargs={"category": slugify(self.db_help_category), "topic": slugify(self.db_key)},
             )
-            # log_info(f'HelpEntry web_get_detail_url url: {url}')
             return url
         except Exception:
             return "#"

--- a/evennia/web/templates/website/help_detail.html
+++ b/evennia/web/templates/website/help_detail.html
@@ -25,7 +25,7 @@
         <div class="row">
           <!-- left column -->
           <div class="col-lg-9 col-sm-12">
-            <p>{{ entry_text }}</p>
+            <pre>{{ entry_text }}</pre>
 
             {% if topic_previous or topic_next %}
             <hr />

--- a/evennia/web/templates/website/help_detail.html
+++ b/evennia/web/templates/website/help_detail.html
@@ -17,8 +17,8 @@
         <hr />
         <ol class="breadcrumb">
           <li class="breadcrumb-item"><a href="{% url 'help' %}">Help Index</a></li>
-          <li class="breadcrumb-item"><a href="{% url 'help' %}#{{ object.help_category }}">{{ object.help_category|title }}</a></li>
-          <li class="breadcrumb-item active" aria-current="page">{{ object.key|title }}</li>
+          <li class="breadcrumb-item"><a href="{% url 'help' %}#{{ object.web_help_category }}">{{ object.help_category|title }}</a></li>
+          <li class="breadcrumb-item active" aria-current="page">{{ object.web_help_key|title }}</li>
         </ol>
         <hr />
 
@@ -62,7 +62,7 @@
             {% endif %}
 
             <div class="card mb-3">
-              <div class="card-header">{{ object.help_category|title }}</div>
+              <div class="card-header">{{ object.web_help_category|title }}</div>
 
               <ul class="list-group list-group-flush">
                 {% for topic in topic_list %}

--- a/evennia/web/templates/website/help_detail.html
+++ b/evennia/web/templates/website/help_detail.html
@@ -62,7 +62,7 @@
             {% endif %}
 
             <div class="card mb-3">
-              <div class="card-header">{{ object.db_help_category|title }}</div>
+              <div class="card-header">{{ object.help_category|title }}</div>
 
               <ul class="list-group list-group-flush">
                 {% for topic in topic_list %}

--- a/evennia/web/templates/website/help_detail.html
+++ b/evennia/web/templates/website/help_detail.html
@@ -9,16 +9,16 @@
 {% load addclass %}
 <div class="row">
   <div class="col">
-    
-    <!-- main content -->  
+
+    <!-- main content -->
     <div class="card mb-3">
       <div class="card-body">
         <h1 class="card-title">{{ view.page_title }} ({{ object|title }})</h1>
         <hr />
         <ol class="breadcrumb">
           <li class="breadcrumb-item"><a href="{% url 'help' %}">Help Index</a></li>
-          <li class="breadcrumb-item"><a href="{% url 'help' %}#{{ object.db_help_category }}">{{ object.db_help_category|title }}</a></li>
-          <li class="breadcrumb-item active" aria-current="page">{{ object.db_key|title }}</li>
+          <li class="breadcrumb-item"><a href="{% url 'help' %}#{{ object.help_category }}">{{ object.help_category|title }}</a></li>
+          <li class="breadcrumb-item active" aria-current="page">{{ object.key|title }}</li>
         </ol>
         <hr />
 
@@ -26,7 +26,7 @@
           <!-- left column -->
           <div class="col-lg-9 col-sm-12">
             <p>{{ entry_text }}</p>
-            
+
             {% if topic_previous or topic_next %}
             <hr />
             <!-- navigation -->
@@ -37,7 +37,7 @@
                   <a class="page-link" href="{{ topic_previous.web_get_detail_url }}">Previous ({{ topic_previous|title }})</a>
                 </li>
                 {% endif %}
-                
+
                 {% if topic_next %}
                 <li class="page-item">
                   <a class="page-link" href="{{ topic_next.web_get_detail_url }}">Next ({{ topic_next|title }})</a>
@@ -47,40 +47,40 @@
             </nav>
             <!-- end navigation -->
             {% endif %}
-            
+
           </div>
           <!-- end left column -->
-          
+
           <!-- right column (sidebar) -->
           <div class="col-lg-3 col-sm-12">
-            
+
             {% if request.user.is_staff %}
             <!-- admin button -->
             <a class="btn btn-info btn-block mb-3" href="{{ object.web_get_admin_url }}">Admin</a>
             <!-- end admin button -->
             <hr />
             {% endif %}
-            
+
             <div class="card mb-3">
               <div class="card-header">{{ object.db_help_category|title }}</div>
-              
+
               <ul class="list-group list-group-flush">
                 {% for topic in topic_list %}
                 <a href="{{ topic.web_get_detail_url }}" class="list-group-item {% if topic == object %}active disabled{% endif %}">{{ topic|title }}</a>
                 {% endfor %}
               </ul>
-              
+
             </div>
           </div>
           <!-- end right column -->
-          
+
         </div>
         <hr />
-          
+
       </div>
     </div>
     <!-- end main content -->
-    
+
   </div>
 </div>
 {% endblock %}

--- a/evennia/web/templates/website/help_list.html
+++ b/evennia/web/templates/website/help_list.html
@@ -42,9 +42,9 @@
                   {% for object in web_help_category.list %}
                   <li>
                       <a href="{{ object.web_get_detail_url }}">{{ object|title }}</a>
-                      {% if object.web_get_update_url %}
+                      {% if object.web_get_admin_url %}
                           {% if user.is_staff %}
-                              <a href="{% url "admin:help_helpentry_changelist" %}">-edit-</a>
+                              <a href="{{ object.web_get_admin_url }}">-edit-</a>
                           {% endif %}
                       {% endif %}
                   </li>

--- a/evennia/web/templates/website/help_list.html
+++ b/evennia/web/templates/website/help_list.html
@@ -40,7 +40,14 @@
               <h5><a id="{{ web_help_category.grouper }}"></a>{{ web_help_category.grouper|title }}</h5>
               <ul>
                   {% for object in web_help_category.list %}
-                  <li><a href="{{ object.web_get_detail_url }}">{{ object|title }}</a></li>
+                  <li>
+                      <a href="{{ object.web_get_detail_url }}">{{ object|title }}</a>
+                      {% if object.web_get_update_url %}
+                          {% if user.is_staff %}
+                              <a href="{% url "admin:help_helpentry_changelist" %}">-edit-</a>
+                          {% endif %}
+                      {% endif %}
+                  </li>
                   {% endfor %}
               </ul>
               {% endfor %}

--- a/evennia/web/templates/website/help_list.html
+++ b/evennia/web/templates/website/help_list.html
@@ -18,12 +18,12 @@
         </ol>
         <hr />
         <div class="row">
-          {% regroup object_list by help_category as category_list %}
-          
+          {% regroup object_list by web_help_category as category_list %}
+
           {% if category_list %}
           <!-- left column -->
           <div class="col-lg-9 col-sm-12">
-            
+
             <!-- intro -->
             <div class="card border-light">
               <div class="card-body">
@@ -33,23 +33,23 @@
             </div>
             <hr />
             <!-- end intro -->
-            
+
             <!-- index list -->
             <div class="mx-3">
-              {% for help_category in category_list %}
-              <h5><a id="{{ help_category.grouper }}"></a>{{ help_category.grouper|title }}</h5>
+              {% for web_help_category in category_list %}
+              <h5><a id="{{ web_help_category.grouper }}"></a>{{ web_help_category.grouper|title }}</h5>
               <ul>
-                  {% for object in help_category.list %}
+                  {% for object in web_help_category.list %}
                   <li><a href="{{ object.web_get_detail_url }}">{{ object|title }}</a></li>
                   {% endfor %}
               </ul>
               {% endfor %}
               <!-- end index list -->
             </div>
-            
+
           </div>
           <!-- end left column -->
-          
+
           <!-- right column (index) -->
           <div class="col-lg-3 col-sm-12">
             {% if user.is_staff %}
@@ -58,16 +58,16 @@
             <!-- end admin button -->
             <hr />
             {% endif %}
-            
+
             <div class="card mb-3">
               <div class="card-header">Category Index</div>
-              
+
               <ul class="list-group list-group-flush">
                 {% for category in category_list %}
                 <a href="#{{ category.grouper }}" class="list-group-item">{{ category.grouper|title }}</a>
                 {% endfor %}
               </ul>
-              
+
             </div>
           </div>
           <!-- end right column -->
@@ -81,14 +81,14 @@
               <p>You're missing out on an opportunity to attract visitors (and potentially new players) to {{ game_name }}!</p>
               <p>Use Evennia's <a href="https://github.com/evennia/evennia/wiki/Help-System#database-help-entries" class="alert-link" target="_blank">Help System</a> to tell the world about the universe you've created, its lore and legends, its people and creatures, and their customs and conflicts!</p>
               <p>You don't even need coding skills-- writing Help Entries is no more complicated than writing an email or blog post. Once you publish your first entry, these ugly boxes go away and this page will turn into an index of everything you've written about {{ game_name }}.</p>
-              <p>The documentation you write is eventually picked up by search engines, so the more you write about how {{ game_name }} works, the larger your web presence will be-- and the more traffic you'll attract. 
+              <p>The documentation you write is eventually picked up by search engines, so the more you write about how {{ game_name }} works, the larger your web presence will be-- and the more traffic you'll attract.
               <p>Everything you write can be viewed either on this site or within the game itself, using the in-game help commands.</p>
               <hr>
               <p class="mb-0"><a href="/admin/help/helpentry/add/" class="alert-link">Click here</a> to start writing about {{ game_name }}!</p>
             </div>
           </div>
           {% endif %}
-          
+
           <div class="col-lg-12 col-sm-12">
             <div class="alert alert-secondary" role="alert">
               <h4 class="alert-heading">Under Construction!</h4>
@@ -99,7 +99,7 @@
             </div>
           </div>
           {% endif %}
-          
+
         </div>
         <hr />
       </div>

--- a/evennia/web/website/tests.py
+++ b/evennia/web/website/tests.py
@@ -135,6 +135,17 @@ class ChannelDetailTest(EvenniaWebTest):
         return {"slug": slugify("demo")}
 
 
+class HelpListTest(EvenniaWebTest):
+    url_name = "help"
+
+
+class HelpDetailTest(EvenniaWebTest):
+    url_name = "help-entry-detail"
+
+    def get_kwargs(self):
+        return {"category": slugify("general"),
+                "topic": slugify("test-key")}
+
 class CharacterCreateView(EvenniaWebTest):
     url_name = "character-create"
     unauthenticated_response = 302

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -11,8 +11,6 @@ from django.views.generic import ListView, DetailView
 from django.http import HttpResponseBadRequest
 from evennia.help.models import HelpEntry
 from evennia.help.filehelp import FILE_HELP_ENTRIES
-from .mixins import TypeclassMixin
-from evennia.utils.logger import log_info
 from evennia.utils.ansi import strip_ansi
 
 DEFAULT_HELP_CATEGORY = settings.DEFAULT_HELP_CATEGORY
@@ -26,162 +24,126 @@ def get_help_category(help_entry, slugify_cat=True):
         slugify_cat (bool): If true the return string is slugified. Default is True.
 
     Notes:
-        If the entry does not have attribute 'web_help_entries'. One is created with
-        a slugified copy of the attribute help_category.
-        This attribute is used for sorting the entries for the help index (ListView) page.
+        If an entry does not have a `help_category` attribute, DEFAULT_HELP_CATEGORY from the
+        settings file is used.
+        If the entry does not have attribute 'web_help_entries'. One is created with a slugified
+        copy of the attribute help_category. This attribute is used for sorting the entries for the
+        help index (ListView) page.
 
     Returns:
         help_category (str): The category for the help entry.
     """
+    help_category = help_entry.help_category if help_entry.help_category else DEFAULT_HELP_CATEGORY
     if not hasattr(help_entry, 'web_help_category'):
-        setattr(help_entry, 'web_help_category', slugify(help_entry.help_category))
-    return slugify(help_entry.help_category) if slugify_cat else help_entry.help_category
+        setattr(help_entry, 'web_help_category', slugify(help_category))
+    return slugify(help_category) if slugify_cat else help_category
 
 
 def get_help_topic(help_entry):
-    topic = getattr(help_entry, 'key', False)
-    if not topic:
-        getattr(help_entry, 'db_key', False)
-    # log_info(f'get_help_topic returning: {topic}')
-    return topic
+    """Get the topic of the help entry.
 
+    Args:
+        help_entry (HelpEntry, FileHelpEntry or Command): Help entry instance.
 
-def can_read_topic(cmd_or_topic, caller):
-        """
-        Helper method. If this return True, the given help topic
-        be viewable in the help listing. Note that even if this returns False,
-        the entry will still be visible in the help index unless `should_list_topic`
-        is also returning False.
-        Args:
-            cmd_or_topic (Command, HelpEntry or FileHelpEntry): The topic/command to test.
-            caller: the caller checking for access.
-        Returns:
-            bool: If command can be viewed or not.
-        Notes:
-            This uses the 'read' lock. If no 'read' lock is defined, the topic is assumed readable
-            by all.
-        """
-        if inherits_from(cmd_or_topic, "evennia.commands.command.Command"):
-            return cmd_or_topic.auto_help and cmd_or_topic.access(caller, 'read', default=True)
-        else:
-            return cmd_or_topic.access(caller, 'read', default=True)
-
-
-def can_list_topic(cmd_or_topic, caller):
+    Returns:
+        topic (str): The topic of the help entry. Default is 'unknown_topic'.
     """
-    Should the specified command appear in the help table?
-    This method only checks whether a specified command should appear in the table of
-    topics/commands.  The command can be used by the caller (see the 'should_show_help' method)
-    and the command will still be available, for instance, if a character type 'help name of the
-    command'.  However, if you return False, the specified command will not appear in the table.
-    This is sometimes useful to "hide" commands in the table, but still access them through the
-    help system.
+    return getattr(help_entry, 'key', 'unknown_topic')
+
+
+def can_read_topic(cmd_or_topic, account):
+    """Check if an account or puppet has read access to a help entry.
+
     Args:
         cmd_or_topic (Command, HelpEntry or FileHelpEntry): The topic/command to test.
-        caller: the caller checking for access.
+        account: the account or puppet checking for access.
+
     Returns:
-        bool: If command should be listed or not.
+        bool: If command can be viewed or not.
+
     Notes:
-        By default, the 'view' lock will be checked, and if no such lock is defined, the 'read'
-        lock will be used. If neither lock is defined, the help entry is assumed to be
-        accessible to all.
+        This uses the 'read' lock. If no 'read' lock is defined, the topic is assumed readable
+        by all.
+        Even if this returns False, the entry will still be visible in the help index unless
+        `can_list_topic` is also returning False.
     """
-    has_view = (
-        "view:" in cmd_or_topic.locks
-        if inherits_from(cmd_or_topic, "evennia.commands.command.Command")
-        else cmd_or_topic.locks.get("view")
-    )
-
-    if has_view:
-        return cmd_or_topic.access(caller, 'view', default=True)
+    if inherits_from(cmd_or_topic, "evennia.commands.command.Command"):
+        return cmd_or_topic.auto_help and cmd_or_topic.access(account, 'read', default=True)
     else:
-        # no explicit 'view' lock - use the 'read' lock
-        return cmd_or_topic.access(caller, 'read', default=True)
+        return cmd_or_topic.access(account, 'read', default=True)
 
 
-def collect_topics(account, mode='list'):
-        """
-        Collect help topics from all sources (cmd/db/file).
-        Args:
-            account (Object or Account): The user of the Command.
-            mode (str): One of 'list' or 'query', where the first means we are collecting to view
-                the help index and the second because of wanting to search for a specific help
-                entry/cmd to read. This determines which access should be checked.
-        Returns:
-            tuple: A tuple of three dicts containing the different types of help entries
-            in the order cmd-help, db-help, file-help:
-                `({key: cmd,...}, {key: dbentry,...}, {key: fileentry,...}`
-        """
-        # start with cmd-help
-        cmd_help_topics = []
-        if not str(account) == 'AnonymousUser':
-            # create list of account and account's puppets
-            puppets = account.db._playable_characters + [account]
-            # add the account's and puppets' commands to cmd_help_topics list
-            for puppet in puppets:
-                for cmdset in puppet.cmdset.get():
-                    # removing doublets in cmdset, caused by cmdhandler
-                    # having to allow doublet commands to manage exits etc.
-                    cmdset.make_unique(puppet)
-                    # retrieve all available commands and database / file-help topics.
-                    # also check the 'cmd:' lock here
-                    for cmd in cmdset:
-                        # skip the command if the puppet does not have access
-                        if not cmd.access(puppet, 'cmd'):
-                            continue
-                        # skip the command if it's help entry already exists in the topic list
-                        entry_exists = False
-                        for verify_cmd in cmd_help_topics:
-                            if verify_cmd.key and cmd.key and \
-                               verify_cmd.help_category == cmd.help_category and \
-                               verify_cmd.__doc__ == cmd.__doc__:
-                                entry_exists = True
-                                break
-                        if entry_exists:
-                            continue
-                        # add this command to the list
-                        cmd_help_topics.append(cmd)
-        # get all file-based help entries, checking perms
-        file_help_topics = {
-            topic.key.lower().strip(): topic
-            for topic in FILE_HELP_ENTRIES.all()
-        }
-        # get db-based help entries, checking perms
-        db_help_topics = {
-            topic.key.lower().strip(): topic
-            for topic in HelpEntry.objects.all()
-        }
-        if mode == 'list':
-            # check the view lock for all help entries/commands and determine key
-            cmd_help_topics = {
-                cmd.auto_help_display_key
-                if hasattr(cmd, "auto_help_display_key") else cmd.key: cmd
-                for cmd in cmd_help_topics if can_list_topic(cmd, account)}
-            db_help_topics = {
-                key: entry for key, entry in db_help_topics.items()
-                if can_list_topic(entry, account)
-            }
-            file_help_topics = {
-                key: entry for key, entry in file_help_topics.items()
-                if can_list_topic(entry, account)}
-        else:
-            # query
-            cmd_help_topics = {
-                cmd.auto_help_display_key
-                if hasattr(cmd, "auto_help_display_key") else cmd.key: cmd
-                for cmd in cmd_help_topics if can_read_topic(cmd, account)}
-            db_help_topics = {
-                key: entry for key, entry in db_help_topics.items()
-                if can_read_topic(entry, account)
-            }
-            file_help_topics = {
-                key: entry for key, entry in file_help_topics.items()
-                if can_read_topic(entry, account)}
+def collect_topics(account):
+    """Collect help topics from all sources (cmd/db/file).
 
-        return cmd_help_topics, db_help_topics, file_help_topics
+    Args:
+        account (Character or Account): Account or Character to collect help topics from.
+
+    Returns:
+        cmd_help_topics (dict): contains Command instances.
+        db_help_topics (dict): contains HelpEntry instances.
+        file_help_topics (dict): contains FileHelpEntry instances
+    """
+
+    # collect commands of account and all puppets
+    # skip a command if an entry is recorded with the same topics, category and help entry
+    cmd_help_topics = []
+    if not str(account) == 'AnonymousUser':
+        # create list of account and account's puppets
+        puppets = account.db._playable_characters + [account]
+        # add the account's and puppets' commands to cmd_help_topics list
+        for puppet in puppets:
+            for cmdset in puppet.cmdset.get():
+                # removing doublets in cmdset, caused by cmdhandler
+                # having to allow doublet commands to manage exits etc.
+                cmdset.make_unique(puppet)
+                # retrieve all available commands and database / file-help topics.
+                # also check the 'cmd:' lock here
+                for cmd in cmdset:
+                    # skip the command if the puppet does not have access
+                    if not cmd.access(puppet, 'cmd'):
+                        continue
+                    # skip the command if the puppet does not have read access
+                    if not can_read_topic(cmd, puppet):
+                        continue
+                    # skip the command if it's help entry already exists in the topic list
+                    entry_exists = False
+                    for verify_cmd in cmd_help_topics:
+                        if verify_cmd.key and cmd.key and \
+                           verify_cmd.help_category == cmd.help_category and \
+                           verify_cmd.__doc__ == cmd.__doc__:
+                            entry_exists = True
+                            break
+                    if entry_exists:
+                        continue
+                    # add this command to the list
+                    cmd_help_topics.append(cmd)
+
+    # Verify account has read access to filehelp entries and gather them into a dictionary
+    file_help_topics = {
+        topic.key.lower().strip(): topic
+        for topic in FILE_HELP_ENTRIES.all()
+        if can_read_topic(topic, account)
+    }
+
+    # Verify account has read access to database entries and gather them into a dictionary
+    db_help_topics = {
+        topic.key.lower().strip(): topic
+        for topic in HelpEntry.objects.all()
+        if can_read_topic(topic, account)
+    }
+
+    # Collect commands into a dictionary, read access verified at puppet level
+    cmd_help_topics = {
+        cmd.auto_help_display_key
+        if hasattr(cmd, "auto_help_display_key") else cmd.key: cmd
+        for cmd in cmd_help_topics
+    }
+
+    return cmd_help_topics, db_help_topics, file_help_topics
 
 
-class HelpMixin(TypeclassMixin):
+class HelpMixin():
     """
     This is a "mixin", a modifier of sorts.
 
@@ -202,21 +164,23 @@ class HelpMixin(TypeclassMixin):
         and other documentation that the current user is allowed to see.
 
         Returns:
-            queryset (QuerySet): List of Help entries available to the user.
+            queryset (list): List of Help entries available to the user.
 
         """
-        log_info('get_queryset')
         account = self.request.user
+
         # collect all help entries
-        cmd_help_topics, db_help_topics, file_help_topics = collect_topics(account, mode='query')
+        cmd_help_topics, db_help_topics, file_help_topics = collect_topics(account)
+
         # merge the entries
         file_db_help_topics = {**file_help_topics, **db_help_topics}
         all_topics = {**file_db_help_topics, **cmd_help_topics}
         all_entries = list(all_topics.values())
+
         # sort the entries
         all_entries = sorted(all_entries, key=get_help_topic)  # sort alphabetically
         all_entries.sort(key=get_help_category)  # group by categories
-        log_info('get_queryset success')
+
         return all_entries
 
 
@@ -242,12 +206,12 @@ class HelpDetailView(HelpMixin, DetailView):
     """
 
     # -- Django constructs --
+    # the html template to use when contructing the detail page for a help topic
     template_name = "website/help_detail.html"
 
     @property
     def page_title(self):
         # Makes sure the page has a sensible title.
-        # return "%s Detail" % self.typeclass._meta.verbose_name.title()
         obj = self.get_object()
         topic = get_help_topic(obj)
         return f'{topic} detail'
@@ -261,14 +225,15 @@ class HelpDetailView(HelpMixin, DetailView):
             context (dict): Django context object
 
         """
-        log_info('get_context_data')
         context = super().get_context_data(**kwargs)
 
-        # Get the object in question
-        obj = self.get_object()
-
-        # Get queryset and filter out non-related categories
+        # get a full query set
         full_set = self.get_queryset()
+
+        # Get the object in question
+        obj = self.get_object(full_set)
+
+        # filter non related caegories from the query set
         obj_category = get_help_category(obj)
         category_set = []
         for entry in full_set:
@@ -277,9 +242,7 @@ class HelpDetailView(HelpMixin, DetailView):
                 category_set.append(entry)
         context["topic_list"] = category_set
 
-        # log_info(f'category_set: {category_set}')
-
-        # Find the index position of the given obj in the queryset
+        # Find the index position of the given obj in the category set
         objs = list(category_set)
         for i, x in enumerate(objs):
             if obj is x:
@@ -298,7 +261,7 @@ class HelpDetailView(HelpMixin, DetailView):
         except:
             context["topic_previous"] = None
 
-        # Format the help entry using HTML instead of newlines
+        # Get the help entry text
         text = 'Failed to find entry.'
         if inherits_from(obj, "evennia.commands.command.Command"):
             text = obj.__doc__
@@ -308,7 +271,7 @@ class HelpDetailView(HelpMixin, DetailView):
             text = obj.entrytext
         text = strip_ansi(text)  # remove ansii markups
         context["entry_text"] = text.strip()
-        log_info('get_context_data success')
+
         return context
 
     def get_object(self, queryset=None):
@@ -316,11 +279,13 @@ class HelpDetailView(HelpMixin, DetailView):
         Override of Django hook that retrieves an object by category and topic
         instead of pk and slug.
 
+        Args:
+            queryset (list): A list of help entry objects.
+
         Returns:
-            entry (HelpEntry): HelpEntry requested in the URL.
+            entry (HelpEntry, FileHelpEntry or Command): HelpEntry requested in the URL.
 
         """
-        log_info('get_object start')
         # Get the queryset for the help entries the user can access
         if not queryset:
             queryset = self.get_queryset()
@@ -334,19 +299,18 @@ class HelpDetailView(HelpMixin, DetailView):
         for entry in queryset:
             # continue to next entry if the topics do not match
             entry_topic = get_help_topic(entry)
-            if not entry_topic.lower() == topic.replace('-', ' '):
+            if not slugify(entry_topic) == topic:
                 continue
             # if the category also matches, object requested is found
             entry_category = get_help_category(entry)
-            if entry_category.lower() == category.replace('-', ' '):
+            if slugify(entry_category) == category:
                 obj = entry
                 break
 
         # Check if this object was requested in a valid manner
         if not obj:
             return HttpResponseBadRequest(
-                f"No ({category}/{topic})s found matching the query"
+                f"No ({category}/{topic})s found matching the query."
             )
 
-        log_info(f'get_obj returning {obj}')
         return obj

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -1,6 +1,8 @@
 """
 Views to manipulate help entries.
 
+Multi entry object type supported added by DaveWithTheNiceHat 2021
+    Pull Request #2429
 """
 from django.utils.text import slugify
 from django.conf import settings
@@ -11,6 +13,7 @@ from evennia.help.models import HelpEntry
 from evennia.help.filehelp import FILE_HELP_ENTRIES
 from .mixins import TypeclassMixin
 from evennia.utils.logger import log_info
+from evennia.utils.ansi import strip_ansi
 
 DEFAULT_HELP_CATEGORY = settings.DEFAULT_HELP_CATEGORY
 
@@ -305,10 +308,8 @@ class HelpDetailView(HelpMixin, DetailView):
             text = obj.db_entrytext
         elif inherits_from(obj, "evennia.help.filehelp.FileHelpEntry"):
             text = obj.entrytext
-        text = text.replace("\r\n\r\n", "\n\n")
-        text = text.replace("\r\n", "\n")
-        text = text.replace("\n", "<br />")
-        context["entry_text"] = text
+        text = strip_ansi(text)  # remove ansii markups
+        context["entry_text"] = text.strip()
         log_info('get_context_data success')
         return context
 

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -33,7 +33,10 @@ def get_help_category(help_entry, slugify_cat=True):
     Returns:
         help_category (str): The category for the help entry.
     """
-    help_category = getattr(help_entry, 'help_category', DEFAULT_HELP_CATEGORY)
+    help_category = getattr(help_entry, 'help_category', None)
+    if not help_category:
+        help_category = getattr(help_entry, 'db_help_category', DEFAULT_HELP_CATEGORY)
+    # if one does not exist, create a category for ease of use with web views html templates
     if not hasattr(help_entry, 'web_help_category'):
         setattr(help_entry, 'web_help_category', slugify(help_category))
     return slugify(help_category) if slugify_cat else help_category
@@ -46,9 +49,16 @@ def get_help_topic(help_entry):
         help_entry (HelpEntry, FileHelpEntry or Command): Help entry instance.
 
     Returns:
-        topic (str): The topic of the help entry. Default is 'unknown_topic'.
+        help_topic (str): The topic of the help entry. Default is 'unknown_topic'.
     """
-    return getattr(help_entry, 'key', 'unknown_topic')
+    help_topic = getattr(help_entry, 'key', None)
+    # if object has no key, assume it is a db help entry.
+    if not help_topic:
+        help_topic = getattr(help_entry, 'db_key', 'unknown_topic')
+    # if one does not exist, create a key for ease of use with web views html templates
+    if not hasattr(help_entry, 'web_help_key'):
+        setattr(help_entry, 'web_help_key', slugify(help_topic))
+    return help_topic
 
 
 def can_read_topic(cmd_or_topic, account):

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -230,7 +230,7 @@ class HelpDetailView(HelpMixin, DetailView):
         # Get the object in question
         obj = self.get_object(full_set)
 
-        # filter non related caegories from the query set
+        # filter non related categories from the query set
         obj_category = get_help_category(obj)
         category_set = []
         for entry in full_set:

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -152,9 +152,6 @@ class HelpMixin():
 
     """
 
-    # -- Django constructs --
-    model = HelpEntry
-
     # -- Evennia constructs --
     page_title = "Help"
 

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -283,6 +283,10 @@ class HelpDetailView(HelpMixin, DetailView):
             entry (HelpEntry, FileHelpEntry or Command): HelpEntry requested in the URL.
 
         """
+
+        if hasattr(self, 'obj'):
+            return getattr(self, 'obj', None)
+
         # Get the queryset for the help entries the user can access
         if not queryset:
             queryset = self.get_queryset()
@@ -309,5 +313,8 @@ class HelpDetailView(HelpMixin, DetailView):
             return HttpResponseBadRequest(
                 f"No ({category}/{topic})s found matching the query."
             )
+        else:
+            # cache the object if one was found
+            self.obj = obj
 
         return obj

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -33,7 +33,7 @@ def get_help_category(help_entry, slugify_cat=True):
     Returns:
         help_category (str): The category for the help entry.
     """
-    help_category = help_entry.help_category if help_entry.help_category else DEFAULT_HELP_CATEGORY
+    help_category = getattr(help_entry, 'help_category', DEFAULT_HELP_CATEGORY)
     if not hasattr(help_entry, 'web_help_category'):
         setattr(help_entry, 'web_help_category', slugify(help_category))
     return slugify(help_category) if slugify_cat else help_category

--- a/evennia/web/website/views/help.py
+++ b/evennia/web/website/views/help.py
@@ -109,9 +109,11 @@ def collect_topics(account):
                     # skip the command if it's help entry already exists in the topic list
                     entry_exists = False
                     for verify_cmd in cmd_help_topics:
-                        if verify_cmd.key and cmd.key and \
-                           verify_cmd.help_category == cmd.help_category and \
-                           verify_cmd.__doc__ == cmd.__doc__:
+                        if (
+                                verify_cmd.key and cmd.key and
+                                verify_cmd.help_category == cmd.help_category and
+                                verify_cmd.__doc__ == cmd.__doc__
+                            ):
                             entry_exists = True
                             break
                     if entry_exists:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds command help entries (command doc strings) and web.


#### Motivation for adding to Evennia
Discussion: https://github.com/evennia/evennia/discussions/2426

#### Other info (issues closed, discussion etc)
Issues found as of yet:

File and command entries only
gray area above entry text does not show proper "Help Index / Category / Topic" format. Probably something that needs to be added to the context dictionary in get_contect_data.
entries need to convert from ascii to html. Or likely just drop ascii text tags all together.
In detail view category name is not showing above "context["topic_list"]", the gray list of other entries in the current category. Probably something that needs to the context dictionary in get_contect_data.

command entries only
The general category is not sorting with the other categories. Probably just case sensitivity?

Loads of log_infos throughout that need to be removed.
Better unit test HelpDetailTest in web/website/tests. It only tests url_name 'help-entry-detail'. Does not matter what the arguments are. It only capable of catching tracebacks or other code breaking errors.
locks need to be verified working.
HelpMixIn.get_queryset needs to support 'AnonymousUser'.
HelpMixIn.get_queryset needs to get commands from all of the user's Characters.
web.website.veiw.help.collect_topics I don't know enough to know if I should be looking for further command sets on the Character.