### PR TITLE
`rpsystem` contrib: cache regex tuples by ID instead of key+aliases

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -321,7 +321,7 @@ def regex_tuple_from_key_alias(obj):
 
     if obj.id not in _REGEX_TUPLE_CACHE:
         permutation_string = " ".join([obj.key] + obj.aliases.all())
-        _REGEX_TUPLE_CACHE[permutation_string] = (
+        _REGEX_TUPLE_CACHE[obj.id] = (
             re.compile(ordered_permutation_regex(permutation_string), _RE_FLAGS),
             obj,
             obj.key,

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -319,7 +319,7 @@ def regex_tuple_from_key_alias(obj):
     """
     global _REGEX_TUPLE_CACHE
     permutation_string = " ".join([obj.key] + obj.aliases.all())
-    cache_key = " ".join((obj.id, permutation_string))
+    cache_key = f"{obj.id} {permutation_string}"
 
     if cache_key not in _REGEX_TUPLE_CACHE:
         _REGEX_TUPLE_CACHE[cache_key] = (

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -318,15 +318,15 @@ def regex_tuple_from_key_alias(obj):
 
     """
     global _REGEX_TUPLE_CACHE
-    permutation_string = " ".join([obj.key] + obj.aliases.all())
 
-    if permutation_string not in _REGEX_TUPLE_CACHE:
+    if obj.id not in _REGEX_TUPLE_CACHE:
+        permutation_string = " ".join([obj.key] + obj.aliases.all())
         _REGEX_TUPLE_CACHE[permutation_string] = (
             re.compile(ordered_permutation_regex(permutation_string), _RE_FLAGS),
             obj,
             obj.key,
         )
-    return _REGEX_TUPLE_CACHE[permutation_string]
+    return _REGEX_TUPLE_CACHE[obj.id]
 
 
 def parse_language(speaker, emote):

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -318,15 +318,16 @@ def regex_tuple_from_key_alias(obj):
 
     """
     global _REGEX_TUPLE_CACHE
+    permutation_string = " ".join([obj.key] + obj.aliases.all())
+    cache_key = " ".join((obj.id, permutation_string))
 
-    if obj.id not in _REGEX_TUPLE_CACHE:
-        permutation_string = " ".join([obj.key] + obj.aliases.all())
-        _REGEX_TUPLE_CACHE[obj.id] = (
+    if cache_key not in _REGEX_TUPLE_CACHE:
+        _REGEX_TUPLE_CACHE[cache_key] = (
             re.compile(ordered_permutation_regex(permutation_string), _RE_FLAGS),
             obj,
             obj.key,
         )
-    return _REGEX_TUPLE_CACHE[obj.id]
+    return _REGEX_TUPLE_CACHE[cache_key]
 
 
 def parse_language(speaker, emote):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The search system for the `rpsystem` contrib stores cached regex for non-Character objects under a key+aliases string, so all objects with a given key+aliases match to the first such object cached.

This PR changes the cache identifier to the object's own ID to prevent false references.

#### Other info (issues closed, discussion etc)

Closes #2705 