### PR TITLE
Improve coverage of evennia.commands.default.general

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -181,6 +181,13 @@ class TestGeneral(CommandTest):
         rid = self.room1.id
         self.call(general.CmdLook(), "here", "Room(#{})\nroom_desc".format(rid))
 
+    def test_look_no_location(self):
+        self.char1.location = None
+        self.call(general.CmdLook(), "", "You have no location to look at!")
+
+    def test_look_nonexisting(self):
+        self.call(general.CmdLook(), "yellow sign", "Could not find 'yellow sign'.")
+
     def test_home(self):
         self.call(general.CmdHome(), "", "You are already home")
 
@@ -220,6 +227,12 @@ class TestGeneral(CommandTest):
         )
         self.assertEqual(None, self.char1.account.nicks.get("testalias", category="account"))
         self.assertEqual("testaliasedstring3", self.char1.nicks.get("testalias", category="object"))
+
+    def test_nick_list(self):
+        self.call(general.CmdNick(), "/list", "No nicks defined.")
+        self.call(general.CmdNick(), "test1 = Hello", 
+            "Inputline-nick 'test1' mapped to 'Hello'.")
+        self.call(general.CmdNick(), "/list", "Defined Nicks:")
 
     def test_get_and_drop(self):
         self.call(general.CmdGet(), "Obj", "You pick up Obj.")

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -184,6 +184,14 @@ class TestGeneral(CommandTest):
     def test_home(self):
         self.call(general.CmdHome(), "", "You are already home")
 
+    def test_go_home(self):
+        self.call(building.CmdTeleport(), "/quiet Room2")
+        self.call(general.CmdHome(), "", "There's no place like home")
+
+    def test_no_home(self):
+        self.char1.home = None
+        self.call(general.CmdHome(), "", "You have no home")
+
     def test_inventory(self):
         self.call(general.CmdInventory(), "", "You are not carrying anything.")
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This adds tests for variations of the general commands "look", "home" and "nick".

#### Motivation for adding to Evennia

In the spirit of #1458, I found some chunks of these command implementations that were not covered by current tests. This should improve the coverage of `evennia.commands.default.general` from around 57% to 62%.

(I'm also demonstrating concepts around test suites, coverage, and source control to a small class of prospective software engineers.)

#### Other info (issues closed, discussion etc)
