### PR TITLE
Fix for bug #2643: NAttributes on examine.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2716,13 +2716,13 @@ class CmdExamine(ObjManipCommand):
 
     def format_nattributes(self, obj):
         try:
-            ndb_attr = obj.nattributes.all(return_tuples=True)
+            ndb_attr = obj.nattributes.all()
         except Exception:
             return
 
         if ndb_attr and ndb_attr[0]:
             return "\n  " + "  \n".join(
-                sorted(self.format_single_attribute(attr) for attr, value in ndb_attr)
+                sorted(self.format_single_attribute(attr) for attr in ndb_attr)
             )
 
     def format_exits(self, obj):

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -928,7 +928,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             try:
                 self.announce_move_from(destination, **kwargs)
             except Exception as err:
-                logerr(errtxt.format(err="at_announce_move()"), err)
+                logerr(errtxt.format(err="announce_move_from()"), err)
                 return False
 
         # Perform move


### PR DESCRIPTION
Non-Persistent Attributes now shown in examine.

#### Brief overview of PR changes/additions
format_nattributes no longer references deprecated all(return_tuple=True) function.

#### Motivation for adding to Evennia
View NAttributes in examine

#### Other info (issues closed, discussion etc)
Closes #2643