### PR TITLE
Adding "mult" to traits contrib

### DIFF
--- a/evennia/contrib/rpg/traits/tests.py
+++ b/evennia/contrib/rpg/traits/tests.py
@@ -487,7 +487,7 @@ class TestTraitCounter(_TraitHandlerBase):
         """Test descriptions"""
         self.trait.min = -5
         self.trait.mod = 0
-        self.assertEqual(self._get_values(), (1, 0, 1, -5, 10))
+        self.assertEqual(self._get_values(), (1, 0, 1.0, 1, -5, 10))
         self.trait.current = -2
         self.assertEqual(self.trait.desc(), "range0")
         self.trait.current = 0
@@ -591,8 +591,9 @@ class TestTraitGauge(_TraitHandlerBase):
             "test1",
             name="Test1",
             trait_type="gauge",
-            base=8,  # max = base + mod
+            base=8,  # max = (base + mod) * mult
             mod=2,
+            mult=1.0,
             extra_val1="xvalue1",
             extra_val2="xvalue2",
             descs={0: "range0", 2: "range1", 5: "range2", 7: "range3",},
@@ -611,6 +612,7 @@ class TestTraitGauge(_TraitHandlerBase):
                 "trait_type": "gauge",
                 "base": 8,
                 "mod": 2,
+                "mult": 1.0,
                 "min": 0,
                 "extra_val1": "xvalue1",
                 "extra_val2": "xvalue2",
@@ -624,71 +626,80 @@ class TestTraitGauge(_TraitHandlerBase):
     def test_value(self):
         """value is current, where current defaults to base + mod"""
         # current unset - follows base + mod
-        self.assertEqual(self._get_values(), (8, 2, 10, 0, 10))
+        self.assertEqual(self._get_values(), (8, 2, 1.0, 10, 0, 10))
         self.trait.base += 4
-        self.assertEqual(self._get_values(), (12, 2, 14, 0, 14))
+        self.assertEqual(self._get_values(), (12, 2, 1.0, 14, 0, 14))
         self.trait.mod -= 1
-        self.assertEqual(self._get_values(), (12, 1, 13, 0, 13))
+        self.assertEqual(self._get_values(), (12, 1, 1.0, 13, 0, 13))
+        self.trait.mult += 1.0
+        self.assertEqual(self._get_values(), (12, 1, 2.0, 26, 0, 26))
         # set current, decouple from base + mod
         self.trait.current = 5
-        self.assertEqual(self._get_values(), (12, 1, 5, 0, 13))
+        self.assertEqual(self._get_values(), (12, 1, 2.0, 5, 0, 26))
         self.trait.mod += 1
         self.trait.base -= 4
-        self.assertEqual(self._get_values(), (8, 2, 5, 0, 10))
+        self.trait.mult -= 1.0
+        self.assertEqual(self._get_values(), (8, 2, 1.0, 5, 0, 10))
         self.trait.min = -100
         self.trait.base = -20
-        self.assertEqual(self._get_values(), (-20, 2, -18, -100, -18))
+        self.assertEqual(self._get_values(), (-20, 2, 1.0, -18, -100, -18))
 
     def test_boundaries__minmax(self):
         """Test range"""
         # current unset - tied to base + mod
         self.trait.base += 20
-        self.assertEqual(self._get_values(), (28, 2, 30, 0, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, 30, 0, 30))
         # set current - decouple from base + mod
         self.trait.current = 19
-        self.assertEqual(self._get_values(), (28, 2, 19, 0, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, 19, 0, 30))
         # test upper bound
         self.trait.current = 100
-        self.assertEqual(self._get_values(), (28, 2, 30, 0, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, 30, 0, 30))
+        # with multiplier
+        self.trait.mult = 2.0
+        self.assertEqual(self._get_values(), (28, 2, 2.0, 30, 0, 60))
+        self.trait.current = 100
+        self.assertEqual(self._get_values(), (28, 2, 2.0, 60, 0, 60))
         # min defaults to 0
+        self.trait.mult = 1.0
         self.trait.current = -10
-        self.assertEqual(self._get_values(), (28, 2, 0, 0, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, 0, 0, 30))
         self.trait.min = -20
-        self.assertEqual(self._get_values(), (28, 2, 0, -20, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, 0, -20, 30))
         self.trait.current = -10
