### PR TITLE
Fix `tickerhandler.clear`

### DIFF
--- a/evennia/scripts/tickerhandler.py
+++ b/evennia/scripts/tickerhandler.py
@@ -585,9 +585,9 @@ class TickerHandler(object):
         self.ticker_pool.stop(interval)
         if interval:
             self.ticker_storage = dict(
-                (store_key, store_key)
-                for store_key in self.ticker_storage
-                if store_key[1] != interval
+                (store_key, store_value)
+                for store_key, store_value in self.ticker_storage.items()
+                if store_key[3] != interval
             )
         else:
             self.ticker_storage = {}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Corrects the index for `interval` in `store_key` and iterates through `ticker_storage` as full key/value pairs to prevent caching bad data.

Note: There are several tuples being passed around in the code with the same data in seemingly different positions, so I referenced the return value for `_store_key` which generates all of the store_keys to find the index of 3:

`        return (packed_obj, methodname, outpath, interval, idstring, persistent)`

#### Other info (issues closed, discussion etc)

Resolves #2722 for develop; can be backported to close it completely.