### PR TITLE
Schedule and Global Script fixes

### DIFF
--- a/evennia/contrib/base_systems/custom_gametime/custom_gametime.py
+++ b/evennia/contrib/base_systems/custom_gametime/custom_gametime.py
@@ -328,4 +328,4 @@ class GametimeScript(DefaultScript):
             callback()
 
         seconds = real_seconds_until(**self.db.gametime)
-        self.restart(interval=seconds)
+        self.start(interval=seconds,force_restart=True)

--- a/evennia/utils/containers.py
+++ b/evennia/utils/containers.py
@@ -167,7 +167,6 @@ class GlobalScriptContainer(Container):
 
             # store a hash representation of the setup
             script.attributes.add("_global_script_settings", compare_hash, category="settings_hash")
-        script.start()
 
         return script
 
@@ -183,9 +182,12 @@ class GlobalScriptContainer(Container):
         # populate self.typeclass_storage
         self.load_data()
 
-        # start registered scripts
+        # make sure settings-defined scripts are loaded
         for key in self.loaded_data:
             self._load_script(key)
+        # start all global scripts
+        for script in self._get_scripts():
+            script.start()
 
     def load_data(self):
         """

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -67,7 +67,7 @@ class TimeScript(DefaultScript):
             callback(*args, **kwargs)
 
         seconds = real_seconds_until(**self.db.gametime)
-        self.restart(interval=seconds)
+        self.start(interval=seconds,force_restart=True)
 
 
 # Access functions


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Corrects leftover and now obsolete `.restart` calls on `schedule` to make them reinitialize delays properly, and updates `GlobalScriptContainer` to make sure all global scripts are loaded in `.start`

#### Other info (issues closed, discussion etc)
Closes #2712 and #2744
