### PR TITLE
Streamline `rpsystem` sdesc processing

### DIFF
--- a/evennia/contrib/rpg/rpsystem/__init__.py
+++ b/evennia/contrib/rpg/rpsystem/__init__.py
@@ -4,7 +4,6 @@ Roleplaying emotes and language - Griatch, 2015
 """
 
 from .rpsystem import EmoteError, SdescError, RecogError, LanguageError  # noqa
-from .rpsystem import ordered_permutation_regex, regex_tuple_from_key_alias  # noqa
 from .rpsystem import parse_language, parse_sdescs_and_recogs, send_emote  # noqa
 from .rpsystem import SdescHandler, RecogHandler  # noqa
 from .rpsystem import RPCommand, CmdEmote, CmdSay, CmdSdesc, CmdPose, CmdRecog, CmdMask  # noqa

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -694,7 +694,7 @@ class SdescHandler:
         self.sdesc = self.obj.attributes.get("_sdesc", default=self.obj.key)
         sdesc_regex = self.obj.attributes.get("_sdesc_regex", default="")
         if not sdesc_regex:
-            permutation_string = " ".join([self.key] + self.aliases.all())
+            permutation_string = " ".join([self.obj.key] + self.obj.aliases.all())
             sdesc_regex = ordered_permutation_regex(permutation_string)
         self.sdesc_regex = re.compile(sdesc_regex, _RE_FLAGS)
 

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -284,7 +284,7 @@ def parse_language(speaker, emote):
         # the key is simply the running match in the emote
         key = f"##{imatch}"
         # replace say with ref markers in emote
-        emote = "{start}{key}{end}".format( start=emote[:istart], key=key, end=emote[iend:] )
+        emote = "{start}{{{key}}}{end}".format( start=emote[:istart], key=key, end=emote[iend:] )
         mapping[key] = (langname, saytext)
 
     if errors:
@@ -408,6 +408,8 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
                 # save current index as end point of matched text
                 iend = i
 
+            # save search string
+            matched_text = "".join(tail[1:iend])
             # recombine remainder of emote back into a string
             tail = "".join(tail[iend+1:])
 
@@ -469,7 +471,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             # multimatch error
             refname = marker_match.group()
             reflist = [
-                "{name}{sep}{num} ({text}{key})".format(
+                "{num}{sep}{name} ({text}{key})".format(
                     num=inum + 1,
                     sep=_NUM_SEP,
                     name=_RE_PREFIX.sub("", refname),
@@ -581,7 +583,7 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
         receiver_sdesc_mapping = dict(
             (
                 ref,
-                obj.get_display_name(receiver, noid=True),
+                obj.get_display_name(receiver, ref=ref, noid=True),
             )
             for ref, obj in obj_mapping.items()
         )
@@ -1109,7 +1111,7 @@ class CmdRecog(RPCommand):  # assign personal alias to object in room
             caller.msg(_EMOTE_NOMATCH_ERROR.format(ref=sdesc))
         elif nmatches > 1:
             reflist = [
-                "{sdesc}{sep}{num} ({recog}{key})".format(
+                "{num}{sep}{sdesc} ({recog}{key})".format(
                     num=inum + 1,
                     sep=_NUM_SEP,
                     sdesc=_RE_PREFIX.sub("", sdesc),
@@ -1461,7 +1463,7 @@ class ContribRPObject(DefaultObject):
         
         # add dbref is looker has control access and `noid` is not set
         if self.access(looker, access_type="control") and not kwargs.get("noid",False):
-            sdesc = f"{sdesc}{self.id}"
+            sdesc = f"{sdesc}(#{self.id})"
         
         return self.get_posed_sdesc(sdesc) if kwargs.get("pose", False) else sdesc
 

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -526,7 +526,7 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
     # if anonymous_add is passed as a kwarg, collect and remove it from kwargs
     if "anonymous_add" in kwargs:
         anonymous_add = kwargs.pop("anonymous_add")
-    self_refs = (f"{skey}{ref}" for ref in ('t','^','v','~',''))
+    self_refs = [f"{skey}{ref}" for ref in ('t','^','v','~','')]
     if anonymous_add and not any(1 for tag in obj_mapping if tag in self_refs):
         # no self-reference in the emote - add to the end
         if anonymous_add == "first":

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1555,18 +1555,24 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
             characters stand out from other objects.
 
         """
