### PR TITLE
Added support for createsuperuser --noinput

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1419,6 +1419,11 @@ def create_superuser():
     Create the superuser account
 
     """
+    required_fields = ["DJANGO_SUPERUSER_EMAIL", "DJANGO_SUPERUSER_PASSWORD", "DJANGO_SUPERUSER_USERNAME"]
+    if all([os.getenv(i) for i in required_fields]):
+        django.core.management.call_command("createsuperuser", interactive=False)
+        return
+
     print(
         "\nCreate a superuser below. The superuser is Account #1, the 'owner' "
         "account of the server. Email is optional and can be empty.\n"

--- a/evennia/server/tests/test_launcher.py
+++ b/evennia/server/tests/test_launcher.py
@@ -194,3 +194,14 @@ class TestLauncher(TwistedTestCase):
         mcall.assert_not_called()
         merr.assert_not_called()
         mcalllater.assert_called()
+
+    @patch.dict(os.environ, {
+        "DJANGO_SUPERUSER_EMAIL": "root@localhost",
+        "DJANGO_SUPERUSER_USERNAME": "root",
+        "DJANGO_SUPERUSER_PASSWORD": "correcthorsebatterystapler"
+        }, clear=True)
+    def test_createsuperuser_noinput(self):
+        from io import StringIO
+        with patch('sys.stdout', new = StringIO()) as fake_out:
+            evennia_launcher.create_superuser()
+            self.assertEqual(fake_out.getvalue(), 'Superuser created successfully.\n')


### PR DESCRIPTION
If the createsuperuser command detects the three required environment
variables, it will bypass the interactive createsuperuser prompt.

https://docs.djangoproject.com/en/3.2/ref/django-admin/#createsuperuser