### PR TITLE
Fix exception leaking when spawning XYRoom Nodes

### DIFF
--- a/evennia/contrib/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/xyzgrid/xymap_legend.py
@@ -18,8 +18,10 @@ except ImportError as err:
 
 import uuid
 from collections import defaultdict
+
+from django.core import exceptions as django_exceptions
 from evennia.prototypes import spawner
-from evennia.utils.utils import make_iter
+
 from .utils import MAPSCAN, REVERSE_DIRECTIONS, MapParserError, BIGVAL
 
 NodeTypeclass = None
@@ -309,7 +311,7 @@ class MapNode:
 
         try:
             nodeobj = NodeTypeclass.objects.get_xyz(xyz=xyz)
-        except NodeTypeclass.DoesNotExist:
+        except django_exceptions.ObjectDoesNotExist:
             # create a new entity with proper coordinates etc
             tclass = self.prototype['typeclass']
             tclass = (f' ({tclass})'
@@ -433,7 +435,7 @@ class MapNode:
 
         try:
             nodeobj = NodeTypeclass.objects.get_xyz(xyz=xyz)
-        except NodeTypeclass.DoesNotExist:
+        except django_exceptions.ObjectDoesNotExist:
             # no object exists
             pass
         else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The code attempts to get a specific Room, creating it when it does not exist.
If you use a custom typeclass it seems the exception being caught is of the custom type while
the exception being raised is the base xyroom's exception so it leaks out.

This PR catches the base django.ObjectDoesNotExist so it is guaranteed to catch any exceptions about the object not existing.
It allowed the rooms to spawn normally.

#### Motivation for adding to Evennia

Fixes an issue with XYZGrid Contrib that prevents it from being used with custom room typeclass

#### Other info (issues closed, discussion etc)

I did an Import Optimize with Pycharm which seems to have removed
from evennia.utils.utils import make_iter