-        idstr = "(#%s)" % self.id if self.access(looker, access_type="control") and not kwargs.get("noid",False) else ""
         ref = kwargs.get("ref","~")
     
         if looker == self:
+            # process your key as recog since you recognize yourself
             sdesc = self.process_recog(self.key,self)
         else:
             try:
+                # get the sdesc looker should see, with formatting
                 sdesc = looker.get_sdesc(self, process=True, ref=ref)
             except AttributeError:
+                # use own sdesc as a fallback
                 sdesc = self.sdesc.get()
-        pose = " %s" % (self.db.pose or "is here.") if kwargs.get("pose", False) else ""
-        return "%s%s%s" % (sdesc, idstr, pose)
+
+        # add dbref is looker has control access and `noid` is not set
+        if self.access(looker, access_type="control") and not kwargs.get("noid",False):
+            sdesc = f"{sdesc}{self.id}"
+
+        return self.get_posed_sdesc(sdesc) if kwargs.get("pose", False) else sdesc
 
 
     def at_object_creation(self):

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -691,7 +691,7 @@ class SdescHandler:
         """
         Cache data from storage
         """
-        self.sdesc = self.obj.attributes.get("_sdesc", default="")
+        self.sdesc = self.obj.attributes.get("_sdesc", default=obj.key)
         sdesc_regex = self.obj.attributes.get("_sdesc_regex", default="")
         if not sdesc_regex:
             permutation_string = " ".join([self.key] + self.aliases.all())

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1531,7 +1531,7 @@ class ContribRPObject(DefaultObject):
             sdesc = self.key
         else:
             try:
-                sdesc = looker.get_sdesc(self, process=True, ref=ref)
+                sdesc = looker.get_sdesc(self, ref=ref)
             except AttributeError:
                 sdesc = self.sdesc.get()
         pose = " %s" % (self.db.pose or "is here.") if kwargs.get("pose", False) else ""

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1583,7 +1583,8 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
             obj (Object): the object whose sdesc or recog is being gotten
         Keyword Args:
             process (bool): If True, the sdesc/recog is run through the
-                appropriate process method (process_sdesc or process_recog)
+                appropriate process method for self - .process_sdesc or
+                .process_recog
         """
         # always see own key
         if obj == self:

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -564,7 +564,6 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
     # broadcast emote to everyone
     for receiver in receivers:
         # first handle the language mapping, which always produce different keys ##nn
-        receiver_lang_mapping = {}
         if hasattr(receiver, "process_language") and callable(receiver.process_language):
             receiver_lang_mapping = {
                 key: receiver.process_language(saytext, sender, langname)

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1585,11 +1585,6 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
     This is a character class that has poses, sdesc and recog.
     """
 
-    # Handlers
-    @lazy_property
-    def sdesc(self):
-        return SdescHandler(self)
-
     @lazy_property
     def recog(self):
         return RecogHandler(self)
@@ -1739,14 +1734,15 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
                 translated from the original sdesc at this point.
             obj (Object): The object the recog:ed string belongs to.
                 This is not used by default.
