### PR TITLE
evennia.commands.default.building.CmdDesc.edit_handler force access r…

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -651,6 +651,7 @@ class CmdDesc(COMMAND_DEFAULT_CLASS):
 
         if not (obj.access(self.caller, "control") or obj.access(self.caller, "edit")):
             self.caller.msg("You don't have permission to edit the description of %s." % obj.key)
+            return
 
         self.caller.db.evmenu_target = obj
         # launch the editor


### PR DESCRIPTION
#### Brief overview of PR changes/additions
evennia.commands.default.buidling.edit_handler did not return after checking access restrictions. Resulting in editing when the command caller did not have access.

#### Motivation for adding to Evennia
To enforce admin intended access restrictions.

#### Other info (issues closed, discussion etc)
My only test of this was to make the change and run all evennia unit tests, on an unchanged version of evennia.
I in no way explored this. My project overrides CmdDesc, It is not advantageous for me to spend time on it.
I did want to point this out with a solution incase this was not the desired behavior. For all I know maybe the access restriction is working and I just don't understand how.

An opinion, "You can't describe oblivion." would not be a helpful error message for most people. If I ran a command and received that message I would not peace that together with my puppet not having a location.