### PR TITLE
Only initialize AttributeProperty and TagProperty in init_evennia_properties

### DIFF
--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -232,12 +232,22 @@ class TestContentHandler(BaseEvenniaTest):
         self.assertEqual(self.room2.contents, [self.obj1, self.obj2])
 
 
+class SubAttributeProperty(AttributeProperty):
+    pass
+
+
+class SubTagProperty(TagProperty):
+    pass
+
+
 class TestObjectPropertiesClass(DefaultObject):
     attr1 = AttributeProperty(default="attr1")
     attr2 = AttributeProperty(default="attr2", category="attrcategory")
     attr3 = AttributeProperty(default="attr3", autocreate=False)
+    attr4 = SubAttributeProperty(default="attr4")
     tag1 = TagProperty()
     tag2 = TagProperty(category="tagcategory")
+    tag3 = SubTagProperty()
     testalias = AliasProperty()
     testperm = PermissionProperty()
 
@@ -276,6 +286,10 @@ class TestProperties(EvenniaTestCase):
         self.assertFalse(obj.attributes.has("attr3"))
         self.assertEqual(obj.attr3, "attr3")
 
+        self.assertEqual(obj.db.attr4, "attr4")
+        self.assertEqual(obj.attributes.get("attr4"), "attr4")
+        self.assertEqual(obj.attr4, "attr4")
+
         obj.attr3 = "attr3b"  # stores it in db!
 
         self.assertEqual(obj.db.attr3, "attr3b")
@@ -283,6 +297,7 @@ class TestProperties(EvenniaTestCase):
 
         self.assertTrue(obj.tags.has("tag1"))
         self.assertTrue(obj.tags.has("tag2", category="tagcategory"))
+        self.assertTrue(obj.tags.has("tag3"))
 
         self.assertTrue(obj.aliases.has("testalias"))
         self.assertTrue(obj.permissions.has("testperm"))

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -241,11 +241,17 @@ class TestObjectPropertiesClass(DefaultObject):
     testalias = AliasProperty()
     testperm = PermissionProperty()
 
+    @property
+    def base_property(self):
+        self.property_initialized = True
+
+
 class TestProperties(EvenniaTestCase):
     """
     Test Properties.
 
     """
+
     def setUp(self):
         self.obj = create.create_object(TestObjectPropertiesClass, key="testobj")
 
@@ -270,7 +276,7 @@ class TestProperties(EvenniaTestCase):
         self.assertFalse(obj.attributes.has("attr3"))
         self.assertEqual(obj.attr3, "attr3")
 
-        obj.attr3 = "attr3b"   # stores it in db!
+        obj.attr3 = "attr3b"  # stores it in db!
 
         self.assertEqual(obj.db.attr3, "attr3b")
         self.assertTrue(obj.attributes.has("attr3"))
@@ -280,3 +286,7 @@ class TestProperties(EvenniaTestCase):
 
         self.assertTrue(obj.aliases.has("testalias"))
         self.assertTrue(obj.permissions.has("testperm"))
+
+        # Verify that regular properties do not get fetched in init_evennia_properties,
+        # only Attribute or TagProperties.
+        self.assertFalse(hasattr(obj, "property_initialized"))

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -332,7 +332,7 @@ class TypedObject(SharedMemoryModel):
         by fetching them once.
         """
         for propkey, prop in self.__class__.__dict__.items():
-            if isinstance(prop, (AttributeProperty, TagProperty)):
+            if inherits_from(prop, AttributeProperty) or inherits_from(prop, TagProperty):
                 try:
                     getattr(self, propkey)
                 except Exception:

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -39,11 +39,12 @@ from django.utils.text import slugify
 from evennia.typeclasses.attributes import (
     Attribute,
     AttributeHandler,
+    AttributeProperty,
     ModelAttributeBackend,
     InMemoryAttributeBackend,
 )
 from evennia.typeclasses.attributes import DbHolder
-from evennia.typeclasses.tags import Tag, TagHandler, AliasHandler, PermissionHandler
+from evennia.typeclasses.tags import Tag, TagHandler, AliasHandler, PermissionHandler, TagProperty
 
 from evennia.utils.idmapper.models import SharedMemoryModel, SharedMemoryModelBase
 from evennia.server.signals import SIGNAL_TYPED_OBJECT_POST_RENAME
@@ -331,7 +332,7 @@ class TypedObject(SharedMemoryModel):
         by fetching them once.
         """
         for propkey, prop in self.__class__.__dict__.items():
-            if hasattr(prop, "__set_name__"):
+            if isinstance(prop, (AttributeProperty, TagProperty)):
                 try:
                     getattr(self, propkey)
                 except Exception:

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -332,7 +332,7 @@ class TypedObject(SharedMemoryModel):
         by fetching them once.
         """
         for propkey, prop in self.__class__.__dict__.items():
-            if inherits_from(prop, AttributeProperty) or inherits_from(prop, TagProperty):
+            if isinstance(prop, (AttributeProperty, TagProperty)):
                 try:
                     getattr(self, propkey)
                 except Exception:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`init_evennia_properties()` attempts to fetch all object properties with a `__set_name__` attribute in order to ensure that AttributeProperty and TagProperty fields are initialized. In python 3.10, this has the side effect of also initializing any fields defined with `@property` (and similar decorators), which is not desired. As this initialization occurs on a new object before any attributes from a `create` call are applied, `@property` fields that cache attribute data will cache the wrong value.

#### Motivation for adding to Evennia

Fixes bug on new object initialization.

#### Other info (issues closed, discussion etc)

The problem only occurs in python 3.10, where the `__set_name__` attribute now exists. Python 3.9 and older do not appear to have attribute (or `__dict__`) on `@property`.