### PR TITLE
Fix webclient error on server-side echo

### DIFF
--- a/evennia/web/static/webclient/js/evennia.js
+++ b/evennia/web/static/webclient/js/evennia.js
@@ -149,7 +149,7 @@ An "emitter" object must have a function
         //   kwargs (obj): keyword-args to listener
         //
         emit: function (cmdname, args, kwargs) {
-            if (kwargs.cmdid) {
+            if (kwargs.cmdid && (kwargs.cmdid in cmdmap)) {
                 cmdmap[kwargs.cmdid].apply(this, [args, kwargs]);
                 delete cmdmap[kwargs.cmdid];
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a check to the webclient to make sure a cmdid has a stored callback before trying to retrieve it.

#### Other info (issues closed, discussion etc)
Closes #2742