### PR TITLE
[DEVEL] Fix typeclass dropdown and make it always show all of the available typeclasses

### DIFF
--- a/evennia/web/admin/accounts.py
+++ b/evennia/web/admin/accounts.py
@@ -59,7 +59,7 @@ class AccountChangeForm(UserChangeForm):
         help_text="This is the Python-path to the class implementing the actual account functionality. "
         "You usually don't need to change this from the default.<BR>"
         "If your custom class is not found here, it may not be imported as part of Evennia's startup.",
-        choices=adminutils.get_and_load_typeclasses(parent=AccountDB),
+        choices=lambda: adminutils.get_and_load_typeclasses(parent=AccountDB),
     )
 
     db_lock_storage = forms.CharField(

--- a/evennia/web/admin/accounts.py
+++ b/evennia/web/admin/accounts.py
@@ -58,7 +58,7 @@ class AccountChangeForm(UserChangeForm):
         label="Typeclass",
         help_text="This is the Python-path to the class implementing the actual account functionality. "
         "You usually don't need to change this from the default.<BR>"
-        "If your custom class is not found here, it may not be imported as part of Evennia's startup.",
+        "If your custom class is not found here, it may not be imported into Evennia yet.",
         choices=lambda: adminutils.get_and_load_typeclasses(parent=AccountDB),
     )
 

--- a/evennia/web/admin/objects.py
+++ b/evennia/web/admin/objects.py
@@ -63,7 +63,7 @@ class ObjectCreateForm(forms.ModelForm):
         help_text="This is the Python-path to the class implementing the actual functionality. "
         f"<BR>If you are creating a Character you usually need <B>{settings.BASE_CHARACTER_TYPECLASS}</B> "
         "or a subclass of that. <BR>If your custom class is not found in the list, it may not be imported "
-        "as part of Evennia's startup.",
+        "into Evennia yet.",
         choices=lambda: adminutils.get_and_load_typeclasses(parent=ObjectDB))
 
     db_lock_storage = forms.CharField( label="Locks",

--- a/evennia/web/admin/objects.py
+++ b/evennia/web/admin/objects.py
@@ -64,7 +64,7 @@ class ObjectCreateForm(forms.ModelForm):
         f"<BR>If you are creating a Character you usually need <B>{settings.BASE_CHARACTER_TYPECLASS}</B> "
         "or a subclass of that. <BR>If your custom class is not found in the list, it may not be imported "
         "as part of Evennia's startup.",
-        choices=adminutils.get_and_load_typeclasses(parent=ObjectDB))
+        choices=lambda: adminutils.get_and_load_typeclasses(parent=ObjectDB))
 
     db_lock_storage = forms.CharField( label="Locks",
         required=False,

--- a/evennia/web/admin/scripts.py
+++ b/evennia/web/admin/scripts.py
@@ -22,7 +22,7 @@ class ScriptForm(forms.ModelForm):
     db_typeclass_path = forms.ChoiceField(
         label="Typeclass",
         help_text="This is the Python-path to the class implementing the actual script functionality. "
-        "<BR>If your custom class is not found here, it may not be imported as part of Evennia's startup.",
+        "<BR>If your custom class is not found here, it may not be imported into Evennia yet.",
         choices=lambda: adminutils.get_and_load_typeclasses(
             parent=ScriptDB, excluded_parents=["evennia.prototypes.prototypes.DbPrototype"])
     )

--- a/evennia/web/admin/scripts.py
+++ b/evennia/web/admin/scripts.py
@@ -23,7 +23,7 @@ class ScriptForm(forms.ModelForm):
         label="Typeclass",
         help_text="This is the Python-path to the class implementing the actual script functionality. "
         "<BR>If your custom class is not found here, it may not be imported as part of Evennia's startup.",
-        choices=adminutils.get_and_load_typeclasses(
+        choices=lambda: adminutils.get_and_load_typeclasses(
             parent=ScriptDB, excluded_parents=["evennia.prototypes.prototypes.DbPrototype"])
     )
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fixes the issue I reported, #2461 where typeclasses are not shown in the admin site.

#### Motivation for adding to Evennia
If this _isn't_ merged, then any time I open an account or an object or a script from the admin site and dare to make a change it'll overwrite the typeclass with one of Evennia's default typeclasses. This should also occur for a stock project, so it's recommended to make this change.

#### Other info (issues closed, discussion etc)
Apparently, you can pass lambda expressions as the choices in a ChoiceField and this will cause Django to call that in order to get the list of choices. I just added `lambda: ` before the call to `adminutils.get_and_load_typeclasses` and it immediately fixed the problem.

![image](https://user-images.githubusercontent.com/56974578/123626147-6887cb80-d808-11eb-8e64-35ed8e49fed7.png)
(My project uses "share.objects.Object" as the default object typeclass, which wasn't showing up before.)