-        Kwargs:
-            ref (str): See process_sdesc.
 
         Returns:
             recog (str): The modified recog string.
 
         """
-        return self.process_sdesc(recog, obj, **kwargs)
+        if not sdesc:
+            return ""
+
+        return "|m%s|n" % sdesc
 
     def process_language(self, text, speaker, language, **kwargs):
         """

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -790,7 +790,7 @@ class RecogHandler:
         """
         if obj in self.obj2recog:
             del self.obj.db._recog_obj2recog[obj]
-            del self.obj.db._recog_obj2regex[obj]
+            del self.obj.db._recog_ref2recog["#%i" % obj.id]
         self._cache()
 
 

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -186,13 +186,13 @@ _EMOTE_MULTIMATCH_ERROR = """|RMultiple possibilities for {ref}:
 
 _RE_FLAGS = re.MULTILINE + re.IGNORECASE + re.UNICODE
 
-_RE_PREFIX = re.compile(r"^%s" % _PREFIX, re.UNICODE)
+_RE_PREFIX = re.compile(rf"^{_PREFIX}", re.UNICODE)
 
 # This regex will return groups (num, word), where num is an optional counter to
 # separate multimatches from one another and word is the first word in the
 # marker. So entering "/tall man" will return groups ("", "tall")
 # and "/2-tall man" will return groups ("2", "tall").
-_RE_OBJ_REF_START = re.compile(r"%s(?:([0-9]+)%s)*(\w+)" % (_PREFIX, _NUM_SEP), _RE_FLAGS)
+_RE_OBJ_REF_START = re.compile(rf"{_PREFIX}(?:([0-9]+){_NUM_SEP})*(\w+)", _RE_FLAGS)
 
 _RE_LEFT_BRACKETS = re.compile(r"\{+", _RE_FLAGS)
 _RE_RIGHT_BRACKETS = re.compile(r"\}+", _RE_FLAGS)
@@ -350,7 +350,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             candidate_map.append((obj, obj.sdesc.get()))
         # if no sdesc, include key plus aliases instead
         else:
-            candidate_map += [(obj, obj.key)] + [(obj, alias) for alias in obj.aliases.all()]
+            candidate_map.extend( [(obj, obj.key)] + [(obj, alias) for alias in obj.aliases.all()] )
 
     # escape mapping syntax on the form {#id} if it exists already in emote,
     # if so it is replaced with just "id".
@@ -1568,7 +1568,7 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
 
         # add dbref is looker has control access and `noid` is not set
         if self.access(looker, access_type="control") and not kwargs.get("noid",False):
-            sdesc = f"{sdesc}{self.id}"
+            sdesc = f"{sdesc}(#{self.id})"
 
         return self.get_posed_sdesc(sdesc) if kwargs.get("pose", False) else sdesc
 

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1232,6 +1232,10 @@ class ContribRPObject(DefaultObject):
         self.db.pose = ""
         self.db.pose_default = "is here."
 
+        # initializing sdesc
+        self.db._sdesc = ""
+        self.sdesc.add("Something")
+
     def search(
         self,
         searchdata,
@@ -1404,6 +1408,22 @@ class ContribRPObject(DefaultObject):
             multimatch_string=multimatch_string,
         )
 
+    def get_posed_sdesc(self, sdesc, **kwargs):
+        """
+        Displays the object with its current pose string.
+        
+        Returns:
+            pose (str): A string containing the object's sdesc and
+                current or default pose.
+        """
+        
+        # get the current pose, or default if no pose is set
+        pose = self.db.pose or self.db.pose_default
+        
+        # return formatted string, or sdesc as fallback
+        return f"{sdesc} {pose}" if pose else sdesc
+
+
     def get_display_name(self, looker, **kwargs):
         """
         Displays the name of the object in a viewer-aware manner.
@@ -1430,7 +1450,6 @@ class ContribRPObject(DefaultObject):
                 is privileged to control said object.
 
         """
-        idstr = "(#%s)" % self.id if self.access(looker, access_type="control") and not kwargs.get("noid",False) else ""
         ref = kwargs.get("ref","~")
     
         if looker == self:
