### PR TITLE
Webclient authentication sometimes fails (fixes #2562)

### DIFF
--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -49,7 +49,7 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
 
     # nonce value, used to prevent the webclient from erasing the
     # webclient_authenticated_uid value of csession on disconnect
-    nonce = None
+    nonce = 0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -143,7 +143,7 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
             # set *before* this disconnect (disconnect called after a new client
             # connects, which occurs in some 'fast' browsers like Google Chrome
             # and Mobile Safari)
-            if csession.get("webclient_authenticated_nonce", None) == self.nonce:
+            if csession.get("webclient_authenticated_nonce", 0) == self.nonce:
                 csession["webclient_authenticated_uid"] = None
                 csession["webclient_authenticated_nonce"] = 0
                 csession.save()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fixes an issue where the webclient authentication sometimes stores a recently deleted guest Account's id in the session, which leads to errors.

#### Motivation for adding to Evennia
Removing these errors from my build, so that guests can log in more than once.

#### Other info (issues closed, discussion etc)
Fixes #2562.