### PR TITLE
Fix ANSI_NORMAL override in text2html

### DIFF
--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -234,9 +234,9 @@ class TextToHTMLparser(object):
 
         for i, substr in enumerate(str_list):
             # reset all current styling
-            if substr == ANSI_NORMAL and not clean:
-                # replace with close existing tag
-                str_list[i] = "</span>"
+            if substr == ANSI_NORMAL:
+                # close any existing span if necessary
+                str_list[i] = "</span>" if not clean else ""
                 # reset to defaults
                 classes = []
                 clean = True


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This patch resets style states on ANSI_NORMAL flag regardless of `clean` status.

#### Motivation for adding to Evennia
Fixes the webclient displaying undesired styling that should be cleared by the ANSI_NORMAL flag.