### PR TITLE
Add deserialize() shortcut on _SaverMutable and fix OrderedDict bug.

### DIFF
--- a/evennia/utils/dbserialize.py
+++ b/evennia/utils/dbserialize.py
@@ -243,6 +243,10 @@ class _SaverMutable(object):
     def __delitem__(self, key):
         self._data.__delitem__(key)
 
+    def deserialize(self):
+        """Deserializes this mutable into its corresponding non-Saver type."""
+        return deserialize(self)
+
 
 class _SaverList(_SaverMutable, MutableSequence):
     """
@@ -418,6 +422,8 @@ def deserialize(obj):
         tname = typ.__name__
         if tname in ("_SaverDict", "dict"):
             return {_iter(key): _iter(val) for key, val in obj.items()}
+        elif tname in ("_SaverOrderedDict", "OrderedDict"):
+            return OrderedDict([(_iter(key), _iter(val)) for key, val in obj.items()])
         elif tname in _DESERIALIZE_MAPPING:
             return _DESERIALIZE_MAPPING[tname](_iter(val) for val in obj)
         elif is_iter(obj):


### PR DESCRIPTION
Add deserialize() shortcut on _SaverMutable and fix OrderedDict bug and fix a bug in deserialize for _SavedOrderedDict as it uses non-standard
initialization.

#### Brief overview of PR changes/additions

Add a simple deserialize() shortcut on _SaverMutables that make it easier to deserialize without needing to import `dbserialize.deserialize()`.

While adding unit tests, I discovered a bug where `OrderedDict` was not being deserialized properly because it requires a single constructor argument rather than varargs like other collections.

#### Motivation for adding to Evennia

Make deserialization easy, fix bug.
