### PR TITLE
Fix NAttr indents on examine

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2732,7 +2732,7 @@ class CmdExamine(ObjManipCommand):
             return
 
         if ndb_attr and ndb_attr[0]:
-            return "\n  " + "  \n".join(
+            return "\n  " + "\n  ".join(
                 sorted(self.format_single_attribute(attr) for attr in ndb_attr)
             )
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A typo in the `examine` command messed up the indentation on the NAttributes section; this corrects the typo.