### PR TITLE
component-contrib:add component name as tag on host

### DIFF
--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -64,7 +64,7 @@ class ComponentHandler:
         """
         self._set_component(component)
         self.db_names.append(component.name)
-        self.host.tags.add(component.name, category="component")
+        self.host.tags.add(component.name, category="components")
         component.at_added(self.host)
 
     def add_default(self, name):
@@ -85,7 +85,7 @@ class ComponentHandler:
         new_component = component.default_create(self.host)
         self._set_component(new_component)
         self.db_names.append(name)
-        self.host.tags.add(name, category="component")
+        self.host.tags.add(name, category="components")
         new_component.at_added(self.host)
 
     def remove(self, component):
@@ -102,7 +102,7 @@ class ComponentHandler:
         if component_name in self._loaded_components:
             component.at_removed(self.host)
             self.db_names.remove(component_name)
-            self.host.tags.remove(component_name, category="component")
+            self.host.tags.remove(component_name, category="components")
             del self._loaded_components[component_name]
         else:
             message = f"Cannot remove {component_name} from {self.host.name} as it is not registered."
@@ -125,7 +125,7 @@ class ComponentHandler:
 
         instance.at_removed(self.host)
         self.db_names.remove(name)
-        self.host.tags.remove(name, category="component")
+        self.host.tags.remove(name, category="components")
         del self._loaded_components[name]
 
     def get(self, name):
@@ -226,7 +226,7 @@ class ComponentHolderMixin(object):
         """
         super().basetype_posthook_setup()
         for component_name in self.db.component_names:
-            self.tags.add(component_name, category="component")
+            self.tags.add(component_name, category="components")
 
     @property
     def components(self) -> ComponentHandler:

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -64,6 +64,7 @@ class ComponentHandler:
         """
         self._set_component(component)
         self.db_names.append(component.name)
+        self.host.tags.add(component.name, category="component")
         component.at_added(self.host)
 
     def add_default(self, name):
@@ -84,6 +85,7 @@ class ComponentHandler:
         new_component = component.default_create(self.host)
         self._set_component(new_component)
         self.db_names.append(name)
+        self.host.tags.add(name, category="component")
         new_component.at_added(self.host)
 
     def remove(self, component):
@@ -100,6 +102,7 @@ class ComponentHandler:
         if component_name in self._loaded_components:
             component.at_removed(self.host)
             self.db_names.remove(component_name)
+            self.host.tags.remove(component_name, category="component")
             del self._loaded_components[component_name]
         else:
             message = f"Cannot remove {component_name} from {self.host.name} as it is not registered."
@@ -122,6 +125,7 @@ class ComponentHandler:
 
         instance.at_removed(self.host)
         self.db_names.remove(name)
+        self.host.tags.remove(name, category="component")
         del self._loaded_components[name]
 
     def get(self, name):
@@ -215,6 +219,14 @@ class ComponentHolderMixin(object):
             self.components._loaded_components[component_name] = component
 
         self.db.component_names = component_names
+
+    def basetype_posthook_setup(self):
+        """
+        Method that add component related tags that were set using ComponentProperty.
+        """
+        super().basetype_posthook_setup()
+        for component_name in self.db.component_names:
+            self.tags.add(component_name, category="component")
 
     @property
     def components(self) -> ComponentHandler:

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -118,26 +118,28 @@ class TestComponents(EvenniaTest):
         self.char1.components.add(rct)
         test_c = self.char1.components.get('test_c')
 
-        assert self.char1.tags.has(key="test_c", category="component")
+        assert self.char1.tags.has(key="test_c", category="components")
 
     def test_host_has_added_default_component_tags(self):
         self.char1.components.add_default("test_c")
         test_c = self.char1.components.get("test_c")
 
-        assert self.char1.tags.has(key="test_c", category="component")
+        assert self.char1.tags.has(key="test_c", category="components")
 
     def test_host_remove_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)
         handler = self.char1.components
         handler.add(rct)
-        assert self.char1.tags.has(key="test_c", category="component")
+        assert self.char1.tags.has(key="test_c", category="components")
         handler.remove(rct)
-        assert not self.char1.tags.has(key="test_c", category="component")
+
+        assert not self.char1.tags.has(key="test_c", category="components")
 
     def test_host_remove_by_name_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)
         handler = self.char1.components
         handler.add(rct)
-        assert self.char1.tags.has(key="test_c", category="component")
+        assert self.char1.tags.has(key="test_c", category="components")
         handler.remove_by_name("test_c")
-        assert not self.char1.tags.has(key="test_c", category="component")
+
+        assert not self.char1.tags.has(key="test_c", category="components")

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -107,3 +107,37 @@ class TestComponents(EvenniaTest):
 
     def test_returns_none_with_regular_get_when_no_attribute(self):
         assert self.char1.cmp.does_not_exist is None
+
+    def test_host_has_class_component_tags(self):
+        assert self.char1.tags.has(key="test_a", category="component")
+        assert self.char1.tags.has(key="test_b", category="component")
+        assert not self.char1.tags.has(key="test_c", category="component")
+
+    def test_host_has_added_component_tags(self):
+        rct = RuntimeComponentTestC.create(self.char1)
+        self.char1.components.add(rct)
+        test_c = self.char1.components.get('test_c')
+
+        assert self.char1.tags.has(key="test_c", category="component")
+
+    def test_host_has_added_default_component_tags(self):
+        self.char1.components.add_default("test_c")
+        test_c = self.char1.components.get("test_c")
+
+        assert self.char1.tags.has(key="test_c", category="component")
+
+    def test_host_remove_component_tags(self):
+        rct = RuntimeComponentTestC.create(self.char1)
+        handler = self.char1.components
+        handler.add(rct)
+        assert self.char1.tags.has(key="test_c", category="component")
+        handler.remove(rct)
+        assert not self.char1.tags.has(key="test_c", category="component")
+
+    def test_host_remove_by_name_component_tags(self):
+        rct = RuntimeComponentTestC.create(self.char1)
+        handler = self.char1.components
+        handler.add(rct)
+        assert self.char1.tags.has(key="test_c", category="component")
+        handler.remove_by_name("test_c")
+        assert not self.char1.tags.has(key="test_c", category="component")

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -109,9 +109,9 @@ class TestComponents(EvenniaTest):
         assert self.char1.cmp.does_not_exist is None
 
     def test_host_has_class_component_tags(self):
-        assert self.char1.tags.has(key="test_a", category="component")
-        assert self.char1.tags.has(key="test_b", category="component")
-        assert not self.char1.tags.has(key="test_c", category="component")
+        assert self.char1.tags.has(key="test_a", category="components")
+        assert self.char1.tags.has(key="test_b", category="components")
+        assert not self.char1.tags.has(key="test_c", category="components")
 
     def test_host_has_added_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Add component names as a tag with the category "component" on host

#### Motivation for adding to Evennia

Searching objects by their components can be useful

Example:
    Applying the logic of a global Weather script to all rooms that contain the component "weather"

#### Other info (issues closed, discussion etc)

This is my first PR ever and also the first time i use tests so i hope i did it the right way ^^' 
