### PR TITLE
[Components Contrib] Changed DBField and NDBField delimiters from __ to ::

### DIFF
--- a/evennia/contrib/base_systems/components/README.md
+++ b/evennia/contrib/base_systems/components/README.md
@@ -39,7 +39,7 @@ class Health(Component):
 Components may define DBFields or NDBFields at the class level.
 DBField will store its values in the host's DB with a prefixed key.
 NDBField will store its values in the host's NDB and will not persist.
-The key used will be 'component_name__field_name'.
+The key used will be 'component_name::field_name'.
 They use AttributeProperty under the hood.
 
 Example:

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -21,7 +21,7 @@ class DBField(AttributeProperty):
             owner (object): The component classF on which this is set
             name (str): The name that was used to set the DBField.
         """
-        key = f"{owner.name}__{name}"
+        key = f"{owner.name}::{name}"
         self._key = key
         db_fields = getattr(owner, "_db_fields", None)
         if db_fields is None:
@@ -45,7 +45,7 @@ class NDBField(NAttributeProperty):
             owner (object): The component class on which this is set
             name (str): The name that was used to set the DBField.
         """
-        key = f"{owner.name}__{name}"
+        key = f"{owner.name}::{name}"
         self._key = key
         ndb_fields = getattr(owner, "_ndb_fields", None)
         if ndb_fields is None:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This changes the delimiter of DBFields and NDBFields to :: instead of __

#### Motivation for adding to Evennia
Related to the security concern raised by @strikaco

#### Other info (issues closed, discussion etc)
Related to #2692

This will require all current contrib users to update their prototypes and attributes.
For module level prototypes, you can find them with the regex     `['"].*__.*['"]`

For database related stuff, the easiest way is to recreate the DB, if that is not possible...

You can run the following query to update your attributes
```
UPDATE
    typeclasses_attribute
SET
    db_key = replace(db_key, '__', '::')
WHERE db_key LIKE '%\_\_%' ESCAPE '\'
```

Alternatively, you can use evennia shell OR the `@py` command ingame and run
```
from evennia.typeclasses.attributes import Attribute
from django.db.models import Value
from django.db.models.functions import Replace

Attribute.objects.filter(db_key__contains="__").update(db_key=Replace("db_key", Value("__"), Value("::"))
```