@@ -1443,8 +1462,13 @@ class ContribRPObject(DefaultObject):
             except AttributeError:
                 # use own sdesc as a fallback
                 sdesc = self.sdesc.get()
-        pose = " %s" % (self.db.pose or "is here.") if kwargs.get("pose", False) else ""
-        return "%s%s%s" % (sdesc, idstr, pose)
+        
+        # add dbref is looker has control access and `noid` is not set
+        if self.access(looker, access_type="control") and not kwargs.get("noid",False):
+            sdesc = f"{sdesc}{self.id}"
+        
+        return self.get_posed_sdesc(sdesc) if kwargs.get("pose", False) else sdesc
+
 
     def return_appearance(self, looker):
         """

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -53,7 +53,7 @@ Add `RPSystemCmdSet` from this module to your CharacterCmdSet:
 
 # ...
 
-from evennia.contrib.rpg.rpsystem import RPSystemCmdSet  <---
+from evennia.contrib.rpg.rpsystem.rpsystem import RPSystemCmdSet  <---
 
 class CharacterCmdSet(default_cmds.CharacterCmdset):
     # ...
@@ -69,7 +69,7 @@ the typeclasses in this module:
 ```python
 # in mygame/typeclasses/characters.py
 
-from evennia.contrib.rpg import ContribRPCharacter
+from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPCharacter
 
 class Character(ContribRPCharacter):
     # ...
@@ -79,7 +79,7 @@ class Character(ContribRPCharacter):
 ```python
 # in mygame/typeclasses/objects.py
 
-from evennia.contrib.rpg import ContribRPObject
+from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPObject
 
 class Object(ContribRPObject):
     # ...
@@ -89,7 +89,7 @@ class Object(ContribRPObject):
 ```python
 # in mygame/typeclasses/rooms.py
 
-from evennia.contrib.rpg import ContribRPRoom
+from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPRoom
 
 class Room(ContribRPRoom):
     # ...
@@ -125,7 +125,7 @@ Extra Installation Instructions:
 
 1. In typeclasses/character.py:
    Import the `ContribRPCharacter` class:
-       `from evennia.contrib.rpg.rpsystem import ContribRPCharacter`
+       `from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPCharacter`
    Inherit ContribRPCharacter:
        Change "class Character(DefaultCharacter):" to
        `class Character(ContribRPCharacter):`
@@ -133,13 +133,13 @@ Extra Installation Instructions:
        Add `super().at_object_creation()` as the top line.
 2. In `typeclasses/rooms.py`:
        Import the `ContribRPRoom` class:
-       `from evennia.contrib.rpg.rpsystem import ContribRPRoom`
+       `from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPRoom`
    Inherit `ContribRPRoom`:
        Change `class Room(DefaultRoom):` to
        `class Room(ContribRPRoom):`
 3. In `typeclasses/objects.py`
        Import the `ContribRPObject` class:
-       `from evennia.contrib.rpg.rpsystem import ContribRPObject`
+       `from evennia.contrib.rpg.rpsystem.rpsystem import ContribRPObject`
    Inherit `ContribRPObject`:
        Change `class Object(DefaultObject):` to
        `class Object(ContribRPObject):`

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -691,7 +691,7 @@ class SdescHandler:
         """
         Cache data from storage
         """
-        self.sdesc = self.obj.attributes.get("_sdesc", default=obj.key)
+        self.sdesc = self.obj.attributes.get("_sdesc", default=self.obj.key)
         sdesc_regex = self.obj.attributes.get("_sdesc_regex", default="")
         if not sdesc_regex:
             permutation_string = " ".join([self.key] + self.aliases.all())

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -644,8 +644,8 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
         sendemote = emote.format(**receiver_lang_mapping)
 
         receiver_sdesc_mapping = dict(
-           (
-               ref,
+            (
+                ref,
                 obj.get_display_name(receiver, ref=ref),
             )
             for ref, obj in obj_mapping.items()
@@ -693,12 +693,10 @@ class SdescHandler:
         """
         self.sdesc = self.obj.attributes.get("_sdesc", default="")
         sdesc_regex = self.obj.attributes.get("_sdesc_regex", default="")
