### PR TITLE
Update evennia.js

### DIFF
--- a/evennia/web/webclient/static/webclient/js/evennia.js
+++ b/evennia/web/webclient/static/webclient/js/evennia.js
@@ -195,7 +195,7 @@ An "emitter" object must have a function
         //     to listen to cmdname events.
         //
         var on = function (cmdname, listener) {
-            if (typeof(listener === 'function')) {
+            if (typeof(listener) === 'function') {
                 listeners[cmdname] = listener;
             };
         };


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fix for misplaced parens-- previous code checked 'is the output of `typeof(listener === 'function')` truthy', which is equivalent of `typeof(boolean)` which is always true. This patch changes it to check for a comparison between the stringified type of listener and the string 'function', which is more likely to be the expected behavior.

#### Motivation for adding to Evennia

Fixing a minor nit.

#### Other info (issues closed, discussion etc)

No issue filed for this yet, it was faster to just write the PR.