-        self.assertEqual(self._get_values(), (28, 2, -10, -20, 30))
+        self.assertEqual(self._get_values(), (28, 2, 1.0, -10, -20, 30))
 
     def test_boundaries__bigmod(self):
         """add a big mod"""
         self.trait.base = 5
         self.trait.mod = 100
-        self.assertEqual(self._get_values(), (5, 100, 105, 0, 105))
+        self.assertEqual(self._get_values(), (5, 100, 1.0, 105, 0, 105))
         # restricted by min
         self.trait.mod = -100
-        self.assertEqual(self._get_values(), (5, -5, 0, 0, 0))
+        self.assertEqual(self._get_values(), (5, -5, 1.0, 0, 0, 0))
         self.trait.min = -200
-        self.assertEqual(self._get_values(), (5, -5, 0, -200, 0))
+        self.assertEqual(self._get_values(), (5, -5, 1.0, 0, -200, 0))
 
     def test_boundaries__change_boundaries(self):
         """Change boundaries after current change"""
         self.trait.current = 20
-        self.assertEqual(self._get_values(), (8, 2, 10, 0, 10))
+        self.assertEqual(self._get_values(), (8, 2, 1.0, 10, 0, 10))
         self.trait.mod = 102
-        self.assertEqual(self._get_values(), (8, 102, 10, 0, 110))
+        self.assertEqual(self._get_values(), (8, 102, 1.0, 10, 0, 110))
         # raising min past current value will force it upwards
         self.trait.min = 20
-        self.assertEqual(self._get_values(), (8, 102, 20, 20, 110))
+        self.assertEqual(self._get_values(), (8, 102, 1.0, 20, 20, 110))
 
     def test_boundaries__disable(self):
         """Disable and re-enable boundary"""
         self.trait.base = 5
         self.trait.min = 1
-        self.assertEqual(self._get_values(), (5, 2, 7, 1, 7))
+        self.assertEqual(self._get_values(), (5, 2, 1.0, 7, 1, 7))
         del self.trait.min
-        self.assertEqual(self._get_values(), (5, 2, 7, 0, 7))
+        self.assertEqual(self._get_values(), (5, 2, 1.0, 7, 0, 7))
         del self.trait.base
         del self.trait.mod
-        self.assertEqual(self._get_values(), (0, 0, 0, 0, 0))
+        self.assertEqual(self._get_values(), (0, 0, 1.0, 0, 0, 0))
         with self.assertRaises(traits.TraitException):
             del self.trait.max
 
@@ -696,39 +707,39 @@ class TestTraitGauge(_TraitHandlerBase):
         """Try to set reversed boundaries"""
         self.trait.mod = 0
         self.trait.base = -10  # limited by min
-        self.assertEqual(self._get_values(), (0, 0, 0, 0, 0))
+        self.assertEqual(self._get_values(), (0, 0, 1.0, 0, 0, 0))
         self.trait.min = -10
-        self.assertEqual(self._get_values(), (0, 0, 0, -10, 0))
+        self.assertEqual(self._get_values(), (0, 0, 1.0, 0, -10, 0))
         self.trait.base = -10
-        self.assertEqual(self._get_values(), (-10, 0, -10, -10, -10))
+        self.assertEqual(self._get_values(), (-10, 0, 1.0, -10, -10, -10))
         self.min = 0  # limited by base + mod
-        self.assertEqual(self._get_values(), (-10, 0, -10, -10, -10))
+        self.assertEqual(self._get_values(), (-10, 0, 1.0, -10, -10, -10))
 
     def test_current(self):
         """Modifying current value"""
         self.trait.base = 10
         self.trait.current = 5
-        self.assertEqual(self._get_values(), (10, 2, 5, 0, 12))
+        self.assertEqual(self._get_values(), (10, 2, 1.0, 5, 0, 12))
         self.trait.current = 10
-        self.assertEqual(self._get_values(), (10, 2, 10, 0, 12))
+        self.assertEqual(self._get_values(), (10, 2, 1.0, 10, 0, 12))
         self.trait.current = 12
-        self.assertEqual(self._get_values(), (10, 2, 12, 0, 12))
+        self.assertEqual(self._get_values(), (10, 2, 1.0, 12, 0, 12))
         self.trait.current = 0