-        if self.sdesc:
-            self.sdesc_regex = re.compile(sdesc_regex, _RE_FLAGS)
-        else:
+        if not sdesc_regex:
             permutation_string = " ".join([self.key] + self.aliases.all())
-            self.sdesc_regex = re.compile(ordered_permutation_regex(permutation_string), _RE_FLAGS)
-
+            sdesc_regex = ordered_permutation_regex(permutation_string)
+        self.sdesc_regex = re.compile(sdesc_regex, _RE_FLAGS)
 
     def add(self, sdesc, max_length=60):
         """
@@ -1739,10 +1737,10 @@ class ContribRPCharacter(DefaultCharacter, ContribRPObject):
             recog (str): The modified recog string.
 
         """
-        if not sdesc:
+        if not recog:
             return ""
 
-        return "|m%s|n" % sdesc
+        return "|m%s|n" % recog
 
     def process_language(self, text, speaker, language, **kwargs):
         """

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -372,11 +372,12 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
         # first see if there is a number given (e.g. 1-tall)
         num_identifier, _ = marker_match.groups("")  # return "" if no match, rather than None
         match_index = marker_match.start()
+        # split the emote string at the reference marker, to process everything after it
         head = string[:match_index]
         tail = string[match_index+1:]
         
         if search_mode:
-            # match the candidates against the whole search string
+            # match the candidates against the whole search string after the marker
             rquery = "".join([r"\b(" + re.escape(word.strip(punctuation)) + r").*" for word in iter(tail.split())])
             matches = ((re.search(rquery, text, _RE_FLAGS), obj, text) for obj, text in candidate_map)
             # filter out any non-matching candidates
@@ -397,7 +398,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
                 word_list.append(item)
                 rquery = "".join([r"\b(" + re.escape(word) + r").*" for word in word_list])
                 # match candidates against the current set of words
-                matches = ((re.search(re.search(rquery, text, _RE_FLAGS), obj, text) for obj, text in candidate_map)
+                matches = ((re.search(rquery, text, _RE_FLAGS), obj, text) for obj, text in candidate_map)
                 matches = [(obj, match.group()) for match, obj, text in matches if match]
                 if len(matches) == 0:
                     # no matches at this length, keep previous iteration as best

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -773,13 +773,13 @@ class RecogHandler:
 
     def get(self, obj):
         """
-        Get recog replacement string, if one exists, otherwise
-        get sdesc and as a last resort, the object's key.
+        Get recog replacement string, if one exists.
 
         Args:
             obj (Object): The object, whose sdesc to replace
         Returns:
-            recog (str): The replacement string to use.
+            recog (str or None): The replacement string to use, or
+                None if there is no recog for this object.
 
         Notes:
             This method will respect a "enable_recog" lock set on

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -96,7 +96,7 @@ recog01 = "Mr Receiver"
 recog02 = "Mr Receiver2"
 recog10 = "Mr Sender"
 emote = 'With a flair, /me looks at /first and /colliding sdesc-guy. She says "This is a test."'
-case_emote = "/Me looks at /first, then /FIRST, /First and /Colliding twice."
+case_emote = "/Me looks at /first. Then, /me looks at /FIRST, /First and /Colliding twice."
 
 
 class TestRPSystem(BaseEvenniaTest):
