### PR TITLE
Change most links to https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Base docker image for running Evennia-based games in a container.
 #
 # Install:
-#   install `docker` (http://docker.com)
+#   install `docker` (https://docker.com)
 #
 # Usage:
 #    cd to a folder where you want your game data to be (or where it already is).

--- a/docs/README.md
+++ b/docs/README.md
@@ -486,8 +486,8 @@ to understand our friendly Google-style docstrings used in classes and functions
 [recommonmark]: https://recommonmark.readthedocs.io/en/latest/index.html
 [commonmark]: https://spec.commonmark.org/current/
 [commonmark-help]: https://commonmark.org/help/
-[sphinx-autodoc]: http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc
-[sphinx-napoleon]: http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+[sphinx-autodoc]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc
+[sphinx-napoleon]: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 [getting-started]: https://github.com/evennia/evennia/wiki/Getting-Started
 [contributing]: https://github.com/evennia/evennia/wiki/Contributing
 [ReST]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html

--- a/docs/source/Coding/Coding-Introduction.md
+++ b/docs/source/Coding/Coding-Introduction.md
@@ -20,7 +20,7 @@ take a look at our [Python introduction](../Howto/Starting/Part1/Python-basic-in
 
 When new to Evennia it can be hard to find things or figure out what is available. Evennia offers a
 special interactive python shell that allows you to experiment and try out things. It's recommended
-to use [ipython](http://ipython.org/) for this since the vanilla python prompt is very limited. Here
+to use [ipython](https://ipython.org/) for this since the vanilla python prompt is very limited. Here
 are some simple commands to get started:
 
     # [open a new console/terminal]
@@ -84,7 +84,7 @@ should just gracefully tell you what errors it finds, it can nevertheless be a g
 check your code for simple syntax errors *before* you load it into the running server.  There are
 many python syntax checkers out there. A fast and easy one is
 [pyflakes](https://pypi.python.org/pypi/pyflakes), a more verbose one is
-[pylint](http://www.pylint.org/). You can also check so that your code looks up to snuff using
+[pylint](https://www.pylint.org/). You can also check so that your code looks up to snuff using
 [pep8](https://pypi.python.org/pypi/pep8). Even with a syntax checker you will not be able to catch
 every possible problem - some bugs or problems will only appear when you actually run the code. But
 using such a checker can be a good start to weed out the simple problems.
@@ -131,7 +131,7 @@ call, but reading docs really *does* help you, promise! Evennia's documentation 
 and knowing what is possible can often give you a lot of new cool game ideas. That said, if you
 can't find the answer in the docs, don't be shy to ask questions! The [discussion
 group](https://sites.google.com/site/evenniaserver/discussions) and the [irc
-chat](http://webchat.freenode.net/?channels=evennia) are also there for you.
+chat](https://webchat.freenode.net/?channels=evennia) are also there for you.
 
 ### The most important point
 

--- a/docs/source/Coding/Unit-Testing.md
+++ b/docs/source/Coding/Unit-Testing.md
@@ -4,7 +4,7 @@
 *Unit testing* means testing components of a program in isolation from each other to make sure every
 part works on its own before using it with others. Extensive testing helps avoid new updates causing
 unexpected side effects as well as alleviates general code rot (a more comprehensive wikipedia
-article on unit testing can be found [here](http://en.wikipedia.org/wiki/Unit_test)).
+article on unit testing can be found [here](https://en.wikipedia.org/wiki/Unit_test)).
 
 A typical unit test set calls some function or method with a given input, looks at the result and
 makes sure that this result looks as expected. Rather than having lots of stand-alone test programs,
@@ -99,7 +99,7 @@ Example of a `TestCase` class:
 ```
 
 You might also want to read the [documentation for the unittest
-module](http://docs.python.org/library/unittest.html).
+module](https://docs.python.org/library/unittest.html).
 
 ### Using the EvenniaTest class
 

--- a/docs/source/Coding/Updating-Your-Game.md
+++ b/docs/source/Coding/Updating-Your-Game.md
@@ -8,7 +8,7 @@ the [Getting Started guide](../Setup/Setup-Quickstart) and get everything runnin
 
 Very commonly we make changes to the Evennia code to improve things. There are many ways to get told
 when to update: You can subscribe to the RSS feed or manually check up on the feeds from
-http://www.evennia.com. You can also simply fetch the latest regularly.
+https://www.evennia.com. You can also simply fetch the latest regularly.
 
 When you're wanting to apply updates, simply `cd` to your cloned `evennia` root directory and type:
 

--- a/docs/source/Coding/Using-Travis.md
+++ b/docs/source/Coding/Using-Travis.md
@@ -1,9 +1,9 @@
 # Using Travis
 
-Evennia uses [Travis CI](http://travis-ci.org/) to check that it's building successfully after every
+Evennia uses [Travis CI](https://travis-ci.org/) to check that it's building successfully after every
 commit to its Github repository (you can for example see the `build: passing` badge at the top of
 Evennia's [Readme file](https://github.com/evennia/evennia)). If your game is open source on Github
-you may also use Travis for free. See [the Travis docs](http://docs.travis-ci.com/user/getting-
+you may also use Travis for free. See [the Travis docs](https://docs.travis-ci.com/user/getting-
 started/) for how to get started.
 
 After logging in you will get to point Travis to your repository on github. One further thing you

--- a/docs/source/Coding/Version-Control.md
+++ b/docs/source/Coding/Version-Control.md
@@ -6,7 +6,7 @@ able to easily backtrack these changes, share your development efforts and more.
 contributing to Evennia itself, and only wish to develop your own MU* using Evennia, having a
 version control system in place is a good idea (and standard coding practice). For an introduction
 to the concept, start with the Wikipedia article
-[here](http://en.wikipedia.org/wiki/Version_control). Evennia uses the version control system
+[here](https://en.wikipedia.org/wiki/Version_control). Evennia uses the version control system
 [Git](https://git-scm.com/) and this is what will be covered henceforth. Note that this page also
 deals with commands for Linux operating systems, and the steps below may vary for other systems,
 however where possible links will be provided for alternative instructions.
@@ -18,7 +18,7 @@ documentation](https://help.github.com/articles/set-up-git#platform-all).
 
 If you have gotten Evennia installed, you will have Git already and can skip to **Step 2** below.
 Otherwise you will need to install Git on your platform. You can find expanded instructions for
-installation [here](http://git-scm.com/book/en/Getting-Started-Installing-Git).
+installation [here](https://git-scm.com/book/en/Getting-Started-Installing-Git).
 
 ### Step 1: Install Git
 
@@ -30,9 +30,9 @@ installation [here](http://git-scm.com/book/en/Getting-Started-Installing-Git).
 
         apt-get install git    
 
-- **Windows**: It is recommended to use [Git for Windows](http://msysgit.github.io/). 
+- **Windows**: It is recommended to use [Git for Windows](https://gitforwindows.org/). 
 - **Mac**:  Mac platforms offer two methods for installation, one via MacPorts, which you can find
-out about [here](http://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac), or
+out about [here](https://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac), or
 you can use the [Git OSX Installer](https://sourceforge.net/projects/git-osx-installer/).
  
 ### Step 2: Define user/e-mail Settings for Git
@@ -282,7 +282,7 @@ git merge master
 If everything went well, your `myfixes` branch will now have the latest version of Evennia merged
 with whatever changes you have done.  Use `git log` to see what has changed. You may need to restart
 the server or run `manage.py migrate` if the database schema changed (this will be seen in the
-commit log and on the mailing list). See the [Git manuals](http://git-scm.com/documentation) for
+commit log and on the mailing list). See the [Git manuals](https://git-scm.com/documentation) for
 learning more about useful day-to-day commands, and special situations such as dealing with merge
 collisions.
 

--- a/docs/source/Components/Attributes.md
+++ b/docs/source/Components/Attributes.md
@@ -201,7 +201,7 @@ With a single object, we mean anything that is *not iterable*, like numbers, str
 instances without the `__iter__` method.
 
 * You can generally store any non-iterable Python entity that can be
-  [pickled](http://docs.python.org/library/pickle.html).
+  [pickled](https://docs.python.org/library/pickle.html).
 * Single database objects/typeclasses can be stored as any other in the Attribute. These can
   normally *not* be pickled, but Evennia will behind the scenes convert them to an internal
   representation using their classname, database-id and creation-date with a microsecond precision,
@@ -327,7 +327,7 @@ instead of `_SaverList` and so on).
 
 
 Remember, this is only valid for *mutable* iterables.
-[Immutable](http://en.wikipedia.org/wiki/Immutable) objects (strings, numbers, tuples etc) are
+[Immutable](https://en.wikipedia.org/wiki/Immutable) objects (strings, numbers, tuples etc) are
 already disconnected from the database from the onset.
 
 ```python

--- a/docs/source/Components/Batch-Command-Processor.md
+++ b/docs/source/Components/Batch-Command-Processor.md
@@ -178,5 +178,5 @@ Processor](Batch-Code-Processor))
 *evennia mode*. This is an Emacs major mode found in `evennia/utils/evennia-mode.el`. It offers
 correct syntax highlighting and indentation with `<tab>` when editing `.ev` files in Emacs. See the
 header of that file for installation instructions.
-- [VIM](http://www.vim.org/) users can use amfl's [vim-evennia](https://github.com/amfl/vim-evennia)
+- [VIM](https://www.vim.org/) users can use amfl's [vim-evennia](https://github.com/amfl/vim-evennia)
 mode instead, see its readme for install instructions.

--- a/docs/source/Components/Batch-Processors.md
+++ b/docs/source/Components/Batch-Processors.md
@@ -44,7 +44,7 @@ encodings* below.
 ## A note on File Encodings
 
 As mentioned, both the processors take text files as input and then proceed to process them. As long
-as you stick to the standard [ASCII](http://en.wikipedia.org/wiki/Ascii) character set (which means
+as you stick to the standard [ASCII](https://en.wikipedia.org/wiki/Ascii) character set (which means
 the normal English characters, basically) you should not have to worry much about this section.
 
 Many languages however use characters outside the simple `ASCII` table. Common examples are various
@@ -52,7 +52,7 @@ apostrophes and umlauts but also completely different symbols like those of the 
 alphabets.
 
 First, we should make it clear that Evennia itself handles international characters just fine. It
-(and Django) uses [unicode](http://en.wikipedia.org/wiki/Unicode) strings internally.
+(and Django) uses [unicode](https://en.wikipedia.org/wiki/Unicode) strings internally.
 
 The problem is that when reading a text file like the batchfile, we need to know how to decode the
 byte-data stored therein to universal unicode. That means we need an *encoding* (a mapping) for how
@@ -74,7 +74,7 @@ file with lots of non-ASCII letters in the editor of your choice, then import to
 as it should.
 
 More help with encodings can be found in the entry [Text Encodings](../Concepts/Text-Encodings) and also in the
-Wikipedia article [here](http://en.wikipedia.org/wiki/Text_encodings).
+Wikipedia article [here](https://en.wikipedia.org/wiki/Text_encodings).
 
 **A footnote for the batch-code processor**: Just because *Evennia* can parse your file and your
 fancy special characters, doesn't mean that *Python* allows their use. Python syntax only allows

--- a/docs/source/Components/Coding-Utils.md
+++ b/docs/source/Components/Coding-Utils.md
@@ -202,7 +202,7 @@ will only catch immediate dependence). This function also accepts as input any c
 classes, instances or python-paths-to-classes.
 
 Note that Python code should usually work with [duck
-typing](http://en.wikipedia.org/wiki/Duck_typing). But in Evennia's case it can sometimes be useful
+typing](https://en.wikipedia.org/wiki/Duck_typing). But in Evennia's case it can sometimes be useful
 to check if an object inherits from a given [Typeclass](./Typeclasses) as a way of identification. Say
 for example that we have a typeclass *Animal*. This has a subclass *Felines* which in turn has a
 subclass *HouseCat*. Maybe there are a bunch of other animal types too, like horses and dogs. Using

--- a/docs/source/Components/Command-Sets.md
+++ b/docs/source/Components/Command-Sets.md
@@ -282,7 +282,7 @@ type **A** has, and which relative priorities the two sets have. By convention, 
 statement as "New command set **A** is merged onto the old command set **B** to form **?**".
 
 Below are the available merge types and how they work. Names are partly borrowed from [Set
-theory](http://en.wikipedia.org/wiki/Set_theory).
+theory](https://en.wikipedia.org/wiki/Set_theory).
 
 - **Union** (default) - The two cmdsets are merged so that as many commands as possible from each
 cmdset ends up in the merged cmdset. Same-key commands are merged by priority.

--- a/docs/source/Components/Commands.md
+++ b/docs/source/Components/Commands.md
@@ -218,9 +218,9 @@ from this method will be returned from the execution as a Twisted Deferred.
 - `at_post_cmd()` is called after `func()` to handle eventual cleanup.
 
 Finally, you should always make an informative [doc
-string](http://www.python.org/dev/peps/pep-0257/#what-is-a-docstring) (`__doc__`) at the top of your
-class. This string is dynamically read by the [Help System](./Help-System) to create the help entry
-for this command. You should decide on a way to format your help and stick to that.
+string](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring) (`__doc__`) at the top of
+your class. This string is dynamically read by the [Help System](./Help-System) to create the help
+entry for this command. You should decide on a way to format your help and stick to that.
 
 Below is how you define a simple alternative "`smile`" command:
 
@@ -288,7 +288,7 @@ that will be used). If you want to tell the parser to require a certain separato
 command name and its arguments (so that `get stone` works but `getstone` gives you a 'command not
 found' error) you can do so with the `arg_regex` property.
 
-The `arg_regex` is a [raw regular expression string](http://docs.python.org/library/re.html). The
+The `arg_regex` is a [raw regular expression string](https://docs.python.org/library/re.html). The
 regex will be compiled by the system at runtime. This allows you to customize how the part
 *immediately following* the command name (or alias) must look in order for the parser to match for
 this command. Some examples:
@@ -644,7 +644,7 @@ doing useful things.
 ## Assorted notes
 
 The return value of `Command.func()` is a Twisted
-[deferred](http://twistedmatrix.com/documents/current/core/howto/defer.html).
+[deferred](https://twistedmatrix.com/documents/current/core/howto/defer.html).
 Evennia does not use this return value at all by default. If you do, you must
 thus do so asynchronously, using callbacks.
 

--- a/docs/source/Components/Server-Conf.md
+++ b/docs/source/Components/Server-Conf.md
@@ -78,10 +78,10 @@ you often have to register with) in order to display what kind of game you are r
 - `portal_services_plugin.py` - this allows for adding your own custom services/protocols to the
 Portal. It must define one particular function that will be called by Evennia at startup. There can
 be any number of service plugin modules, all will be imported and used if defined. More info can be
-found [here](http://code.google.com/p/evennia/wiki/SessionProtocols#Adding_custom_Protocols).
+found [here](https://code.google.com/p/evennia/wiki/SessionProtocols#Adding_custom_Protocols).
 - `server_services_plugin.py` - this is equivalent to the previous one, but used for adding new
 services to the Server instead. More info can be found
-[here](http://code.google.com/p/evennia/wiki/SessionProtocols#Adding_custom_Protocols).
+[here](https://code.google.com/p/evennia/wiki/SessionProtocols#Adding_custom_Protocols).
 
 Some other Evennia systems can be customized by plugin modules but has no explicit template in
 `conf/`:

--- a/docs/source/Concepts/Async-Process.md
+++ b/docs/source/Concepts/Async-Process.md
@@ -227,7 +227,7 @@ expected, but they may appear with delays or in groups.
 ## Further reading
 
 Technically, `run_async` is just a very thin and simplified wrapper around a
-[Twisted Deferred](http://twistedmatrix.com/documents/9.0.0/core/howto/defer.html) object; the
+[Twisted Deferred](https://twistedmatrix.com/documents/9.0.0/core/howto/defer.html) object; the
 wrapper sets
 up a default errback also if none is supplied. If you know what you are doing there is nothing
 stopping you from bypassing the utility function, building a more sophisticated callback chain after

--- a/docs/source/Concepts/OOB.md
+++ b/docs/source/Concepts/OOB.md
@@ -79,16 +79,16 @@ translations described below.
 
 #### Telnet + GMCP
 
-[GMCP](http://www.gammon.com.au/gmcp), the *Generic Mud Communication Protocol* sends data on the
+[GMCP](https://www.gammon.com.au/gmcp), the *Generic Mud Communication Protocol* sends data on the
 form `cmdname + JSONdata`. Here the cmdname is expected to be on the form "Package.Subpackage".
 There could also be additional Sub-sub packages etc. The names of these 'packages' and 'subpackages'
 are not that well standardized beyond what individual MUDs or companies have chosen to go with over
 the years. You can decide on your own package names, but here are what others are using:
 
-- [Aardwolf GMCP](http://www.aardwolf.com/wiki/index.php/Clients/GMCP)
-- [Discworld GMCP](http://discworld.starturtle.net/lpc/playing/documentation.c?path=/concepts/gmcp)
-- [Avatar GMCP](http://www.outland.org/infusions/wiclear/index.php?title=MUD%20Protocols&lang=en)
-- [IRE games GMCP](http://nexus.ironrealms.com/GMCP)
+- [Aardwolf GMCP](https://www.aardwolf.com/wiki/index.php/Clients/GMCP)
+- [Discworld GMCP](https://discworld.starturtle.net/lpc/playing/documentation.c?path=/concepts/gmcp)
+- [Avatar GMCP](https://www.outland.org/infusions/wiclear/index.php?title=MUD%20Protocols&lang=en)
+- [IRE games GMCP](https://nexus.ironrealms.com/GMCP)
 
 Evennia will translate underscores to `.` and capitalize to fit the specification. So the
 outputcommand `foo_bar` will become a GMCP command-name `Foo.Bar`. A GMCP command "Foo.Bar" will be

--- a/docs/source/Concepts/Soft-Code.md
+++ b/docs/source/Concepts/Soft-Code.md
@@ -42,8 +42,8 @@ The `v()` function returns the `HELLO_VALUE.D` attribute on the object that the 
 
 If you are still curious about how Softcode works, take a look at some external resources:
 
-- http://www.tinymux.com/wiki/index.php/Softcode
-- http://www.duh.com/discordia/mushman/man2x1
+- https://wiki.tinymux.org/index.php/Softcode
+- https://www.duh.com/discordia/mushman/man2x1
 
 ## Problems with Softcode
 

--- a/docs/source/Concepts/Text-Encodings.md
+++ b/docs/source/Concepts/Text-Encodings.md
@@ -63,4 +63,4 @@ Note that having to try several different encodings every input/output adds
 unneccesary overhead. Try to guess the most common encodings you players will
 use and make sure these are tried first. The International *UTF-8* encoding is
 what Evennia assumes by default (and also what Python/Django use normally). See
-the Wikipedia article [here](http://en.wikipedia.org/wiki/Text_encodings) for more help.
+the Wikipedia article [here](https://en.wikipedia.org/wiki/Text_encodings) for more help.

--- a/docs/source/Concepts/Using-MUX-as-a-Standard.md
+++ b/docs/source/Concepts/Using-MUX-as-a-Standard.md
@@ -6,10 +6,10 @@ you could emulate that with Evennia. If you are ambitious you could even design 
 perfectly fitting your own dreams of the ideal game.
 
 We do offer a default however. The default Evennia setup tends to *resemble*
-[MUX2](http://www.tinymux.org/), and its cousins [PennMUSH](http://www.pennmush.org),
-[TinyMUSH](http://tinymush.sourceforge.net/), and [RhostMUSH](http://www.rhostmush.org/). While the
-reason for this similarity is partly historical, these codebases offer very mature feature sets for
-administration and building.
+[MUX2](https://www.tinymux.org/), and its cousins [PennMUSH](https://www.pennmush.org),
+[TinyMUSH](https://github.com/TinyMUSH/TinyMUSH/wiki), and [RhostMUSH](http://www.rhostmush.com/).
+While the reason for this similarity is partly historical, these codebases offer very mature feature
+sets for administration and building.
 
 Evennia is *not* a MUX system though. It works very differently in many ways. For example, Evennia
 deliberately lacks an online softcode language (a policy explained on our [softcode policy

--- a/docs/source/Contribs/Arxcode-installing-help.md
+++ b/docs/source/Contribs/Arxcode-installing-help.md
@@ -2,8 +2,8 @@
 
 ## Introduction 
 
-[Arx - After the Reckoning](http://play.arxmush.org/) is a big and very popular
-[Evennia](http://www.evennia.com)-based game. Arx is heavily roleplaying-centric, relying on game
+[Arx - After the Reckoning](https://play.arxmush.org/) is a big and very popular
+[Evennia](https://www.evennia.com)-based game. Arx is heavily roleplaying-centric, relying on game
 masters to drive the story. Technically it's maybe best described as "a MUSH, but with more coded
 systems". In August of 2018, the game's developer, Tehom, generously released the [source code of
 Arx on github](https://github.com/Arx-Game/arxcode). This is a treasure-trove for developers wanting
@@ -22,7 +22,7 @@ better match with the vanilla Evennia install.
 
 Firstly, set aside a folder/directory on your drive for everything to follow. 
 
-You need to start by installing [Evennia](http://www.evennia.com) by following most of the 
+You need to start by installing [Evennia](https://www.evennia.com) by following most of the 
 [Getting Started Instructions](../Setup/Setup-Quickstart) for your OS. The difference is that you need to `git clone
 https://github.com/TehomCD/evennia.git` instead of Evennia's repo because Arx uses TehomCD's older
 Evennia 0.8 [fork](https://github.com/TehomCD/evennia), notably still using Python2. This detail is
@@ -211,7 +211,7 @@ process is a little bit trickier.
  Make sure you have:
  * Git for Windows               https://git-scm.com/download/win
  * Anaconda for Windows          https://www.anaconda.com/distribution/
- * VC++ Compiler for Python 2.7  http://aka.ms/vcpython27
+ * VC++ Compiler for Python 2.7  https://aka.ms/vcpython27
 
 conda update conda
 conda create -n arx python=2.7

--- a/docs/source/Contribs/Building-menus.md
+++ b/docs/source/Contribs/Building-menus.md
@@ -170,7 +170,7 @@ probably not appear in your MUD client):
 ```
 > look
 Limbo(#2)
-Welcome to your new Evennia-based game! Visit http://www.evennia.com if you need
+Welcome to your new Evennia-based game! Visit https://www.evennia.com if you need
 help, want to contribute, report issues or just join the community.
 As Account #1 you can create a demo/tutorial area with @batchcommand tutorial_world.build.
 
@@ -222,7 +222,7 @@ Closing the building menu.
 
 > look
 A beautiful meadow(#2)
-Welcome to your new Evennia-based game! Visit http://www.evennia.com if you need
+Welcome to your new Evennia-based game! Visit https://www.evennia.com if you need
 help, want to contribute, report issues or just join the community.
 As Account #1 you can create a demo/tutorial area with @batchcommand tutorial_world.build.
 ```
@@ -329,7 +329,7 @@ Building menu: A beautiful meadow
 
  [K]ey: A beautiful meadow
  [D]escription: 
-   Welcome to your new Evennia-based game! Visit http://www.evennia.com if you need
+   Welcome to your new Evennia-based game! Visit https://www.evennia.com if you need
 help, want to contribute, report issues or just join the community.
 As Account #1 you can create a demo/tutorial area with @batchcommand tutorial_world.build.
  [Q]uit this editor
@@ -337,7 +337,7 @@ As Account #1 you can create a demo/tutorial area with @batchcommand tutorial_wo
 > d
 
 ----------Line Editor [editor]----------------------------------------------------
-01| Welcome to your new |wEvennia|n-based game! Visit http://www.evennia.com if you need
+01| Welcome to your new |wEvennia|n-based game! Visit https://www.evennia.com if you need
 02| help, want to contribute, report issues or just join the community.
 03| As Account #1 you can create a demo/tutorial area with |w@batchcommand tutorial_world.build|n.
 

--- a/docs/source/Contribs/Static-In-Game-Map.md
+++ b/docs/source/Contribs/Static-In-Game-Map.md
@@ -55,11 +55,11 @@ Our map will be in-game text but that doesn't mean we're restricted to the norma
 you've ever selected the [Wingdings font](https://en.wikipedia.org/wiki/Wingdings) in Microsoft Word
 you will know there are a multitude of other characters around to use. When creating your game with
 Evennia you have access to the [UTF-8 character encoding](https://en.wikipedia.org/wiki/UTF-8) which
-put at your disposal [thousands of letters, number and geometric shapes](http://mcdlr.com/utf-8/#1).
+put at your disposal [thousands of letters, number and geometric shapes](https://mcdlr.com/utf-8/#1).
 
 For this exercise, we've copy-and-pasted from the pallet of special characters used over at 
-[Dwarf Fortress](http://dwarffortresswiki.org/index.php/Character_table) to create what is hopefully a
-pleasing and easy to understood landscape:
+[Dwarf Fortress](https://dwarffortresswiki.org/index.php/Character_table) to create what is hopefully
+a pleasing and easy to understood landscape:
 
 ```
 ≈≈↑↑↑↑↑∩∩

--- a/docs/source/Contributing-Docs.md
+++ b/docs/source/Contributing-Docs.md
@@ -688,8 +688,8 @@ to understand our friendly Google-style docstrings used in classes and functions
 [recommonmark](https://recommonmark.readthedocs.io/en/latest/index.html)
 [commonmark](https://spec.commonmark.org/current/)
 [commonmark-help](https://commonmark.org/help/)
-[sphinx-autodoc](http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc)
-[sphinx-napoleon](http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html)
+[sphinx-autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc)
+[sphinx-napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html)
 [getting-started]: Setup/Setup-Quickstart
 [contributing]: ./Contributing
 [ReST](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)

--- a/docs/source/Contributing.md
+++ b/docs/source/Contributing.md
@@ -56,7 +56,7 @@ above. But for small, well isolated fixes you are also welcome to submit your su
 fixes/addendums as a [patch][patch].
 
 You can include your patch in an Issue or a Mailing list post. Please avoid pasting the full patch
-text directly in your post though, best is to use a site like [Pastebin](http://pastebin.com/) and
+text directly in your post though, best is to use a site like [Pastebin](https://pastebin.com/) and
 just supply the link. 
 
 ## Contributing with Contribs

--- a/docs/source/Evennia-Introduction.md
+++ b/docs/source/Evennia-Introduction.md
@@ -5,10 +5,10 @@ Domain) is a multiplayer real-time virtual world described primarily in text. MU
 of role-playing games, hack and slash, player versus player, interactive fiction and online chat.
 Players can read or view descriptions of rooms, objects, other players, non-player characters, and
 actions performed in the virtual world. Players typically interact with each other and the world by
-typing commands that resemble a natural language.* - [Wikipedia](http://en.wikipedia.org/wiki/MUD)
+typing commands that resemble a natural language.* - [Wikipedia](https://en.wikipedia.org/wiki/MUD)
 
 If you are reading this, it's quite likely you are dreaming of creating and running a text-based
-massively-multiplayer game ([MUD/MUX/MUSH](http://tinyurl.com/c5sc4bm) etc) of your very own. You
+massively-multiplayer game ([MUD/MUX/MUSH](https://tinyurl.com/c5sc4bm) etc) of your very own. You
 might just be starting to think about it, or you might have lugged around that *perfect* game in
 your mind for years ... you know *just* how good it would be, if you could only make it come to
 reality. We know how you feel. That is, after all, why Evennia came to be.
@@ -79,17 +79,17 @@ page](Links#wiki-litterature) for some reading suggestions. To efficiently code 
 Evennia you don't need to be a Python guru, but you do need to be able to read example code
 containing at least these basic Python features:
 
-- Importing and using python [modules](http://docs.python.org/3.7/tutorial/modules.html)
-- Using [variables](http://www.tutorialspoint.com/python/python_variable_types.htm), [conditional
-statements](http://docs.python.org/tutorial/controlflow.html#if-statements),
-[loops](http://docs.python.org/tutorial/controlflow.html#for-statements) and
-[functions](http://docs.python.org/tutorial/controlflow.html#defining-functions)
+- Importing and using python [modules](https://docs.python.org/3.7/tutorial/modules.html)
+- Using [variables](https://www.tutorialspoint.com/python/python_variable_types.htm), [conditional
+statements](https://docs.python.org/tutorial/controlflow.html#if-statements),
+[loops](https://docs.python.org/tutorial/controlflow.html#for-statements) and
+[functions](https://docs.python.org/tutorial/controlflow.html#defining-functions)
 - Using [lists, dictionaries and list
-comprehensions](http://docs.python.org/tutorial/datastructures.html)
-- Doing [string handling and formatting](http://docs.python.org/tutorial/introduction.html#strings)
+comprehensions](https://docs.python.org/tutorial/datastructures.html)
+- Doing [string handling and formatting](https://docs.python.org/tutorial/introduction.html#strings)
 - Have a basic understanding of [object-oriented
-programming](http://www.tutorialspoint.com/python/python_classes_objects.htm), using
-[Classes](http://docs.python.org/tutorial/classes.html), their methods and properties
+programming](https://www.tutorialspoint.com/python/python_classes_objects.htm), using
+[Classes](https://docs.python.org/tutorial/classes.html), their methods and properties
 
 Obviously, the more things you feel comfortable with, the easier time you'll have to find your way.
 With just basic knowledge you should be able to define your own [Commands](Components/Commands), create custom
@@ -120,9 +120,9 @@ Some more hints:
 1. Get engaged in the community. Make an introductory post to our [mailing
 list/forum](https://groups.google.com/forum/#!forum/evennia) and get to know people. It's also
 highly recommended you hop onto our [Developer
-chat](http://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
+chat](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
 on IRC. This allows you to chat directly with other developers new and old as well as with the devs
-of Evennia itself. This chat is logged (you can find links on http://www.evennia.com) and can also
+of Evennia itself. This chat is logged (you can find links on https://www.evennia.com) and can also
 be searched from the same place for discussion topics you are interested in.
 2. Read the [Game Planning](Howto/Starting/Part2/Game-Planning) wiki page. It gives some ideas for your work flow and the
 state of mind you should aim for - including cutting down the scope of your game for its first

--- a/docs/source/How-To-Get-And-Give-Help.md
+++ b/docs/source/How-To-Get-And-Give-Help.md
@@ -54,13 +54,13 @@ issues by putting up a monetary [bounty][bountysource] on it.
 
 
 [form]: https://docs.google.com/spreadsheet/viewform?hl=en_US&formkey=dGN0VlJXMWpCT3VHaHpscDEzY1RoZGc6MQ#gid=0
-[group]:http://groups.google.com/group/evennia/
+[group]:https://groups.google.com/group/evennia/
 [issues]:https://github.com/evennia/evennia/issues
 [issues-master]:https://github.com/evennia/evennia/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3Amaster-branch
-[chat]: http://webchat.freenode.net/?channels=evennia
+[chat]: https://webchat.freenode.net/?channels=evennia
 [paypal]: https://www.paypal.com/se/cgi-bin/webscr?cmd=_flow&SESSION=Z-VlOvfGjYq2qvCDOUGpb6C8Due7skT0qOklQEy5EbaD1f0eyEQaYlmCc8O&dispatch=5885d80a13c0db1f8e263663d3faee8d64ad11bbf4d2a5a1a0d303a50933f9b2
-[donate-img]: http://images-focus-opensocial.googleusercontent.com/gadgets/proxy?url=https://www.paypalobjects.com/en%255fUS/SE/i/btn/btn%255fdonateCC%255fLG.gif&container=focus&gadget=a&rewriteMime=image/*
+[donate-img]: https://images-focus-opensocial.googleusercontent.com/gadgets/proxy?url=https://www.paypalobjects.com/en%255fUS/SE/i/btn/btn%255fdonateCC%255fLG.gif&container=focus&gadget=a&rewriteMime=image/*
 [patreon]: https://www.patreon.com/griatch
-[patreon-img]: http://www.evennia.com/_/rsrc/1424724909023/home/evennia_patreon_100x100.png
+[patreon-img]: https://www.evennia.com/_/rsrc/1424724909023/home/evennia_patreon_100x100.png
 [issues-bounties]:https://github.com/evennia/evennia/labels/bounty
 [bountysource]: https://www.bountysource.com/teams/evennia

--- a/docs/source/Howto/Add-a-wiki-on-your-website.md
+++ b/docs/source/Howto/Add-a-wiki-on-your-website.md
@@ -8,13 +8,13 @@
 This tutorial will provide a step-by-step process to installing a wiki on your website.
 Fortunately, you don't have to create the features manually, since it has been done by others, and
 we can integrate their work quite easily with Django.  I have decided to focus on
-the [Django-wiki](http://django-wiki.readthedocs.io/).
+the [Django-wiki](https://django-wiki.readthedocs.io/).
 
 > Note: this article has been updated for Evennia 0.9.  If you're not yet using this version, be
 careful, as the django wiki doesn't support Python 2 anymore.  (Remove this note when enough time
 has passed.)
 
-The [Django-wiki](http://django-wiki.readthedocs.io/) offers a lot of features associated with
+The [Django-wiki](https://django-wiki.readthedocs.io/) offers a lot of features associated with
 wikis, is
 actively maintained (at this time, anyway), and isn't too difficult to install in Evennia.  You can
 see a [demonstration of Django-wiki here](https://demo.django.wiki).

--- a/docs/source/Howto/Command-Duration.md
+++ b/docs/source/Howto/Command-Duration.md
@@ -119,7 +119,7 @@ Looking at it you might think that `utils.delay(10, callback)` in the code above
 alternative to some more familiar thing like `time.sleep(10)`. This is *not* the case. If you do
 `time.sleep(10)` you will in fact freeze the *entire server* for ten seconds! The `utils.delay()`is
 a thin wrapper around a Twisted
-[Deferred](http://twistedmatrix.com/documents/11.0.0/core/howto/defer.html) that will delay
+[Deferred](https://twistedmatrix.com/documents/11.0.0/core/howto/defer.html) that will delay
 execution until 10 seconds have passed, but will do so asynchronously, without bothering anyone else
 (not even you - you can continue to do stuff normally while it waits to continue).
 

--- a/docs/source/Howto/Evennia-for-MUSH-Users.md
+++ b/docs/source/Howto/Evennia-for-MUSH-Users.md
@@ -1,7 +1,7 @@
 # Evennia for MUSH Users
 
 *This page is adopted from an article originally posted for the MUSH community [here on
-musoapbox.net](http://musoapbox.net/topic/1150/evennia-for-mushers).*
+musoapbox.net](https://musoapbox.net/topic/1150/evennia-for-mushers).*
 
 [MUSH](https://en.wikipedia.org/wiki/MUSH)es are text multiplayer games traditionally used for
 heavily roleplay-focused game styles. They are often (but not always) utilizing game masters and
@@ -138,7 +138,7 @@ Note that Python cares about indentation, so make sure to indent with the same n
 shown above!
 
 So what happens above? We [import the
-module](http://www.linuxtopia.org/online_books/programming_books/python_programming/python_ch28s03.html)
+module](https://www.linuxtopia.org/online_books/programming_books/python_programming/python_ch28s03.html)
 `evennia/contrib/multidescer.py` at the top. Once imported we can access stuff inside that module
 using full stop (`.`). The multidescer is defined as a class `CmdMultiDesc` (we could find this out
 by opening said module in a text editor). At the bottom we create a new instance of this class and
@@ -217,5 +217,5 @@ to try out. If you feel you want a more visual overview you can also look at
 [Evennia in pictures](https://evennia.blogspot.se/2016/05/evennia-in-pictures.html).
 
 … And of course, if you need further help you can always drop into the [Evennia
-chatroom](http://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
+chatroom](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
 or post a question in our [forum/mailing list](https://groups.google.com/forum/#%21forum/evennia)!

--- a/docs/source/Howto/Starting/Part1/Python-basic-introduction.md
+++ b/docs/source/Howto/Starting/Part1/Python-basic-introduction.md
@@ -1,7 +1,7 @@
 # Starting to code Evennia
 
-Time to dip our toe into some coding! Evennia is written and extended in [Python](http://python.org), which
-is a mature and professional programming language that is very fast to work with.
+Time to dip our toe into some coding! Evennia is written and extended in [Python](https://python.org),
+which is a mature and professional programming language that is very fast to work with.
 
 That said, even though Python is widely considered easy to learn, we can only cover the most immediately
 important aspects of Python in this series of starting tutorials. Hopefully we can get you started

--- a/docs/source/Howto/Starting/Part2/Game-Planning.md
+++ b/docs/source/Howto/Starting/Part2/Game-Planning.md
@@ -193,7 +193,7 @@ pre-alpha games are allowed in the index so don't be shy)!
 ## Beta Release/Perpetual Beta
 
 Once things stabilize in Alpha you can move to *Beta* and let more people in. Many MUDs are in
-[perpetual beta](http://en.wikipedia.org/wiki/Perpetual_beta), meaning they are never considered
+[perpetual beta](https://en.wikipedia.org/wiki/Perpetual_beta), meaning they are never considered
 "finished", but just repeat the cycle of Planning, Coding, Testing and Building over and over as new
 features get implemented or Players come with suggestions. As the game designer it is now up to you
 to gradually perfect your vision.

--- a/docs/source/Howto/Starting/Part3/Implementing-a-game-rule-system.md
+++ b/docs/source/Howto/Starting/Part3/Implementing-a-game-rule-system.md
@@ -52,7 +52,7 @@ to look at the Ainneve [Trait
 handler](https://github.com/evennia/ainneve/blob/master/world/traits.py). Finally you could even go
 with a [custom django model](../../../Concepts/New-Models). Which is the better depends on your game and the
 complexity of your system.
-- Make a clear [API](http://en.wikipedia.org/wiki/Application_programming_interface) into your
+- Make a clear [API](https://en.wikipedia.org/wiki/Application_programming_interface) into your
 rules. That is, make methods/functions that you feed with, say, your Character and which skill you
 want to check. That is, you want something similar to this:
 

--- a/docs/source/Howto/Starting/Part3/Tutorial-for-basic-MUSH-like-game.md
+++ b/docs/source/Howto/Starting/Part3/Tutorial-for-basic-MUSH-like-game.md
@@ -2,7 +2,7 @@
 
 
 This tutorial lets you code a small but complete and functioning MUSH-like game in Evennia. A
-[MUSH](http://en.wikipedia.org/wiki/MUSH) is, for our purposes, a class of roleplay-centric games
+[MUSH](https://en.wikipedia.org/wiki/MUSH) is, for our purposes, a class of roleplay-centric games
 focused on free form storytelling. Even if you are not interested in MUSH:es, this is still a good
 first game-type to try since it's not so code heavy. You will be able to use the same principles for
 building other types of games.

--- a/docs/source/Howto/Starting/Part5/Web-Tutorial.md
+++ b/docs/source/Howto/Starting/Part5/Web-Tutorial.md
@@ -18,10 +18,10 @@ you might have an app for conducting polls, or an app for showing news posts or,
 creating a web client.
 
 Each of these applications has a `urls.py` file, which specifies what
-[URL](http://en.wikipedia.org/wiki/Uniform_resource_locator)s are used by the app, a `views.py` file
+[URL](https://en.wikipedia.org/wiki/Uniform_resource_locator)s are used by the app, a `views.py` file
 for the code that the URLs activate, a `templates` directory for displaying the results of that code
-in [HTML](http://en.wikipedia.org/wiki/Html) for the user, and a `static` folder that holds assets
-like [CSS](http://en.wikipedia.org/wiki/CSS), [Javascript](http://en.wikipedia.org/wiki/Javascript),
+in [HTML](https://en.wikipedia.org/wiki/Html) for the user, and a `static` folder that holds assets
+like [CSS](https://en.wikipedia.org/wiki/CSS), [Javascript](https://en.wikipedia.org/wiki/Javascript),
 and Image files (You may note your mygame/web folder does not have a `static` or `template` folder.
 This is intended and explained further below). Django applications may also have a `models.py` file
 for storing information in the database. We will not change any models here, take a look at the 

--- a/docs/source/Licensing.md
+++ b/docs/source/Licensing.md
@@ -1,7 +1,7 @@
 # Licensing
 
 
-Evennia is licensed under the very friendly [BSD](http://en.wikipedia.org/wiki/BSD_license)
+Evennia is licensed under the very friendly [BSD](https://en.wikipedia.org/wiki/BSD_license)
 (3-clause) license.  You can find the license as
 [LICENSE.txt](https://github.com/evennia/evennia/blob/master/LICENSE.txt) in the Evennia
 repository's root.

--- a/docs/source/Links.md
+++ b/docs/source/Links.md
@@ -4,22 +4,22 @@
 
 ### Official Evennia links
 
-- [evennia.com](http://www.evennia.com) - Main Evennia portal page. Links to all corners of Evennia.
+- [evennia.com](https://www.evennia.com) - Main Evennia portal page. Links to all corners of Evennia.
 - [Evennia github page](https://github.com/evennia/evennia) - Download code and read documentation.
 - [Evennia official chat
-channel](http://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
+channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
 - Our official IRC chat #evennia at irc.freenode.net:6667.
-- [Evennia forums/mailing list](http://groups.google.com/group/evennia) - Web interface to our
+- [Evennia forums/mailing list](https://groups.google.com/group/evennia) - Web interface to our
 google group.
-- [Evennia development blog](http://evennia.blogspot.se/) - Musings from the lead developer.
-- [Evennia's manual on ReadTheDocs](http://readthedocs.org/projects/evennia/) - Read and download
+- [Evennia development blog](https://evennia.blogspot.com/) - Musings from the lead developer.
+- [Evennia's manual on ReadTheDocs](https://readthedocs.org/projects/evennia/) - Read and download
 offline in html, PDF or epub formats.
 - [Evennia Game Index](http://games.evennia.com/) - An automated listing of Evennia games.
 ----
 - [Evennia on Open Hub](https://www.openhub.net/p/6906)
 - [Evennia on OpenHatch](https://openhatch.org/projects/Evennia)
 - [Evennia on PyPi](https://pypi.python.org/pypi/Evennia-MUD-Server/)
-- [Evennia subreddit](http://www.reddit.com/r/Evennia/) (not much there yet though)
+- [Evennia subreddit](https://www.reddit.com/r/Evennia/) (not much there yet though)
 
 ### Third-party Evennia utilities and resources
 
@@ -40,7 +40,7 @@ _Blackbirds_ Evennia game project.
 Evennia game dir with batchcode to build the custom _Hackers_ style cyberspace zone with puzzles and
 challenges [used during the conference](https://dcdark.net/home#).
 - [Arx sources](https://github.com/Arx-Game/arxcode) - Open-source code release of the very popular
-[Arx](http://play.arxmush.org/) Evennia game. [Here are instructions for installing](Arxcode-
+[Arx](https://play.arxmush.org/) Evennia game. [Here are instructions for installing](Arxcode-
 installing-help)
 - [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your
 website.
@@ -54,12 +54,12 @@ here](https://www.reddit.com/r/MUD/comments/6z6s3j/encarnia_an_evennia_python_mu
 - [The world of Cool battles sources](https://github.com/FlutterSprite/coolbattles) - Open source
 turn-based battle system for Evennia. It also has a [live demo](http://wcb.battlestudio.com/).
 - [nextRPI](https://github.com/cluebyte/nextrpi) - A github project for making a toolbox for people
-to make [RPI](http://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
+to make [RPI](https://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
 - [Muddery](https://github.com/muddery/muddery) - A mud framework under development, based on an
 older fork of Evennia. It has some specific design goals for building and extending the game based
 on input files.
 - [vim-evennia](https://github.com/amfl/vim-evennia) - A mode for editing batch-build files (`.ev`)
-files in the [vim](http://www.vim.org/) text editor (Emacs users can use [evennia-
+files in the [vim](https://www.vim.org/) text editor (Emacs users can use [evennia-
 mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mode.el)).
 - [Other Evennia-related repos on github](https://github.com/search?p=1&q=evennia)
 ----
@@ -69,11 +69,11 @@ Tutorial videos explaining installing Evennia, basic Python etc.
 container](https://www.docker.com/) for quick install and deployment in just a few commands.
 - [Evennia's docs in Chinese](http://www.evenniacn.com/) - A translated mirror of a slightly older
 Evennia version. Announcement [here](https://groups.google.com/forum/#!topic/evennia/3AXS8ZTzJaA).
-- [Evennia for MUSHers](http://musoapbox.net/topic/1150/evennia-for-mushers) - An article describing
+- [Evennia for MUSHers](https://musoapbox.net/topic/1150/evennia-for-mushers) - An article describing
 Evennia for those used to the MUSH way of doing things.
 - *[Language Understanding for Text games using Deep reinforcement
 learning](http://news.mit.edu/2015/learning-language-playing-computer-games-0924#_msocom_1)*
-([PDF](http://people.csail.mit.edu/karthikn/pdfs/mud-play15.pdf)) - MIT research paper using Evennia
+([PDF](https://people.csail.mit.edu/karthikn/pdfs/mud-play15.pdf)) - MIT research paper using Evennia
 to train AIs.
 
 ### Other useful mud development resources
@@ -86,7 +86,7 @@ Python objects.
 
 - [MUD Coder's Guild](https://mudcoders.com/) - A blog and [associated Slack
 channel](https://slack.mudcoders.com/) with discussions on MUD development.
-- [MuSoapbox](http://www.musoapbox.net/) - Very active Mu* game community mainly focused on MUSH-
+- [MuSoapbox](https://www.musoapbox.net/) - Very active Mu* game community mainly focused on MUSH-
 type gaming.
 - [Imaginary Realities](http://journal.imaginary-realities.com/) - An e-magazine on game and MUD
 design that has several articles about Evennia. There is also an [archive of older
@@ -107,16 +107,16 @@ Influential mailing list active 1996-2004. Advanced game design discussions.
 - [Mud-dev wiki](http://mud-dev.wikidot.com/) - A (very) slowly growing resource on MUD creation.
 - [Mud Client/Server Interaction](http://cryosphere.net/mud-protocol.html) - A page on classic MUD
 telnet protocols.
-- [Mud Tech's fun/cool but ...](http://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-
+- [Mud Tech's fun/cool but ...](https://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-
 ship-damned-thing/) - Greg Taylor gives good advice on mud design.
-- [Lost Library of MOO](http://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in
+- [Lost Library of MOO](https://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in
 particular moo).
 - [Nick Gammon's hints thread](http://www.gammon.com.au/forum/bbshowpost.php?bbsubject_id=5959) -
 Contains a very useful list of things to think about when starting your new MUD.
 - [Lost Garden](http://www.lostgarden.com/) - A game development blog with long and interesting
 articles (not MUD-specific)
 - [What Games Are](http://whatgamesare.com/) - A blog about general game design (not MUD-specific)
-- [The Alexandrian](http://thealexandrian.net/) - A blog about tabletop roleplaying and board games,
+- [The Alexandrian](https://thealexandrian.net/) - A blog about tabletop roleplaying and board games,
 but with lots of general discussion about rule systems and game balance that could be applicable
 also for MUDs.
 - [Raph Koster's laws of game design](https://www.raphkoster.com/games/laws-of-online-world-
@@ -125,7 +125,7 @@ when designing a virtual multiplayer world (Raph is known for *Ultima Online* am
 
 ### Literature
 
-- Richard Bartle *Designing Virtual Worlds*  ([amazon page](http://www.amazon.com/Designing-Virtual-
+- Richard Bartle *Designing Virtual Worlds*  ([amazon page](https://www.amazon.com/Designing-Virtual-
 Worlds-Richard-Bartle/dp/0131018167)) - Essential reading for the design of any persistent game
 world, written by the co-creator of the original game *MUD*. Published in 2003 but it's still as
 relevant now as when it came out. Covers everything you need to know and then some.
@@ -134,15 +134,15 @@ the imposing name this book is for the absolute Python/programming beginner. One
 by gradually creating a small text game! It has been used by multiple users before moving on to
 Evennia. *Update: This used to be free to read online, this is no longer the case.*
 - David M. Beazley *Python Essential Reference (4th ed)* ([amazon
-page](http://www.amazon.com/Python-Essential-Reference-David-Beazley/dp/0672329786/)) - Our
+page](https://www.amazon.com/Python-Essential-Reference-David-Beazley/dp/0672329786/)) - Our
 recommended book on Python; it not only efficiently summarizes the language but is also an excellent
 reference to the standard library for more experienced Python coders.
 - Luciano Ramalho, *Fluent Python* ([o'reilly
-page](http://shop.oreilly.com/product/0636920032519.do)) - This is an excellent book for experienced
+page](https://shop.oreilly.com/product/0636920032519.do)) - This is an excellent book for experienced
 Python coders willing to take their code to the next level. A great read with a lot of useful info
 also for veteran Pythonistas.
 - Richard Cantillon *An Essay on Economic Theory* ([free
-pdf](http://mises.org/books/essay_on_economic_theory_cantillon.pdf)) - A very good English
+pdf](https://mises.org/books/essay_on_economic_theory_cantillon.pdf)) - A very good English
 translation of *Essai sur la Nature du Commerce en Général*, one of the foundations of modern
 economic theory. Written in 1730 but the translation is annotated and the essay is actually very
 easy to follow also for a modern reader. Required reading if you think of implementing a sane game
@@ -150,26 +150,26 @@ economic system.
 
 ### Frameworks
 
-- [Django's homepage](http://www.djangoproject.com/)
- - [Documentation](http://docs.djangoproject.com/en)
- - [Code](http://code.djangoproject.com/)
-- [Twisted homepage](http://twistedmatrix.com/)
- - [Documentation](http://twistedmatrix.com/documents/current/core/howto/index.html)
- - [Code](http://twistedmatrix.com/trac/browser)
+- [Django's homepage](https://www.djangoproject.com/)
+ - [Documentation](https://docs.djangoproject.com/en)
+ - [Code](https://code.djangoproject.com/)
+- [Twisted homepage](https://twistedmatrix.com/)
+ - [Documentation](https://twistedmatrix.com/documents/current/core/howto/index.html)
+ - [Code](https://twistedmatrix.com/trac/browser)
 
 ### Tools
 
-- [GIT](http://git-scm.com/)
- - [Documentation](http://git-scm.com/documentation)
- - [Learn GIT in 15 minutes](http://try.github.io/levels/1/challenges/1) (interactive tutorial)
+- [GIT](https://git-scm.com/)
+ - [Documentation](https://git-scm.com/documentation)
+ - [Learn GIT in 15 minutes](https://try.github.io/levels/1/challenges/1) (interactive tutorial)
  
 ### Python Info
 
-- [Python Website](http://www.python.org/)
- - [Documentation](http://www.python.org/doc/)
- - [Tutorial](http://docs.python.org/tut/tut.html)
- - [Library Reference](http://docs.python.org/lib/lib.html)
- - [Language Reference](http://docs.python.org/ref/ref.html)
- - [Python tips and tricks](http://www.siafoo.net/article/52)
+- [Python Website](https://www.python.org/)
+ - [Documentation](https://www.python.org/doc/)
+ - [Tutorial](https://docs.python.org/tut/tut.html)
+ - [Library Reference](https://docs.python.org/lib/lib.html)
+ - [Language Reference](https://docs.python.org/ref/ref.html)
+ - [Python tips and tricks](https://www.siafoo.net/article/52)
  - [Jetbrains Python academy](https://hyperskill.org/onboarding?track=python) - free online
 programming curriculum for different skill levels

--- a/docs/source/Setup/Apache-Config.md
+++ b/docs/source/Setup/Apache-Config.md
@@ -59,7 +59,7 @@ You'll then want to reload or restart apache2 after changing the configurations.
 With any luck, you'll be able to point your browser at your domain or subdomain that you set up in
 your vhost and see the nifty default Evennia webpage. If not, read the hopefully informative error
 message and work from there. Questions may be directed to our [Evennia Community
-site](http://evennia.com).
+site](https://evennia.com).
 
 ### A note on code reloading
 

--- a/docs/source/Setup/Choosing-An-SQL-Server.md
+++ b/docs/source/Setup/Choosing-An-SQL-Server.md
@@ -7,10 +7,10 @@ This page gives an overview of the supported SQL databases as well as instructio
  - PostgreSQL
  - MySQL / MariaDB
 
-Since Evennia uses [Django](http://djangoproject.com), most of our notes are based off of what we
+Since Evennia uses [Django](https://djangoproject.com), most of our notes are based off of what we
 know from the community and their documentation. While the information below may be useful, you can
 always find the most up-to-date and "correct" information at Django's [Notes about supported
-Databases](http://docs.djangoproject.com/en/dev/ref/databases/#ref-databases) page.
+Databases](https://docs.djangoproject.com/en/dev/ref/databases/#ref-databases) page.
 
 ## SQLite3
 
@@ -338,5 +338,5 @@ database.
 ## Others
 
 No testing has been performed with Oracle, but it is also supported through Django. There are
-community maintained drivers for [MS SQL](http://code.google.com/p/django-mssql/) and possibly a few
+community maintained drivers for [MS SQL](https://code.google.com/p/django-mssql/) and possibly a few
 others. If you try other databases out, consider expanding this page with instructions.

--- a/docs/source/Setup/Client-Support-Grid.md
+++ b/docs/source/Setup/Client-Support-Grid.md
@@ -71,22 +71,22 @@ new [documentation issue](github:issue) for it. Everyone's encouraged to report 
 .. _Evennia Webclient: ../Components/Webclient.html
 .. _tintin++: http://tintin.sourceforge.net/
 .. _tinyfugue: http://tinyfugue.sourceforge.net/
-.. _MUSHclient: http://mushclient.com/
+.. _MUSHclient: https://mushclient.com/
 .. _Zmud: http://forums.zuggsoft.com/index.php?page=4&action=file&file_id=65
 .. _Cmud: http://forums.zuggsoft.com/index.php?page=4&action=category&cat_id=11
-.. _Potato: http://www.potatomushclient.com/
-.. _Mudlet: http://www.mudlet.org/
+.. _Potato: https://www.potatomushclient.com/
+.. _Mudlet: https://www.mudlet.org/
 .. _SimpleMU: https://archive.org/details/tucows_196173_SimpleMU_MU_Client
-.. _Atlantis: http://www.riverdark.net/atlantis/
+.. _Atlantis: https://www.riverdark.net/atlantis/
 .. _GMUD: https://sourceforge.net/projects/g-mud/
 .. _BeipMU: http://www.beipmu.com/
 .. _MudRammer: https://itunes.apple.com/us/app/mudrammer-a-modern-mud-client/id597157072
 .. _MUDMaster: https://itunes.apple.com/us/app/mudmaster/id341160033
-.. _BlowTorch: http://bt.happygoatstudios.com/
+.. _BlowTorch: https://bt.happygoatstudios.com/
 .. _Mukluk: https://play.google.com/store/apps/details?id=com.crap.mukluk
 .. _Gnome-MUD: https://github.com/GNOME/gnome-mud
 .. _Spyrit: https://spyrit.ierne.eu.org/
-.. _JamochaMUD: http://jamochamud.org/
+.. _JamochaMUD: https://jamochamud.org/
 .. _DuckClient: http://duckclient.com/
 .. _KildClient: https://www.kildclient.org/
 

--- a/docs/source/Setup/Evennia-Game-Index.md
+++ b/docs/source/Setup/Evennia-Game-Index.md
@@ -45,7 +45,7 @@ GAME_INDEX_LISTING = {
     # optional 
     'long_description':
         "Longer description that can use Markdown like *bold*, _italic_"
-        "and [linkname](http://link.com). Use \n for line breaks."
+        "and [linkname](https://link.com). Use \n for line breaks."
     'telnet_hostname': 'dummy.com',            
     'telnet_port': '1234',                     
     'web_client_url': 'dummy.com/webclient',   

--- a/docs/source/Setup/Extended-Installation.md
+++ b/docs/source/Setup/Extended-Installation.md
@@ -48,21 +48,21 @@ everything in the following sections.
 - Windows (Vista, Win7, Win8, Win10)
 - Mac OSX (>=10.5 recommended)
 
-- [Python](http://www.python.org) (v3.7, 3.8 and 3.9 are tested)
-  - [virtualenv](http://pypi.python.org/pypi/virtualenv) for making isolated
+- [Python](https://www.python.org) (v3.7, 3.8 and 3.9 are tested)
+  - [virtualenv](https://pypi.python.org/pypi/virtualenv) for making isolated
     Python environments. Installed with `pip install virtualenv`.
 
-- [GIT](http://git-scm.com/) - version control software for getting and
+- [GIT](https://git-scm.com/) - version control software for getting and
 updating Evennia itself - Mac users can use the
-[git-osx-installer](http://code.google.com/p/git-osx-installer/) or the
-[MacPorts version](http://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac).
-- [Twisted](http://twistedmatrix.com) (v19.0+)
-  - [ZopeInterface](http://www.zope.org/Products/ZopeInterface) (v3.0+)  - usually included in
+[git-osx-installer](https://code.google.com/p/git-osx-installer/) or the
+[MacPorts version](https://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac).
+- [Twisted](https://twistedmatrix.com) (v19.0+)
+  - [ZopeInterface](https://www.zope.org/Products/ZopeInterface) (v3.0+)  - usually included in
 Twisted packages
   - Linux/Mac users may need the `gcc` and `python-dev` packages or equivalent.
   - Windows users need [MS Visual C++](https://aka.ms/vs/16/release/vs_buildtools.exe) and *maybe*
 [pypiwin32](https://pypi.python.org/pypi/pypiwin32).
-- [Django](http://www.djangoproject.com) (v2.2.x), be warned that latest dev
+- [Django](https://www.djangoproject.com) (v2.2.x), be warned that latest dev
   version is usually untested with Evennia)
 
 ## Linux Install
@@ -182,17 +182,17 @@ created. Check out [where to go next](./Getting-Started#where-to-go-next).
 
 The Evennia server is a terminal program. Open the terminal e.g. from
 *Applications->Utilities->Terminal*. [Here is an introduction to the Mac
-terminal](http://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line)
+terminal](https://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line)
 if you are unsure how it works. If you run into any issues during the
 installation, please check out [Mac Troubleshooting](./Getting-Started#mac-troubleshooting).
 
 * Python should already be installed but you must make sure it's a high enough version.
-([This](http://docs.python-guide.org/en/latest/starting/install/osx/) discusses
+([This](https://docs.python-guide.org/en/latest/starting/install/osx/) discusses
  how you may upgrade it). Remember that you need Python3.7, not Python2.7!
 * GIT can be obtained with
-[git-osx-installer](http://code.google.com/p/git-osx-installer/) or via
+[git-osx-installer](https://code.google.com/p/git-osx-installer/) or via
 MacPorts [as described
-here](http://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac).
+here](https://git-scm.com/book/en/Getting-Started-Installing-Git#Installing-on-Mac).
 * If you run into issues with installing `Twisted` later you may need to
 install gcc and the Python headers.
 
@@ -302,7 +302,7 @@ If you run into any issues during the installation, please check out
 The Evennia server itself is a command line program. In the Windows launch
 menu, start *All Programs -> Accessories -> command prompt* and you will get
 the Windows command line interface. Here is [one of many tutorials on using the Windows command
-line](http://www.bleepingcomputer.com/tutorials/windows-command-prompt-introduction/)
+line](https://www.bleepingcomputer.com/tutorials/windows-command-prompt-introduction/)
 if you are unfamiliar with it.
 
 * Install Python [from the Python homepage](https://www.python.org/downloads/windows/). You will
@@ -314,7 +314,7 @@ to check-mark *all* install options, especially the one about making Python
 available on the path (you may have to scroll to see it)**. This allows you to
 just write `python` in any console without first finding where the `python`
 program actually sits on your hard drive.
-* You need to also get [GIT](http://git-scm.com/downloads) and install it. You
+* You need to also get [GIT](https://git-scm.com/downloads) and install it. You
 can use the default install options but when you get asked to "Adjust your PATH
 environment", you should select the second option "Use Git from the Windows
 Command Prompt", which gives you more freedom as to where you can use the
@@ -472,7 +472,7 @@ combat systems. You can find the [growing list of contribs
 here](https://github.com/evennia/evennia/blob/master/evennia/contrib/README.md).
 
 If you have any questions, you can always ask in [the developer
-chat](http://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
+chat](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
 `#evennia` on `irc.freenode.net` or by posting to the [Evennia
 forums](https://groups.google.com/forum/#%21forum/evennia). You can also join the [Discord
 Server](https://discord.gg/NecFePw).

--- a/docs/source/Setup/Grapevine.md
+++ b/docs/source/Setup/Grapevine.md
@@ -1,7 +1,7 @@
 # Grapevine
 
 
-[Grapevine](http://grapevine.haus) is a new chat network for `MU*`*** games. By
+[Grapevine](https://grapevine.haus) is a new chat network for `MU*`*** games. By
 connecting an in-game channel to the grapevine network, players on your game
 can chat with players in other games, also non-Evennia ones.
 

--- a/docs/source/Setup/How-to-connect-Evennia-to-Twitter.md
+++ b/docs/source/Setup/How-to-connect-Evennia-to-Twitter.md
@@ -1,7 +1,7 @@
 # How to connect Evennia to Twitter
 
 
-[Twitter](http://en.wikipedia.org/wiki/twitter) is an online social networking service that enables
+[Twitter](https://en.wikipedia.org/wiki/twitter) is an online social networking service that enables
 users to send and read short 280-character messages called "tweets". Following is a short tutorial
 explaining how to enable users to send tweets from inside Evennia.
 

--- a/docs/source/Setup/IRC.md
+++ b/docs/source/Setup/IRC.md
@@ -5,12 +5,12 @@ _Disambiguation: This page is related to using IRC inside an Evennia game. To jo
 Evennia IRC chat, connect to irc.freenode.net and join #evennia. Alternatively, you can [join our
 Discord](https://discord.gg/NecFePw), which is mirrored to IRC._
 
-[IRC (Internet Relay Chat)](http://en.wikipedia.org/wiki/Internet_Relay_Chat) is a long standing
+[IRC (Internet Relay Chat)](https://en.wikipedia.org/wiki/Internet_Relay_Chat) is a long standing
 chat protocol used by many open-source projects for communicating in real time. By connecting one of
 Evennia's [Channels](../Components/Communications) to an IRC channel you can communicate also with people not on
 an mud themselves. You can also use IRC if you are only running your Evennia MUD locally on your
 computer (your game doesn't need to be open to the public)! All you need is an internet connection.
-For IRC operation you also need [twisted.words](http://twistedmatrix.com/trac/wiki/TwistedWords).
+For IRC operation you also need [twisted.words](https://twistedmatrix.com/trac/wiki/TwistedWords).
 This is available simply as a package *python-twisted-words* in many Linux distros, or directly
 downloadable from the link.
 
@@ -40,7 +40,7 @@ if you like), but for testing, let's set up a new channel `irc`.
 You will automatically join the new channel.
 
 Next we will create a connection to an external IRC network and channel. There are many, many IRC
-nets. [Here is a list](http://www.irchelp.org/irchelp/networks/popular.html) of some of the biggest
+nets. [Here is a list](https://www.irchelp.org/networks/popular.html) of some of the biggest
 ones, the one you choose is not really very important unless you want to connect to a particular
 channel (also make sure that the network allows for "bots" to connect).
 

--- a/docs/source/Setup/Online-Setup.md
+++ b/docs/source/Setup/Online-Setup.md
@@ -294,7 +294,7 @@ your game. What you need is to alias it to a more sensible domain name - an alia
 around also when the IP changes.
 
 1. To set up a domain name alias, we recommend starting with a free domain name from
-[FreeDNS](http://freedns.afraid.org/). Once you register there (it's free) you have access to tens
+[FreeDNS](https://freedns.afraid.org/). Once you register there (it's free) you have access to tens
 of thousands domain names that people have "donated" to allow you to use for your own sub domain.
 For example, `strangled.net` is one of those available domains. So tying our IP address to
 `strangled.net` using the subdomain `evennia` would mean that one could henceforth direct people to
@@ -305,7 +305,7 @@ and tell FreeDNS that. There are many alternatives to be found from FreeDNS:s ho
 works on multiple platforms is [inadyn](http://www.inatech.eu/inadyn/). Get it from their page or,
 in Linux, through something like `apt-get install inadyn`.
 1. Next, you login to your account on FreeDNS and go to the
-[Dynamic](http://freedns.afraid.org/dynamic/) page. You should have a list of your subdomains. Click
+[Dynamic](https://freedns.afraid.org/dynamic/) page. You should have a list of your subdomains. Click
 the `Direct URL` link and you'll get a page with a text message. Ignore that and look at the URL of
 the page. It should be ending in a lot of random letters. Everything after the question mark is your
 unique "hash". Copy this string.
@@ -405,10 +405,10 @@ servers with this option as they don't have a lot of support.
 [Linode][11] | Cloud | $5/month / on-demand | Multiple regions. Smallest option provides 1GB RAM
 *Please help us expand this list.*
 
-[1]: http:silvren.com
+[1]: https://silvren.com
 [2](https://www.digitalocean.com/pricing)
 [3](https://aws.amazon.com/pricing/)
-[4](http://www.genesismuds.com/)
+[4](https://www.genesismuds.com/)
 [5](https://www.host1plus.com/)
 [6](https://www.scaleway.com/)
 [7](https://lowendbox.com/)

--- a/docs/source/Setup/Online-Setup.md
+++ b/docs/source/Setup/Online-Setup.md
@@ -32,7 +32,7 @@ terminal.
 > Note: If you need to close the log-view, use `Ctrl-C`. Use just `evennia --log` on its own to
 start tailing the logs again.
  - Make sure you can connect with your web browser to `http://localhost:4001` or, alternatively,
-`http:127.0.0.1:4001` which is the same thing. You should get your Evennia web site and be able to
+`http://127.0.0.1:4001` which is the same thing. You should get your Evennia web site and be able to
 play the game in the web client. Also check so that you can connect with a mud client to host
 `localhost`, port `4000` or host `127.0.0.1`, port `4000`.
 - [Google for "my ip"](https://www.google.se/search?q=my+ip) or use any online service to figure out

--- a/docs/source/Setup/RSS.md
+++ b/docs/source/Setup/RSS.md
@@ -1,7 +1,7 @@
 # RSS
 
 
-[RSS](http://en.wikipedia.org/wiki/RSS) is a format for easily tracking updates on websites. The
+[RSS](https://en.wikipedia.org/wiki/RSS) is a format for easily tracking updates on websites. The
 principle is simple - whenever a site is updated, a small text file is updated. An RSS reader can
 then regularly go online, check this file for updates and let the user know what's new.
 
@@ -10,11 +10,11 @@ the feed will be conveniently echoed to the channel. There are many potential us
 example the MUD might use a separate website to host its forums. Through RSS, the players can then
 be notified when new posts are made. Another example is to let everyone know you updated your dev
 blog. Admins might also want to track the latest Evennia updates through our own RSS feed
-[here](http://code.google.com/feeds/p/evennia/updates/basic).
+[here](https://code.google.com/feeds/p/evennia/updates/basic).
 
 ## Configuring RSS
 
-To use RSS, you first need to install the [feedparser](http://code.google.com/p/feedparser/) python
+To use RSS, you first need to install the [feedparser](https://code.google.com/p/feedparser/) python
 module.
 
     pip install feedparser

--- a/docs/source/_templates/links.html
+++ b/docs/source/_templates/links.html
@@ -3,9 +3,9 @@
   <li><a href="https://www.evennia.com">Home page</a> </li>
   <li><a href="https://github.com/evennia/evennia">Evennia Github</a> </li>
   <li><a href="http://games.evennia.com">Game Index</a> </li>
-  <li><a href="http://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb">IRC</a> - 
+  <li><a href="https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb">IRC</a> - 
     <a href="https://discord.gg/NecFePw">Discord</a> - 
       <a href="https://groups.google.com/forum/#%21forum/evennia">Forums</a>
   </li>
-  <li><a href="http://evennia.blogspot.com/">Evennia Dev blog</a> </li>
+  <li><a href="https://evennia.blogspot.com/">Evennia Dev blog</a> </li>
 </ul>

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,7 +13,7 @@
 
 # Evennia Documentation
 
-This is the manual of [Evennia](http://www.evennia.com), the open source Python
+This is the manual of [Evennia](https://www.evennia.com), the open source Python
 `MU*` creation system.
 
 - [Evennia Introduction](./Evennia-Introduction)

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         "Issue tracker": "https://github.com/evennia/evennia/issues",
         "Chat": "http://www.evennia.com/chat-redirect-3",
         "Forum": "https://groups.google.com/forum/#%21forum/evennia",
-        "Dev Blog": "http://evennia.blogspot.com/",
+        "Dev Blog": "https://evennia.blogspot.com/",
         "Patreon": "https://www.patreon.com/griatch",
     },
 )


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR changes most links in the site/docs/codebase from http to https.

This is not a blanket find-and-replace. I have made a good effort to check that every link I change still works. (Examples: https://games.evennia.com does not work, and thus has not been changed. References to localhost also remain http.)

#### Motivation for adding to Evennia

The usage of https improves security for users.
References: https://www.cloudflare.com/learning/ssl/why-use-https/, https://www.eff.org/https-everywhere

Most sites automatically redirect the user to https, but some do not. Changing the links in the source means that users don't accidentally end up on an insecure portal.

#### Other info (issues closed, discussion etc)

I noticed the link to blogspot on the homepage used http and thought "Hey, I can fix that..."
I may have become distracted :)