-        self.assertEqual(self._get_values(), (10, 2, 0, 0, 12))
+        self.assertEqual(self._get_values(), (10, 2, 1.0, 0, 0, 12))
         self.trait.current = -1
-        self.assertEqual(self._get_values(), (10, 2, 0, 0, 12))
+        self.assertEqual(self._get_values(), (10, 2, 1.0, 0, 0, 12))
 
     def test_delete(self):
         """Deleting resets to default."""
         del self.trait.mod
-        self.assertEqual(self._get_values(), (8, 0, 8, 0, 8))
+        self.assertEqual(self._get_values(), (8, 0, 1.0, 8, 0, 8))
         self.trait.mod = 2
         del self.trait.base
-        self.assertEqual(self._get_values(), (0, 2, 2, 0, 2))
+        self.assertEqual(self._get_values(), (0, 2, 1.0, 2, 0, 2))
         del self.trait.min
-        self.assertEqual(self._get_values(), (0, 2, 2, 0, 2))
+        self.assertEqual(self._get_values(), (0, 2, 1.0, 2, 0, 2))
         self.trait.min = -10
-        self.assertEqual(self._get_values(), (0, 2, 2, -10, 2))
+        self.assertEqual(self._get_values(), (0, 2, 1.0, 2, -10, 2))
         del self.trait.min
         self.assertEqual(self._get_values(), (0, 2, 2, 0, 2))
 

--- a/evennia/contrib/rpg/traits/tests.py
+++ b/evennia/contrib/rpg/traits/tests.py
@@ -274,13 +274,14 @@ class TestTraitStatic(_TraitHandlerBase):
             trait_type="static",
             base=1,
             mod=2,
+            mult=2.0,
             extra_val1="xvalue1",
             extra_val2="xvalue2",
         )
         self.trait = self.traithandler.get("test1")
 
     def _get_values(self):
-        return self.trait.base, self.trait.mod, self.trait.value
+        return self.trait.base, self.trait.mod, self.trait.mult, self.trait.value
 
     def test_init(self):
         self.assertEqual(
@@ -290,25 +291,33 @@ class TestTraitStatic(_TraitHandlerBase):
                 "trait_type": "static",
                 "base": 1,
                 "mod": 2,
+                "mult": 2.0,
                 "extra_val1": "xvalue1",
                 "extra_val2": "xvalue2",
             },
         )
 
     def test_value(self):
-        """value is base + mod"""
-        self.assertEqual(self._get_values(), (1, 2, 3))
+        """value is (base + mod) * mult"""
+        self.assertEqual(self._get_values(), (1, 2, 2.0, 6))
         self.trait.base += 4
-        self.assertEqual(self._get_values(), (5, 2, 7))
+        self.assertEqual(self._get_values(), (5, 2, 2.0, 14))
         self.trait.mod -= 1
-        self.assertEqual(self._get_values(), (5, 1, 6))
+        self.assertEqual(self._get_values(), (5, 1, 2.0, 12))
+        self.trait.mult += 1.0
+        self.assertEqual(self._get_values(), (5, 1, 3.0, 18))
+        self.trait.mult = 0.75
+        self.assertEqual(self._get_values(), (5, 1, 0.75, 4.5))
+
 
     def test_delete(self):
         """Deleting resets to default."""
         del self.trait.base
-        self.assertEqual(self._get_values(), (0, 2, 2))
+        self.assertEqual(self._get_values(), (0, 2, 2.0, 4))
+        del self.trait.mult
+        self.assertEqual(self._get_values(), (0, 2, 1.0, 2))
         del self.trait.mod
-        self.assertEqual(self._get_values(), (0, 0, 0))
+        self.assertEqual(self._get_values(), (0, 0, 1.0, 0))
 
 
 class TestTraitCounter(_TraitHandlerBase):

--- a/evennia/contrib/rpg/traits/tests.py
+++ b/evennia/contrib/rpg/traits/tests.py
@@ -274,7 +274,7 @@ class TestTraitStatic(_TraitHandlerBase):
             trait_type="static",
             base=1,
             mod=2,
-            mult=2.0,
+            mult=1.0,
             extra_val1="xvalue1",
             extra_val2="xvalue2",
         )