@@ -225,20 +225,21 @@ class TestRPSystem(BaseEvenniaTest):
         rpsystem.send_emote(speaker, receivers, case_emote)
         self.assertEqual(
             self.out0,
-            "|mSender|n looks at |bthe first receiver of emotes.|n, then "
-            "|bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of emotes.|n and "
-            "|bAnother nice colliding sdesc-guy for tests|n twice.",
+            "|mSender|n looks at |bthe first receiver of emotes.|n. Then, |mSender|n "
+            "looks at |bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of emotes.|n "
+            "and |bAnother nice colliding sdesc-guy for tests|n twice.",
         )
         self.assertEqual(
             self.out1,
-            "|bA nice sender of emotes|n looks at |mReceiver1|n, then |mReceiver1|n, "
-            "|mReceiver1|n and |bAnother nice colliding sdesc-guy for tests|n twice.",
+            "|bA nice sender of emotes|n looks at |mReceiver1|n. Then, "
+            "|ba nice sender of emotes|n looks at |mReceiver1|n, |mReceiver1|n "
+            "and |bAnother nice colliding sdesc-guy for tests|n twice."
         )
         self.assertEqual(
             self.out2,
-            "|bA nice sender of emotes|n looks at |bthe first receiver of emotes.|n, "
-            "then |bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of "
-            "emotes.|n and |mReceiver2|n twice.",
+            "|bA nice sender of emotes|n looks at |bthe first receiver of emotes.|n. "
+            "Then, |ba nice sender of emotes|n looks at |bTHE FIRST RECEIVER OF EMOTES.|n, "
+            "|bThe first receiver of emotes.|n and |mReceiver2|n twice.",
         )
 
     def test_rpsearch(self):

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -96,7 +96,7 @@ recog01 = "Mr Receiver"
 recog02 = "Mr Receiver2"
 recog10 = "Mr Sender"
 emote = 'With a flair, /me looks at /first and /colliding sdesc-guy. She says "This is a test."'
-case_emote = "/me looks at /first, then /FIRST, /First and /Colliding twice."
+case_emote = "/Me looks at /first, then /FIRST, /First and /Colliding twice."
 
 
 class TestRPSystem(BaseEvenniaTest):
@@ -178,18 +178,18 @@ class TestRPSystem(BaseEvenniaTest):
         rpsystem.send_emote(speaker, receivers, emote, case_sensitive=False)
         self.assertEqual(
             self.out0,
-            "With a flair, |bSender|n looks at |bThe first receiver of emotes.|n "
+            "With a flair, |mSender|n looks at |bThe first receiver of emotes.|n "
             'and |bAnother nice colliding sdesc-guy for tests|n. She says |w"This is a test."|n',
         )
         self.assertEqual(
             self.out1,
-            "With a flair, |bA nice sender of emotes|n looks at |bReceiver1|n and "
+            "With a flair, |bA nice sender of emotes|n looks at |mReceiver1|n and "
             '|bAnother nice colliding sdesc-guy for tests|n. She says |w"This is a test."|n',
         )
         self.assertEqual(
             self.out2,
             "With a flair, |bA nice sender of emotes|n looks at |bThe first "
-            'receiver of emotes.|n and |bReceiver2|n. She says |w"This is a test."|n',
+            'receiver of emotes.|n and |mReceiver2|n. She says |w"This is a test."|n',
         )
 
     def test_send_case_sensitive_emote(self):
@@ -207,20 +207,20 @@ class TestRPSystem(BaseEvenniaTest):
         rpsystem.send_emote(speaker, receivers, case_emote)
         self.assertEqual(
             self.out0,
-            "|bSender|n looks at |bthe first receiver of emotes.|n, then "
+            "|mSender|n looks at |bthe first receiver of emotes.|n, then "
             "|bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of emotes.|n and "
             "|bAnother nice colliding sdesc-guy for tests|n twice.",
         )
         self.assertEqual(
             self.out1,
-            "|bA nice sender of emotes|n looks at |bReceiver1|n, then |bReceiver1|n, "
-            "|bReceiver1|n and |bAnother nice colliding sdesc-guy for tests|n twice.",
+            "|bA nice sender of emotes|n looks at |mReceiver1|n, then |mReceiver1|n, "
+            "|mReceiver1|n and |bAnother nice colliding sdesc-guy for tests|n twice.",
         )
         self.assertEqual(
             self.out2,
             "|bA nice sender of emotes|n looks at |bthe first receiver of emotes.|n, "
             "then |bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of "
-            "emotes.|n and |bReceiver2|n twice.",
+            "emotes.|n and |mReceiver2|n twice.",
         )
 
     def test_rpsearch(self):

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -164,6 +164,24 @@ class TestRPSystem(BaseEvenniaTest):
             result,
         )
 
