### PR TITLE
dbserialize fix to support Python 3.10

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -19,8 +19,8 @@ be out of sync with the database.
 
 """
 from functools import update_wrapper
-from collections import defaultdict, MutableSequence, MutableSet, MutableMapping
-from collections import OrderedDict, deque
+from collections import deque, OrderedDict, defaultdict
+from collections.abc import MutableSequence, MutableSet, MutableMapping
 
 try:
     from pickle import dumps, loads


### PR DESCRIPTION
**Overview:**
Update to imports supports Python 3.10 while maintaining backwards compatibility.

For updated collections references, see:
https://docs.python.org/3.10/library/collections.html
https://docs.python.org/3/library/collections.abc.html