@@ -291,7 +291,7 @@ class TestTraitStatic(_TraitHandlerBase):
                 "trait_type": "static",
                 "base": 1,
                 "mod": 2,
-                "mult": 2.0,
+                "mult": 1.0,
                 "extra_val1": "xvalue1",
                 "extra_val2": "xvalue2",
             },
@@ -299,19 +299,20 @@ class TestTraitStatic(_TraitHandlerBase):
 
     def test_value(self):
         """value is (base + mod) * mult"""
-        self.assertEqual(self._get_values(), (1, 2, 2.0, 6))
+        self.assertEqual(self._get_values(), (1, 2, 1.0, 3))
         self.trait.base += 4
-        self.assertEqual(self._get_values(), (5, 2, 2.0, 14))
+        self.assertEqual(self._get_values(), (5, 2, 1.0, 7))
         self.trait.mod -= 1
-        self.assertEqual(self._get_values(), (5, 1, 2.0, 12))
+        self.assertEqual(self._get_values(), (5, 1, 1.0, 6))
         self.trait.mult += 1.0
-        self.assertEqual(self._get_values(), (5, 1, 3.0, 18))
+        self.assertEqual(self._get_values(), (5, 1, 2.0, 12))
         self.trait.mult = 0.75
         self.assertEqual(self._get_values(), (5, 1, 0.75, 4.5))
 
 
     def test_delete(self):
         """Deleting resets to default."""
+        self.trait.mult = 2.0
         del self.trait.base
         self.assertEqual(self._get_values(), (0, 2, 2.0, 4))
         del self.trait.mult

--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -1151,7 +1151,7 @@ class StaticTrait(Trait):
 
     trait_type = "static"
 
-    default_keys = {"base": 0, "mod": 0}
+    default_keys = {"base": 0, "mod": 0, "mult": 1.0}
 
     def __str__(self):
         status = "{value:11}".format(value=self.value)
@@ -1180,9 +1180,19 @@ class StaticTrait(Trait):
             self._data["mod"] = amount
 
     @property
+    def mult(self):
+        """The trait's multiplier."""
+        return self._data["mult"]
+    
+    @mult.setter
+    def mult(self, amount):
+        if type(amount) in (int, float):
+            self._data["mult"] = amount
+
+    @property
     def value(self):
-        "The value of the Trait"
-        return self.base + self.mod
+        "The value of the Trait."
+        return (self.base + self.mod) * self.mult
 
 
 class CounterTrait(Trait):
