### PR TITLE
fix google style URL on CODING_STYLE.md

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -199,7 +199,7 @@ or in the chat.
 
 [pep8]: http://www.python.org/dev/peps/pep-0008
 [pep8tool]: https://pypi.python.org/pypi/pep8
-[googlestyle]: http://www.sphinx-doc.org/en/stable/ext/example_google.html
+[googlestyle]: https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html
 [githubmarkdown]: https://help.github.com/articles/github-flavored-markdown/
 [markdown-hilight]: https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting
 [command-docstrings]: https://github.com/evennia/evennia/wiki/Using%20MUX%20As%20a%20Standard#documentation-policy


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Current URL for the example google style docstring is leading to a 404 page. This PR just update to the proper URL.