+    def test_get_sdesc(self):
+        looker = self.speaker # Sender
+        target = self.receiver1 # Receiver1
+        looker.sdesc.add(sdesc0) # A nice sender of emotes
+        target.sdesc.add(sdesc1) # The first receiver of emotes.
+
+        # sdesc with no processing
+        self.assertEqual(looker.get_sdesc(target), "The first receiver of emotes.")
+        # sdesc with processing
+        self.assertEqual(looker.get_sdesc(target, process=True), "|bThe first receiver of emotes.|n")
+        
+        looker.recog.add(target, recog01) # Mr Receiver
+
+        # recog with no processing
+        self.assertEqual(looker.get_sdesc(target), "Mr Receiver")
+        # recog with processing
+        self.assertEqual(looker.get_sdesc(target, process=True), "|mMr Receiver|n")
+
     def test_send_emote(self):
         speaker = self.speaker
         receiver1 = self.receiver1
@@ -259,7 +277,7 @@ class TestRPSystemCommands(BaseEvenniaCommandTest):
         self.call(
             rpsystem.CmdRecog(),
             "barfoo as friend",
-            "Char will now remember BarFoo Character as friend.",
+            "You will now remember BarFoo Character as friend.",
         )
         self.call(
             rpsystem.CmdRecog(),
@@ -270,6 +288,6 @@ class TestRPSystemCommands(BaseEvenniaCommandTest):
         self.call(
             rpsystem.CmdRecog(),
             "friend",
-            "Char will now know them only as 'BarFoo Character'",
+            "You will now know them only as 'BarFoo Character'",
             cmdstring="forget",
         )

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -113,41 +113,11 @@ class TestRPSystem(BaseEvenniaTest):
             rpsystem.ContribRPCharacter, key="Receiver2", location=self.room
         )
 
-    def test_ordered_permutation_regex(self):
-        self.assertEqual(
-            rpsystem.ordered_permutation_regex(sdesc0),
-            "/[0-9]*-*A\\ nice\\ sender\\ of\\ emotes(?=\\W|$)+|"
-            "/[0-9]*-*nice\\ sender\\ of\\ emotes(?=\\W|$)+|"
-            "/[0-9]*-*A\\ nice\\ sender\\ of(?=\\W|$)+|"
-            "/[0-9]*-*sender\\ of\\ emotes(?=\\W|$)+|"
-            "/[0-9]*-*nice\\ sender\\ of(?=\\W|$)+|"
-            "/[0-9]*-*A\\ nice\\ sender(?=\\W|$)+|"
-            "/[0-9]*-*nice\\ sender(?=\\W|$)+|"
-            "/[0-9]*-*of\\ emotes(?=\\W|$)+|"
-            "/[0-9]*-*sender\\ of(?=\\W|$)+|"
-            "/[0-9]*-*A\\ nice(?=\\W|$)+|"
-            "/[0-9]*-*emotes(?=\\W|$)+|"
-            "/[0-9]*-*sender(?=\\W|$)+|"
-            "/[0-9]*-*nice(?=\\W|$)+|"
-            "/[0-9]*-*of(?=\\W|$)+|"
-            "/[0-9]*-*A(?=\\W|$)+",
-        )
-
     def test_sdesc_handler(self):
         self.speaker.sdesc.add(sdesc0)
         self.assertEqual(self.speaker.sdesc.get(), sdesc0)
         self.speaker.sdesc.add("This is {#324} ignored")
         self.assertEqual(self.speaker.sdesc.get(), "This is 324 ignored")
