### PR TITLE
Getting Started: more troubleshooting info

### DIFF
--- a/docs/source/Getting-Started.md
+++ b/docs/source/Getting-Started.md
@@ -486,6 +486,9 @@ you can run `evennia -l`, or (in the future) start the server with `evennia star
 - Under some not-updated Linux distributions you may run into errors with a
   too-old `setuptools` or missing `functools`. If so, update your environment
   with `pip install --upgrade pip wheel setuptools`. Then try `pip install -e evennia` again.
+- If you get an `setup.py not found` error message while trying to `pip install`, make sure you are
+  in the right directory. You should be at the same level of the `evenv` directory, and the
+  `evennia` git repository. Note that there is an `evennia` directory inside of the repository too.
 - One user reported a rare issue on Ubuntu 16 is an install error on installing Twisted; `Command
 "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-vnIFTg/twisted/` with errors
 like `distutils.errors.DistutilsError: Could not find suitable distribution for


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Issues #2434 or #2070 show that the installation guide can be a little
bit confusing regarding on which directory should the user be when
trying to pip install.

This commit adds an entry on the Troubleshooting section, in hopes of
helping those who stumble with that process.