### PR TITLE
Auto-start global scripts

### DIFF
--- a/evennia/utils/containers.py
+++ b/evennia/utils/containers.py
@@ -167,7 +167,7 @@ class GlobalScriptContainer(Container):
 
             # store a hash representation of the setup
             script.attributes.add("_global_script_settings", compare_hash, category="settings_hash")
-            script.start()
+        script.start()
 
         return script
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves the `script.start()` call outside of the "(re)create script" block, so the script is actually being started regardless of whether it's new or pre-existing.

#### Motivation for adding to Evennia
I had to fix it for my own game anyway. <.<

#### Other info (issues closed, discussion etc)
Closes #2707 