@@ -1225,6 +1235,7 @@ class CounterTrait(Trait):
     default_keys = {
         "base": 0,
         "mod": 0,
+        "mult": 1.0,
         "min": None,
         "max": None,
         "descs": None,
@@ -1354,6 +1365,15 @@ class CounterTrait(Trait):
             self._data["mod"] = value
 
     @property
+    def mult(self):
+        return self._data["mult"]
+    
+    @mult.setter
+    def mult(self, amount):
+        if type(amount) in (int, float):
+            self._data["mult"] = amount
+
+    @property
     def min(self):
         return self._data["min"]
 
@@ -1398,8 +1418,8 @@ class CounterTrait(Trait):
 
     @property
     def value(self):
-        "The value of the Trait (current + mod)"
-        return self._enforce_boundaries(self.current + self.mod)
+        "The value of the Trait. (current + mod) * mult"
+        return self._enforce_boundaries( (self.current + self.mod) * self.mult)
 
     @property
     def ratetarget(self):
@@ -1494,6 +1514,7 @@ class GaugeTrait(CounterTrait):
     default_keys = {
         "base": 0,
         "mod": 0,
+        "mult": 1.0,
         "min": 0,
         "descs": None,
         "rate": 0,
@@ -1560,6 +1581,15 @@ class GaugeTrait(CounterTrait):
             if value + self.base < self.min:
                 value = self.min - self.base
             self._data["mod"] = value
+    
+    @property
+    def mult(self):
+        return self._data["mult"]
+    
+    @mult.setter
+    def mult(self, amount):
+        if type(amount) in (int, float):
+            self._data["mult"] = amount
 
     @property
     def min(self):
@@ -1576,8 +1606,8 @@ class GaugeTrait(CounterTrait):
 
     @property
     def max(self):
-        "The max is always base + mod."
-        return self.base + self.mod
+        "The max is always (base + mod) * mult."
+        return (self.base + self.mod) * self.mult
 
     @max.setter
     def max(self, value):

--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -1196,6 +1196,10 @@ class StaticTrait(Trait):
         if type(amount) in (int, float):
             self._data["mult"] = amount
 
+    @mult.deleter
+    def mult(self):
+        self._data["mult"] = 1.0
+
     @property
     def value(self):
         "The value of the Trait."
@@ -1209,14 +1213,14 @@ class CounterTrait(Trait):
     This includes modifications and min/max limits as well as the notion of a
     current value. The value can also be reset to the base value.
 
-    min/unset     base    base+mod                       max/unset
+    min/unset     base  (base+mod)*mult                  max/unset
      |--------------|--------|---------X--------X------------|
                                     current   value
                                               = (current
                                               + mod)
                                               * mult
 
-    - value = (current + mod) * mult, starts at base + mod
+    - value = (current + mod) * mult, starts at (base + mod) * mult
     - if min or max is None, there is no upper/lower bound (default)
     - if max is set to "base", max will be equal ot base+mod
     - descs are used to optionally describe each value interval.
@@ -1381,6 +1385,10 @@ class CounterTrait(Trait):
         if type(amount) in (int, float):
             self._data["mult"] = amount
 
+    @mult.deleter
+    def mult(self):
+        self._data["mult"] = 1.0
+
     @property
     def min(self):
         return self._data["min"]
@@ -1407,11 +1415,11 @@ class CounterTrait(Trait):
         elif type(value) in (int, float):
             if self.min is not None:
                 value = max(self.min, value)
-            self._data["max"] = max(value, (self.base + self.mod) * self.mult)
+            self._data["max"] = max(value, self.base + self.mod)
 
     @property
     def current(self):
-        """The `current` value of the `Trait`. This does not have .mod added."""
+        """The `current` value of the `Trait`. This does not have .mod added and is not .mult-iplied."""
         return self._update_current(self._data.get("current", self.base))
 
     @current.setter
@@ -1598,6 +1606,10 @@ class GaugeTrait(CounterTrait):
     def mult(self, amount):
         if type(amount) in (int, float):
             self._data["mult"] = amount
+
+    @mult.deleter
+    def mult(self):
+        self._data["mult"] = 1.0
 
     @property
     def min(self):

--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -173,9 +173,10 @@ if trait1 > trait2:
 
 `value = (base + mod) * mult`
 
-The static trait has a `base` value and an optional `mod`-ifier and 'mult'-iplier. A typical use
-of a static trait would be a Strength stat or Skill value. That is, something
-that varies slowly or not at all, and which may be modified in-place.
+The static trait has a `base` value and an optional `mod`-ifier and 'mult'-iplier.
+The modifier defaults to 0, and the multiplier to 1.0, for no change in value.
+A typical use of a static trait would be a Strength stat or Skill value. That is, 
+somethingthat varies slowly or not at all, and which may be modified in-place.
 
 ```python
 > obj.traits.add("str", "Strength", trait_type="static", base=10, mod=2)
@@ -200,15 +201,16 @@ that varies slowly or not at all, and which may be modified in-place.
     min/unset     base    base+mod                       max/unset
     |--------------|--------|---------X--------X------------|
                                   current    value
-                                             = current
-                                             + mod
+                                             = (current
+                                             + mod)
                                              * mult
 
 A counter describes a value that can move from a base. The `.current` property
 is the thing usually modified. It starts at the `.base`. One can also add a
 modifier, which is added to both the base and to current. '.value' is then formed 
-by multiplying by the multiplier. The min/max of the range are optional, a boundary 
-set to None will remove it. A suggested use for a Counter Trait would be to track skill values.
+by multiplying by the multiplier, which defaults to 1.0 for no change. The min/max 
+of the range are optional, a boundary set to None will remove it. A suggested use 
+for a Counter Trait would be to track skill values.
 
 ```python
 > obj.traits.add("hunting", "Hunting Skill", trait_type="counter",
@@ -1210,8 +1212,8 @@ class CounterTrait(Trait):
     min/unset     base    base+mod                       max/unset
      |--------------|--------|---------X--------X------------|
                                     current   value
-                                              = current
-                                              + mod
+                                              = (current
+                                              + mod)
                                               * mult
 
     - value = (current + mod) * mult, starts at base + mod

--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -1580,10 +1580,10 @@ class GaugeTrait(CounterTrait):
 
     @base.setter
     def base(self, value):
-        """Limit so (base+mod)*mult can never go below min."""
+        """Limit so base+mod can never go below min."""
         if type(value) in (int, float):
-            if (value + self.mod) * self.mult < self.min:
-                value = (self.min - self.mod) / self.mult
+            if value + self.mod < self.min:
+                value = self.min - self.mod
             self._data["base"] = value
 
     @property
@@ -1592,10 +1592,10 @@ class GaugeTrait(CounterTrait):
 
     @mod.setter
     def mod(self, value):
-        """Limit so (base+mod)*mult can never go below min."""
+        """Limit so base+mod can never go below min."""
         if type(value) in (int, float):
-            if (value + self.base) * self.mult < self.min:
-                value = (self.min - self.base) / self.mult
+            if value + self.base < self.min:
+                value = self.min - self.base
             self._data["mod"] = value
     
     @property

--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -1319,16 +1319,16 @@ class CounterTrait(Trait):
             now = time()
             tdiff = now - self._data["last_update"]
             current += rate * tdiff
-            value = (current + self.mod) * self.mult
+            value = (current + self.mod)
 
             # we must make sure so we don't overstep our bounds
             # even if .mod is included
 
             if self._passed_ratetarget(value):
-                current = (self._data["ratetarget"] - self.mod) / self.mult
+                current = (self._data["ratetarget"] - self.mod)
                 self._stop_timer()
             elif not self._within_boundaries(value):
-                current = (self._enforce_boundaries(value) - self.mod) / self.mult
+                current = (self._enforce_boundaries(value) - self.mod)
                 self._stop_timer()
             else:
                 self._data["last_update"] = now
@@ -1350,10 +1350,10 @@ class CounterTrait(Trait):
         if value is None:
             self._data["base"] = self.default_keys["base"]
         if type(value) in (int, float):
-            if self.min is not None and (value + self.mod) * self.mult < self.min:
-                value = (self.min - self.mod) / self.mult
-            if self.max is not None and (value + self.mod) * self.mult > self.max:
-                value = (self.max - self.mod) / self.mult
+            if self.min is not None and value + self.mod < self.min:
+                value = self.min - self.mod
+            if self.max is not None and value + self.mod > self.max:
+                value = self.max - self.mod
             self._data["base"] = value
 
     @property
@@ -1366,10 +1366,10 @@ class CounterTrait(Trait):
             # unsetting the boundary to default
             self._data["mod"] = self.default_keys["mod"]
         elif type(value) in (int, float):
-            if self.min is not None and (value + self.base) * self.mult < self.min:
-                value = (self.min - self.base) / self.mult
-            if self.max is not None and (value + self.base) * self.mult > self.max:
-                value = (self.max - self.base) / self.mult
+            if self.min is not None and value + self.base < self.min:
+                value = self.min - self.base
+            if self.max is not None and value + self.base > self.max:
+                value = self.max - self.base
             self._data["mod"] = value
 
     @property
@@ -1393,7 +1393,7 @@ class CounterTrait(Trait):
         elif type(value) in (int, float):
             if self.max is not None:
                 value = min(self.max, value)
-            self._data["min"] = min(value, (self.base + self.mod) * self.mult)
+            self._data["min"] = min(value, self.base + self.mod)
 
     @property
     def max(self):
@@ -1427,7 +1427,7 @@ class CounterTrait(Trait):
     @property
     def value(self):
         "The value of the Trait. (current + mod) * mult"
-        return self._enforce_boundaries( (self.current + self.mod) * self.mult)
+        return self._enforce_boundaries((self.current + self.mod) * self.mult)
 
     @property
     def ratetarget(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds "mult" as a stat to the traits contrib, allowing developers to use multiplicative modifiers for their traits. Anywhere that you would receive "`base + mod`" as a return has been edited to "`(base + mod) * mult`". This is the current value for Static and Counter traits, and the max value for Gauge traits.

#### Motivation for adding to Evennia

I use multiplicative math for my game's buffs and stats sometimes, so I figure other people might too.
