### PR TITLE
evennia.utils.format_grid duplicate rows fix

### DIFF
--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -1943,6 +1943,7 @@ def format_grid(elements, width=78, sep="  ", verbatim_elements=None):
                     else:
                         row += " " * max(0, width - lrow)
                     rows.append(row)
+                    row = ""
                     ic = 0
                 else:
                     # add a new slot


### PR DESCRIPTION
#### Brief overview of PR changes/additions
evennia.utils.format_grid did not reset the row variable after extending past the grid.
Resulting in duplicate rows.
Looks like it only happens when the second to the last element in the row extends into the space that the last element should be in.

Verified issue is in basic evennia game with no code changes (a "mygame" instance).

Example of instance without fix:
![image](https://user-images.githubusercontent.com/54369722/123495346-5c75f100-d5f1-11eb-847c-3b6e18a9b52f.png)

After the fix:
![image](https://user-images.githubusercontent.com/54369722/123495473-d5754880-d5f1-11eb-85b9-12027f00cb90.png)

#### Motivation for adding to Evennia
Avoid duplicate rows in help command.

#### Other info (issues closed, discussion etc)