-        self.speaker.sdesc.add("Testing three words")
-        self.assertEqual(
-            self.speaker.sdesc.get_regex_tuple()[0].pattern,
-            "/[0-9]*-*Testing\ three\ words(?=\W|$)+|"
-            "/[0-9]*-*Testing\ three(?=\W|$)+|"
-            "/[0-9]*-*three\ words(?=\W|$)+|"
-            "/[0-9]*-*Testing(?=\W|$)+|"
-            "/[0-9]*-*three(?=\W|$)+|"
-            "/[0-9]*-*words(?=\W|$)+",
-        )
 
     def test_recog_handler(self):
         self.speaker.sdesc.add(sdesc0)
@@ -156,12 +126,8 @@ class TestRPSystem(BaseEvenniaTest):
         self.speaker.recog.add(self.receiver2, recog02)
         self.assertEqual(self.speaker.recog.get(self.receiver1), recog01)
         self.assertEqual(self.speaker.recog.get(self.receiver2), recog02)
-        self.assertEqual(
-            self.speaker.recog.get_regex_tuple(self.receiver1)[0].pattern,
-            "/[0-9]*-*Mr\\ Receiver(?=\\W|$)+|/[0-9]*-*Receiver(?=\\W|$)+|/[0-9]*-*Mr(?=\\W|$)+",
-        )
         self.speaker.recog.remove(self.receiver1)
-        self.assertEqual(self.speaker.recog.get(self.receiver1), sdesc1)
+        self.assertEqual(self.speaker.recog.get(self.receiver1), None)
 
         self.assertEqual(self.speaker.recog.all(), {"Mr Receiver2": self.receiver2})
 
@@ -264,18 +230,6 @@ class TestRPSystem(BaseEvenniaTest):
         self.speaker.msg = lambda text, **kwargs: setattr(self, "out0", text)
         self.assertEqual(self.speaker.search("receiver of emotes"), self.receiver1)
         self.assertEqual(self.speaker.search("colliding"), self.receiver2)
-
-    def test_regex_tuple_from_key_alias(self):
-        self.speaker.aliases.add("foo bar")
-        self.speaker.aliases.add("this thing is a long thing")
-        t0 = time.time()
-        result = rpsystem.regex_tuple_from_key_alias(self.speaker)
-        t1 = time.time()
-        result = rpsystem.regex_tuple_from_key_alias(self.speaker)
-        t2 = time.time()
-        # print(f"t1: {t1 - t0}, t2: {t2 - t1}")
-        self.assertLess(t2 - t1, 10**-4)
-        self.assertEqual(result, (Anything, self.speaker, self.speaker.key))
 
 
 class TestRPSystemCommands(BaseEvenniaCommandTest):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves the SdescHandler to the base `ContribRPObject` class and streamlines the recog/sdesc fetching and processing for ease of customization.

It also rewrites the sdesc parsing for searches and emotes, moving the regex processing onto the search/emote text and eliminating the regex calculations and cache for sdescs, as per #2724

#### Motivation for adding to Evennia
I've been using the rpsystem contrib for a while and it has a lot of quirks which have made basic customizations a bit difficult. Most of the streamlining changes are intended to make that customization simpler by minimizing how much code you have to modify in order to overload display options, such as sdesc vs recog coloring.

Additionally, the current ordered permutation regex generation makes loading multiple objects with multi-word names cause sizeable hangs in the game (see issue above), which can be a real problem in any game with descriptive object names.

#### Other information
~~This is a draft because it's currently a port of some of my own customizations back into the base contrib, and while I won't have an opportunity to test it and review the unit tests for at least a couple days, I'd like to make it available for feedback.~~

Please feel free to critique/correct any regex that could be improved; regular expressions are not my forte.