### PR TITLE
Properly display whitespace in the webclient

### DIFF
--- a/evennia/utils/tests/test_text2html.py
+++ b/evennia/utils/tests/test_text2html.py
@@ -120,13 +120,6 @@ class TestText2Html(TestCase):
         )
         # TODO: doesn't URL encode correctly
 
-    def test_re_double_space(self):
-        parser = text2html.HTML_PARSER
-        self.assertEqual("foo", parser.re_double_space("foo"))
-        self.assertEqual(
-            "a &nbsp;red &nbsp;&nbsp;&nbsp;foo", parser.re_double_space("a  red    foo")
-        )
-
     def test_sub_mxp_links(self):
         parser = text2html.HTML_PARSER
         mocked_match = mock.Mock()
@@ -156,7 +149,7 @@ class TestText2Html(TestCase):
             "tab": "\t",
             "space": "",
         }
-        self.assertEqual(" &nbsp;", parser.sub_text(mocked_match))
+        self.assertEqual("  ", parser.sub_text(mocked_match))
 
         mocked_match.groupdict.return_value = {
             "htmlchars": "",
@@ -165,7 +158,7 @@ class TestText2Html(TestCase):
             "space": " ",
             "spacestart": " ",
         }
-        self.assertEqual(" &nbsp; &nbsp;", parser.sub_text(mocked_match))
+        self.assertEqual("    ", parser.sub_text(mocked_match))
 
         mocked_match.groupdict.return_value = {
             "htmlchars": "",
@@ -181,24 +174,13 @@ class TestText2Html(TestCase):
         parser = text2html.HTML_PARSER
         parser.tabstop = 4
         # single tab
-        self.assertEqual(parser.parse("foo|>foo"), "foo &nbsp;&nbsp;&nbsp;foo")
+        self.assertEqual(parser.parse("foo|>foo"), "foo    foo")
 
         # space and tab
-        self.assertEqual(parser.parse("foo |>foo"), "foo &nbsp;&nbsp;&nbsp;&nbsp;foo")
+        self.assertEqual(parser.parse("foo |>foo"), "foo     foo")
 
         # space, tab, space
-        self.assertEqual(parser.parse("foo |> foo"), "foo &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;foo")
-
-    def test_parse_space_to_html(self):
-        """test space parsing - a single space should be kept, two or more
-        should get &nbsp;"""
-        parser = text2html.HTML_PARSER
-        # single space
-        self.assertEqual(parser.parse("foo foo"), "foo foo")
-        # double space
-        self.assertEqual(parser.parse("foo  foo"), "foo &nbsp;foo")
-        # triple space
-        self.assertEqual(parser.parse("foo   foo"), "foo &nbsp;&nbsp;foo")
+        self.assertEqual(parser.parse("foo |> foo"), "foo      foo")
 
     def test_parse_html(self):
         self.assertEqual("foo", text2html.parse_html("foo"))

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -97,8 +97,7 @@ class TextToHTMLparser(object):
     re_blink = re.compile("(?:%s)(.*?)(?=%s|%s)" % (blink.replace("[", r"\["), fgstop, bgstop))
     re_inverse = re.compile("(?:%s)(.*?)(?=%s|%s)" % (inverse.replace("[", r"\["), fgstop, bgstop))
     re_string = re.compile(
-        r"(?P<htmlchars>[<&>])|(?P<tab>[\t]+)|(?P<space> +)|"
-        r"(?P<spacestart>^ )|(?P<lineend>\r\n|\r|\n)",
+        r"(?P<htmlchars>[<&>])|(?P<tab>[\t]+)|(?P<lineend>\r\n|\r|\n)",
         re.S | re.M | re.I,
     )
     re_url = re.compile(
@@ -109,20 +108,16 @@ class TextToHTMLparser(object):
 
     def _sub_bgfg(self, colormatch):
         # print("colormatch.groups()", colormatch.groups())
-        bgcode, prespace, fgcode, text, postspace = colormatch.groups()
+        bgcode, fgcode, text = colormatch.groups()
         if not fgcode:
             ret = r"""<span class="%s">%s%s%s</span>""" % (
                 self.bg_colormap.get(bgcode, self.fg_colormap.get(bgcode, "err")),
-                prespace and "&nbsp;" * len(prespace) or "",
-                postspace and "&nbsp;" * len(postspace) or "",
                 text,
             )
         else:
             ret = r"""<span class="%s"><span class="%s">%s%s%s</span></span>""" % (
                 self.bg_colormap.get(bgcode, self.fg_colormap.get(bgcode, "err")),
                 self.fg_colormap.get(fgcode, self.bg_colormap.get(fgcode, "err")),
-                prespace and "&nbsp;" * len(prespace) or "",
-                postspace and "&nbsp;" * len(postspace) or "",
                 text,
             )
         return ret
@@ -316,11 +311,7 @@ class TextToHTMLparser(object):
         elif cdict["lineend"]:
             return "<br>"
         elif cdict["tab"]:
-            text = cdict["tab"].replace("\t", " " + "&nbsp;" * (self.tabstop - 1))
-            return text
-        elif cdict["space"] or cdict["spacestart"]:
-            text = cdict["space"]
-            text = " " if len(text) == 1 else " " + text[1:].replace(" ", "&nbsp;")
+            text = cdict["tab"].replace("\t", " " * (self.tabstop))
             return text
         return None
 

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -79,11 +79,11 @@ class TextToHTMLparser(object):
     # create stop markers
     fgstop = "(?:\033\[1m|\033\[22m){0,1}\033\[3[0-8].*?m|\033\[0m|$"
     bgstop = "(?:\033\[1m|\033\[22m){0,1}\033\[4[0-8].*?m|\033\[0m|$"
-    bgfgstop = bgstop[:-2] + r"(\s*)" + fgstop
+    bgfgstop = bgstop[:-2] + fgstop
 
     fgstart = "((?:\033\[1m|\033\[22m){0,1}\033\[3[0-8].*?m)"
     bgstart = "((?:\033\[1m|\033\[22m){0,1}\033\[4[0-8].*?m)"
-    bgfgstart = bgstart + r"(\s*)" + "((?:\033\[1m|\033\[22m){0,1}\033\[[3-4][0-8].*?m){0,1}"
+    bgfgstart = bgstart + r"((?:\033\[1m|\033\[22m){0,1}\033\[[3-4][0-8].*?m){0,1}"
 
     # extract color markers, tagging the start marker and the text marked
     re_fgs = re.compile(fgstart + "(.*?)(?=" + fgstop + ")")
@@ -110,12 +110,12 @@ class TextToHTMLparser(object):
         # print("colormatch.groups()", colormatch.groups())
         bgcode, fgcode, text = colormatch.groups()
         if not fgcode:
-            ret = r"""<span class="%s">%s%s%s</span>""" % (
+            ret = r"""<span class="%s">%s</span>""" % (
                 self.bg_colormap.get(bgcode, self.fg_colormap.get(bgcode, "err")),
                 text,
             )
         else:
-            ret = r"""<span class="%s"><span class="%s">%s%s%s</span></span>""" % (
+            ret = r"""<span class="%s"><span class="%s">%s</span></span>""" % (
                 self.bg_colormap.get(bgcode, self.fg_colormap.get(bgcode, "err")),
                 self.fg_colormap.get(fgcode, self.bg_colormap.get(fgcode, "err")),
                 text,

--- a/evennia/web/static/webclient/css/webclient.css
+++ b/evennia/web/static/webclient/css/webclient.css
@@ -49,6 +49,7 @@ div {margin:0px;}
 .out {
   color: #aaa;
   background-color: #000;
+  white-space: pre-wrap;
 }
 
 /* Error messages (red) */


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, Evennia attempts to control the display of white-space in the webclient by doing server-side parsing. Not only is this resulting in numerous inconsistent spacing issues, but controlling content display should be done on the client, not the server.

This removes the white-space parsing from the server entirely and instead adds a CSS rule to the webclient that forces display of white space.

#### Other info (issues closed, discussion etc)
Closes #2701 (if backported), #2677