### PR TITLE
Fix Prototype Loading when using injected prototypes

### DIFF
--- a/evennia/prototypes/prototypes.py
+++ b/evennia/prototypes/prototypes.py
@@ -528,8 +528,10 @@ def search_prototype(
 
     """
     # This will load the prototypes the first time they are searched
-    if not _MODULE_PROTOTYPE_MODULES:
+    loaded = getattr(load_module_prototypes, '_LOADED', False)
+    if not loaded:
         load_module_prototypes()
+        setattr(load_module_prototypes, '_LOADED', True)
 
     # prototype keys are always in lowecase
     if key:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, it calls load_module_prototypes if no module prototypes were found.
This works most of the time but it will fail when prototypes are injected, like XYZGrid does.
This fix will force a complete load on the first search.

The benefit is you are guaranteed loading all prototypes in a deferred way.
The drawback is you may load twice if you already loaded for some reason, since only
search will set the _LOADED value on the method.

#### Motivation for adding to Evennia
Prototypes are very useful, having them not load is a pain.

#### Other info (issues closed, discussion etc)
This is a follow-up to #2634