### PR TITLE
Update the Links page

### DIFF
--- a/docs/source/Links.md
+++ b/docs/source/Links.md
@@ -24,15 +24,15 @@ channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUm
 
 ## Third-party Evennia tools
 
+- [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional coloration for Evennia unit-test output.
 - [Evennia-docker](https://github.com/gtaylor/evennia-docker) - Evennia in a [Docker container](https://www.docker.com/) for quick install and deployment in just a few commands.
 - [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your website.
-- [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional coloration for Evennia unit-test output.
 - [Paxboards](https://github.com/aurorachain/paxboards) - Evennia bulletin board system (both for telnet/web).
-- [The world of Cool battles sources](https://github.com/FlutterSprite/coolbattles) - Open source turn-based battle system for an older version of Evennia.
 - [nextRPI](https://github.com/cluebyte/nextrpi) - A github project for making a toolbox for people to make [RPI](https://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
 - [Unreal Engine Evennia plugin](https://www.unrealengine.com/marketplace/en-US/slug/evennia-plugin) an in-progress Unreal plugin for integrating Evennia with Epic Games' Unreal Engine.
 - [vim-evennia](https://github.com/amfl/vim-evennia) - A mode for editing batch-build files (`.ev`) files in the [vim](https://www.vim.org/) text editor (Emacs users can use [evennia-
 mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mode.el)).
+- [The world of Cool battles sources](https://github.com/FlutterSprite/coolbattles) - Open source turn-based battle system for an older version of Evennia.
 - [Other Evennia-related repos on github](https://github.com/search?p=1&q=evennia)
 
 ----
@@ -41,9 +41,9 @@ mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mo
 
 ### Code bases
 - [Arx sources](https://github.com/Arx-Game/arxcode) - Open-source code release of the very popular [Arx](https://play.arxmush.org/) Evennia game. [Here are instructions for installing](https://www.evennia.com/docs/1.0-dev/Howtos/Arxcode-Installation.html)
+- [Encarnia sources](https://github.com/whitehorse-io/encarnia) - An open-sourced game dir for an older version of Evennia with things like races, combat etc. [Summary here](https://www.reddit.com/r/MUD/comments/6z6s3j/encarnia_an_evennia_python_mud_code_base_with/).
 - [The dark net/March Hare MUD](https://github.com/thedarknet/evennia) from the 2019 [DEF CON 27](https://www.defcon.org/html/defcon-27/dc-27-index.html) hacker conference in Paris. This is an Evennia game dir with batchcode to build the custom _Hackers_ style cyberspace zone with puzzles and challenges [used during the conference](https://dcdark.net/home#).
 - [Muddery](https://github.com/muddery/muddery) - A mud framework under development, based on an older fork of Evennia. It has some specific design goals for building and extending the game based on input files.
-- [Encarnia sources](https://github.com/whitehorse-io/encarnia) - An open-sourced game dir for an older version of Evennia with things like races, combat etc. [Summary here](https://www.reddit.com/r/MUD/comments/6z6s3j/encarnia_an_evennia_python_mud_code_base_with/).
 
 ### Other
 
@@ -62,24 +62,23 @@ mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mo
 
 ### Informational
 
-- [Mud-dev wiki](http://mud-dev.wikidot.com/) - A (very) slowly growing resource on MUD creation.
-- [Mud Client/Server Interaction](http://cryosphere.net/mud-protocol.html) - A page on classic MUD telnet protocols.
-- [Mud Tech's fun/cool but ...](https://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-ship-damned-thing/) - Greg Taylor gives good advice on mud design.
-- [Lost Library of MOO](https://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in particular moo).
-- [Nick Gammon's hints thread](http://www.gammon.com.au/forum/bbshowpost.php?bbsubject_id=5959) - Contains a very useful list of things to think about when starting your new MUD.
-- Mud Dev mailing list archive ([mirror](http://www.disinterest.org/resource/MUD-Dev/)) - Influential mailing list active 1996-2004. Advanced game design discussions.
-- [Raph Koster's laws of game design](https://www.raphkoster.com/games/laws-of-online-world-design/the-laws-of-online-world-design/) - thought-provoking guidelines and things to think about when designing a virtual multiplayer world (Raph is known for *Ultima Online* among other things).
 - [Imaginary Realities unofficial archive](http://tharsis-gate.org/articles/imaginary.html) - An e-magazine on game and MUD design that has several articles about Evennia.
+- [Lost Library of MOO](https://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in particular moo).
+- [Mud Client/Server Interaction](http://cryosphere.net/mud-protocol.html) - A page on classic MUD telnet protocols.
+- [Mud-dev wiki](http://mud-dev.wikidot.com/) - A (very) slowly growing resource on MUD creation.
+- [Mud Tech's fun/cool but ...](https://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-ship-damned-thing/) - Greg Taylor gives good advice on mud design.
+- [Nick Gammon's hints thread](http://www.gammon.com.au/forum/bbshowpost.php?bbsubject_id=5959) - Contains a very useful list of things to think about when starting your new MUD.
+- [Raph Koster's laws of game design](https://www.raphkoster.com/games/laws-of-online-world-design/the-laws-of-online-world-design/) - thought-provoking guidelines and things to think about when designing a virtual multiplayer world (Raph is known for *Ultima Online* among other things).
 
 ### Community
 
-- [Grapevine MUD community and chat network](https://grapevine.haus/)
+- [Grapevine](https://grapevine.haus/) - MUD listings and inter-game chat network
 - [MUD Coder's Guild](https://mudcoders.com/) - A blog and [associated Slack channel](https://slack.mudcoders.com/) with discussions on MUD development.
+- [MudBytes](http://www.mudbytes.net/) - MUD listing and forums
+- [MudConnector](http://www.mudconnect.com/) - MUD listing and forums
+- [MudLab](http://mudlab.org/) - MUD design discussion forum
 - [MuSoapbox](https://musoapbox.net/) - MU* forum mainly focused on MUSH-type gaming.
-- [MudLab](http://mudlab.org/) - Mud design discussion forum
-- [MudConnector](http://www.mudconnect.com/) - Mud listing and forums
-- [MudBytes](http://www.mudbytes.net/) - Mud listing and forums
-- [Top Mud Sites](http://www.topmudsites.com/) - Mud listing and forums
+- [Top Mud Sites](http://www.topmudsites.com/) - MUD listing and forums
 
 ----
 

--- a/docs/source/Links.md
+++ b/docs/source/Links.md
@@ -2,127 +2,121 @@
 
 *A list of resources that may be useful for Evennia users and developers.*
 
-## Official Evennia links
+## Official Evennia resources
 
 - [evennia.com](https://www.evennia.com) - Main Evennia portal page. Links to all corners of Evennia.
-- [Evennia github page](https://github.com/evennia/evennia) - Download code and read documentation.
-- [Evennia official chat
-channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb)
-- Our official IRC chat #evennia at irc.freenode.net:6667.
-- [Evennia forums/mailing list](https://groups.google.com/group/evennia) - Web interface to our
-google group.
-- [Evennia development blog](https://evennia.blogspot.com/) - Musings from the lead developer.
 - [Evennia's manual on ReadTheDocs](https://readthedocs.org/projects/evennia/) - Read and download
 offline in html, PDF or epub formats.
-- [Evennia Game Index](http://games.evennia.com/) - An automated listing of Evennia games.
-----
+- [Evennia development blog](https://evennia.blogspot.com/) - Musings from the lead developer.
+- [Evennia on GitHub](https://github.com/evennia/evennia) - Download code and read documentation.
 - [Evennia on Open Hub](https://www.openhub.net/p/6906)
 - [Evennia on OpenHatch](https://openhatch.org/projects/Evennia)
 - [Evennia on PyPi](https://pypi.python.org/pypi/Evennia-MUD-Server/)
-- [Evennia subreddit](https://www.reddit.com/r/Evennia/) (not much there yet though)
 
-## Third-party Evennia utilities and resources
+## Evennia Community
 
-*For publicly available games running on Evennia, add and find those in the [Evennia game
-index](http://games.evennia.com) instead!*
+- [Evennia Game Index](http://games.evennia.com/) - An automated listing of Evennia games.
+- [Evennia official Discord channel](https://discord.gg/AJJpcRUhtF)
+- [Evennia official IRC
+channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb) ( #evennia at [irc.freenode.net:6667](http://irc.freenode.net:6667/) )
+- [Evennia official forums](https://github.com/evennia/evennia/discussions) on Github Discussions.
+- [Evennia subreddit](https://www.reddit.com/r/Evennia/)
 
-- [Discord Evennia channel](https://discord.gg/NecFePw) - This is a fan-driven Discord channel with
-a bridge to the official Evennia IRC channel.
+## Third-party Evennia tools
 
----
-
-- [Discord live blog](https://discordapp.com/channels/517176782357528616/517176782781415434) of the
-_Blackbirds_ Evennia game project.
-- [Unreal Engine Evennia plugin](https://www.unrealengine.com/marketplace/en-US/slug/evennia-plugin)
-  an in-progress Unreal plugin for integrating Evennia with Epic Games' Unreal Engine.
-- [The dark net/March Hare MUD](https://github.com/thedarknet/evennia) from the 2019 [DEF CON
-27](https://www.defcon.org/html/defcon-27/dc-27-index.html) hacker conference in Paris. This is an
-Evennia game dir with batchcode to build the custom _Hackers_ style cyberspace zone with puzzles and
-challenges [used during the conference](https://dcdark.net/home#).
-- [Arx sources](https://github.com/Arx-Game/arxcode) - Open-source code release of the very popular
-[Arx](https://play.arxmush.org/) Evennia game. [Here are instructions for installing](Arxcode-
-installing-help)
-- [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your
-website.
-- [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional
-coloration for Evennia unit-test output.
-- [Paxboards](https://github.com/aurorachain/paxboards) - Evennia bulletin board system (both for
-telnet/web).
-- [Encarnia sources](https://github.com/whitehorse-io/encarnia) - An open-sourced game dir for
-Evennia with things like races, combat etc. [Summary
-here](https://www.reddit.com/r/MUD/comments/6z6s3j/encarnia_an_evennia_python_mud_code_base_with/).
-- [The world of Cool battles sources](https://github.com/FlutterSprite/coolbattles) - Open source
-turn-based battle system for Evennia. It also has a [live demo](http://wcb.battlestudio.com/).
-- [nextRPI](https://github.com/cluebyte/nextrpi) - A github project for making a toolbox for people
-to make [RPI](https://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
-- [Muddery](https://github.com/muddery/muddery) - A mud framework under development, based on an
-older fork of Evennia. It has some specific design goals for building and extending the game based
-on input files.
-- [vim-evennia](https://github.com/amfl/vim-evennia) - A mode for editing batch-build files (`.ev`)
-files in the [vim](https://www.vim.org/) text editor (Emacs users can use [evennia-
+- [Evennia-docker](https://github.com/gtaylor/evennia-docker) - Evennia in a [Docker container](https://www.docker.com/) for quick install and deployment in just a few commands.
+- [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your website.
+- [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional coloration for Evennia unit-test output.
+- [Paxboards](https://github.com/aurorachain/paxboards) - Evennia bulletin board system (both for telnet/web).
+- [The world of Cool battles sources](https://github.com/FlutterSprite/coolbattles) - Open source turn-based battle system for an older version of Evennia.
+- [nextRPI](https://github.com/cluebyte/nextrpi) - A github project for making a toolbox for people to make [RPI](https://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
+- [Unreal Engine Evennia plugin](https://www.unrealengine.com/marketplace/en-US/slug/evennia-plugin) an in-progress Unreal plugin for integrating Evennia with Epic Games' Unreal Engine.
+- [vim-evennia](https://github.com/amfl/vim-evennia) - A mode for editing batch-build files (`.ev`) files in the [vim](https://www.vim.org/) text editor (Emacs users can use [evennia-
 mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mode.el)).
 - [Other Evennia-related repos on github](https://github.com/search?p=1&q=evennia)
+
 ----
-- [EvCast video series](https://www.youtube.com/playlist?list=PLyYMNttpc-SX1hvaqlUNmcxrhmM64pQXl) -
-Tutorial videos explaining installing Evennia, basic Python etc.
-- [Evennia-docker](https://github.com/gtaylor/evennia-docker) - Evennia in a [Docker
-container](https://www.docker.com/) for quick install and deployment in just a few commands.
-- [Evennia's docs in Chinese](http://www.evenniacn.com/) - A translated mirror of a slightly older
-Evennia version. Announcement [here](https://groups.google.com/forum/#!topic/evennia/3AXS8ZTzJaA).
-- [Evennia for MUSHers](https://musoapbox.net/topic/1150/evennia-for-mushers) - An article describing
-Evennia for those used to the MUSH way of doing things.
-- *[Language Understanding for Text games using Deep reinforcement
-learning](http://news.mit.edu/2015/learning-language-playing-computer-games-0924#_msocom_1)*
-([PDF](https://people.csail.mit.edu/karthikn/pdfs/mud-play15.pdf)) - MIT research paper using Evennia
-to train AIs.
 
-## Other useful mud development resources
+## Evennia-Based Projects
 
-- [ROM area reader](https://github.com/ctoth/area_reader) - Parser for converting ROM area files to
-Python objects.
-- [Gossip MUD chat network](https://gossip.haus/)
+### Code bases
+- [Arx sources](https://github.com/Arx-Game/arxcode) - Open-source code release of the very popular [Arx](https://play.arxmush.org/) Evennia game. [Here are instructions for installing](https://www.evennia.com/docs/1.0-dev/Howtos/Arxcode-Installation.html)
+- [The dark net/March Hare MUD](https://github.com/thedarknet/evennia) from the 2019 [DEF CON 27](https://www.defcon.org/html/defcon-27/dc-27-index.html) hacker conference in Paris. This is an Evennia game dir with batchcode to build the custom _Hackers_ style cyberspace zone with puzzles and challenges [used during the conference](https://dcdark.net/home#).
+- [Muddery](https://github.com/muddery/muddery) - A mud framework under development, based on an older fork of Evennia. It has some specific design goals for building and extending the game based on input files.
+- [Encarnia sources](https://github.com/whitehorse-io/encarnia) - An open-sourced game dir for an older version of Evennia with things like races, combat etc. [Summary here](https://www.reddit.com/r/MUD/comments/6z6s3j/encarnia_an_evennia_python_mud_code_base_with/).
 
-## General MUD forums and discussions
+### Other
 
-- [MUD Coder's Guild](https://mudcoders.com/) - A blog and [associated Slack
-  channel](https://slack.mudcoders.com/) with discussions on MUD development.
-- [MuSoapbox](https://www.musoapbox.net/) - Very active Mu* game community mainly focused on MUSH-type gaming.
-- [Imaginary Realities](http://journal.imaginary-realities.com/) - An e-magazine on game and MUD
-  design that has several articles about Evennia. There is also an
-  [archive of older issues](http://disinterest.org/resource/imaginary-realities/)
-  from 1998-2001 that are still very relevant.
-- [Optional Realities](http://optionalrealities.com/) - Mud development discussion forums that has
-  regular articles on MUD development focused on roleplay-intensive games. After a HD crash it's not
-  as content-rich as it once was.
+- [Discord live blog](https://discordapp.com/channels/517176782357528616/517176782781415434) of the _Blackbirds_ Evennia game project.
+- [Evennia for MUSHers](https://musoapbox.net/topic/1150/evennia-for-mushers) - An article describing Evennia for those used to the MUSH way of doing things.
+- *[Language Understanding for Text games using Deep reinforcement learning](http://news.mit.edu/2015/learning-language-playing-computer-games-0924#_msocom_1)*
+([PDF](https://people.csail.mit.edu/karthikn/pdfs/mud-play15.pdf)) - MIT research paper using Evennia to train AIs.
+
+----
+
+## General MU* resources
+
+### Tools
+
+- [ROM area reader](https://github.com/ctoth/area_reader) - Parser for converting ROM area files to Python objects.
+
+### Informational
+
+- [Mud-dev wiki](http://mud-dev.wikidot.com/) - A (very) slowly growing resource on MUD creation.
+- [Mud Client/Server Interaction](http://cryosphere.net/mud-protocol.html) - A page on classic MUD telnet protocols.
+- [Mud Tech's fun/cool but ...](https://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-ship-damned-thing/) - Greg Taylor gives good advice on mud design.
+- [Lost Library of MOO](https://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in particular moo).
+- [Nick Gammon's hints thread](http://www.gammon.com.au/forum/bbshowpost.php?bbsubject_id=5959) - Contains a very useful list of things to think about when starting your new MUD.
+- Mud Dev mailing list archive ([mirror](http://www.disinterest.org/resource/MUD-Dev/)) - Influential mailing list active 1996-2004. Advanced game design discussions.
+- [Raph Koster's laws of game design](https://www.raphkoster.com/games/laws-of-online-world-design/the-laws-of-online-world-design/) - thought-provoking guidelines and things to think about when designing a virtual multiplayer world (Raph is known for *Ultima Online* among other things).
+- [Imaginary Realities unofficial archive](http://tharsis-gate.org/articles/imaginary.html) - An e-magazine on game and MUD design that has several articles about Evennia.
+
+### Community
+
+- [Grapevine MUD community and chat network](https://grapevine.haus/)
+- [MUD Coder's Guild](https://mudcoders.com/) - A blog and [associated Slack channel](https://slack.mudcoders.com/) with discussions on MUD development.
+- [MuSoapbox](https://musoapbox.net/) - MU* forum mainly focused on MUSH-type gaming.
 - [MudLab](http://mudlab.org/) - Mud design discussion forum
 - [MudConnector](http://www.mudconnect.com/) - Mud listing and forums
 - [MudBytes](http://www.mudbytes.net/) - Mud listing and forums
 - [Top Mud Sites](http://www.topmudsites.com/) - Mud listing and forums
-- [Planet Mud-Dev](http://planet-muddev.disinterest.org/) - A blog aggregator following blogs of
-  current MUD development (including Evennia) around the 'net. Worth to put among your RSS
-  subscriptions.
-- Mud Dev mailing list archive ([mirror](http://www.disinterest.org/resource/MUD-Dev/)) -
-  Influential mailing list active 1996-2004. Advanced game design discussions.
-- [Mud-dev wiki](http://mud-dev.wikidot.com/) - A (very) slowly growing resource on MUD creation.
-- [Mud Client/Server Interaction](http://cryosphere.net/mud-protocol.html) - A page on classic MUD
-  telnet protocols.
-- [Mud Tech's fun/cool but ...](https://gc-taylor.com/blog/2013/01/08/mud-tech-funcool-dont-forget-ship-damned-thing/) -
-  Greg Taylor gives good advice on mud design.
-- [Lost Library of MOO](https://www.hayseed.net/MOO/) - Archive of scientific articles on mudding (in
-particular moo).
-- [Nick Gammon's hints thread](http://www.gammon.com.au/forum/bbshowpost.php?bbsubject_id=5959) -
-Contains a very useful list of things to think about when starting your new MUD.
-- [Lost Garden](http://www.lostgarden.com/) - A game development blog with long and interesting
-  articles (not MUD-specific)
-- [What Games Are](http://whatgamesare.com/) - A blog about general game design (not MUD-specific)
-- [The Alexandrian](https://thealexandrian.net/) - A blog about tabletop roleplaying and board games,
-  but with lots of general discussion about rule systems and game balance that could be applicable
-  also for MUDs.
-- [Raph Koster's laws of game design](https://www.raphkoster.com/games/laws-of-online-world-design/the-laws-of-online-world-design/) -
-  thought-provoking guidelines and things to think about when designing a virtual multiplayer world
-  (Raph is known for *Ultima Online* among other things).
 
-## Literature
+----
+
+## General Game-Dev Resources
+
+### Tools
+
+- [GIT](https://git-scm.com/)
+  - [Documentation](https://git-scm.com/documentation)
+  - [Learn GIT in 15 minutes](https://try.github.io/levels/1/challenges/1) (interactive tutorial)
+
+### Frameworks
+
+- [Django's homepage](https://www.djangoproject.com/)
+  - [Documentation](https://docs.djangoproject.com/en)
+  - [Code](https://code.djangoproject.com/)
+- [Twisted homepage](https://twistedmatrix.com/)
+  - [Documentation](https://twistedmatrix.com/documents/current/core/howto/index.html)
+  - [Code](https://twistedmatrix.com/trac/browser)
+
+### Learning Python
+
+- [Python Website](https://www.python.org/)
+  - [Documentation](https://www.python.org/doc/)
+  - [Tutorial](https://docs.python.org/tut/tut.html)
+  - [Library Reference](https://docs.python.org/lib/lib.html)
+  - [Language Reference](https://docs.python.org/ref/ref.html)
+- [Python tips and tricks](https://www.siafoo.net/article/52)
+- [Jetbrains Python academy](https://hyperskill.org/onboarding?track=python) - free online programming curriculum for different skill levels
+
+### Blogs
+
+- [Lost Garden](https://lostgarden.home.blog/) - A game development blog with long and interesting articles (not MUD-specific)
+- [What Games Are](http://whatgamesare.com/) - A blog about general game design (not MUD-specific)
+- [The Alexandrian](https://thealexandrian.net/) - A blog about tabletop roleplaying and board games, but with lots of general discussion about rule systems and game balance that could be applicable also for MUDs.
+
+### Literature
 
 - Richard Bartle *Designing Virtual Worlds*
   ([amazon page](https://www.amazon.com/Designing-Virtual-Worlds-Richard-Bartle/dp/0131018167)) -
@@ -148,29 +142,3 @@ Contains a very useful list of things to think about when starting your new MUD.
   economic theory. Written in 1730 but the translation is annotated and the essay is actually very
   easy to follow also for a modern reader. Required reading if you think of implementing a sane game
   economic system.
-
-## Frameworks
-
-- [Django's homepage](https://www.djangoproject.com/)
-  - [Documentation](https://docs.djangoproject.com/en)
-  - [Code](https://code.djangoproject.com/)
-- [Twisted homepage](https://twistedmatrix.com/)
-  - [Documentation](https://twistedmatrix.com/documents/current/core/howto/index.html)
-  - [Code](https://twistedmatrix.com/trac/browser)
-
-## Tools
-
-- [GIT](https://git-scm.com/)
-  - [Documentation](https://git-scm.com/documentation)
-  - [Learn GIT in 15 minutes](https://try.github.io/levels/1/challenges/1) (interactive tutorial)
-
-## Python Info
-
-- [Python Website](https://www.python.org/)
-  - [Documentation](https://www.python.org/doc/)
-  - [Tutorial](https://docs.python.org/tut/tut.html)
-  - [Library Reference](https://docs.python.org/lib/lib.html)
-  - [Language Reference](https://docs.python.org/ref/ref.html)
-- [Python tips and tricks](https://www.siafoo.net/article/52)
-- [Jetbrains Python academy](https://hyperskill.org/onboarding?track=python) -
-  free online programming curriculum for different skill levels

--- a/docs/source/Links.md
+++ b/docs/source/Links.md
@@ -17,19 +17,17 @@ offline in html, PDF or epub formats.
 
 - [Evennia Game Index](http://games.evennia.com/) - An automated listing of Evennia games.
 - [Evennia official Discord channel](https://discord.gg/AJJpcRUhtF)
-- [Evennia official IRC
-channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUmMTE9MTk1JjEyPXRydWUbb) ( #evennia at [irc.freenode.net:6667](http://irc.freenode.net:6667/) )
 - [Evennia official forums](https://github.com/evennia/evennia/discussions) on Github Discussions.
 - [Evennia subreddit](https://www.reddit.com/r/Evennia/)
 
 ## Third-party Evennia tools
 
 - [Discord relay](https://github.com/InspectorCaracal/evennia-things/tree/main/discord_relay) - Two-way chat relays between Evennia channels and Discord channels.
+- [docker-compose for Evennia](https://github.com/gtaylor/evennia-docker) - A quick-install setup for running Evennia in a [Docker container](https://www.docker.com/). (See [the official Evennia docs](https://www.evennia.com/docs/latest/Running-Evennia-in-Docker.html) for more details on running Evennia with Docker.)
 - [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional coloration for Evennia unit-test output.
-- [Evennia-docker](https://github.com/gtaylor/evennia-docker) - Evennia in a [Docker container](https://www.docker.com/) for quick install and deployment in just a few commands.
 - [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your website.
-- [Paxboards](https://github.com/aurorachain/paxboards) - Evennia bulletin board system (both for telnet/web).
 - [nextRPI](https://github.com/cluebyte/nextrpi) - A github project for making a toolbox for people to make [RPI](https://www.topmudsites.com/forums/showthread.php?t=4804)-style Evennia games.
+- [Paxboards](https://github.com/aurorachain/paxboards) - Evennia bulletin board system (both for telnet/web).
 - [Unreal Engine Evennia plugin](https://www.unrealengine.com/marketplace/en-US/slug/evennia-plugin) an in-progress Unreal plugin for integrating Evennia with Epic Games' Unreal Engine.
 - [vim-evennia](https://github.com/amfl/vim-evennia) - A mode for editing batch-build files (`.ev`) files in the [vim](https://www.vim.org/) text editor (Emacs users can use [evennia-
 mode.el](https://github.com/evennia/evennia/blob/master/evennia/utils/evennia-mode.el)).

--- a/docs/source/Links.md
+++ b/docs/source/Links.md
@@ -24,6 +24,7 @@ channel](https://webchat.freenode.net/?channels=evennia&uio=MT1mYWxzZSY5PXRydWUm
 
 ## Third-party Evennia tools
 
+- [Discord relay](https://github.com/InspectorCaracal/evennia-things/tree/main/discord_relay) - Two-way chat relays between Evennia channels and Discord channels.
 - [Evcolor](https://github.com/taladan/Pegasus/blob/origin/world/utilities/evcolor) - Optional coloration for Evennia unit-test output.
 - [Evennia-docker](https://github.com/gtaylor/evennia-docker) - Evennia in a [Docker container](https://www.docker.com/) for quick install and deployment in just a few commands.
 - [Evennia-wiki](https://github.com/vincent-lg/evennia-wiki) - An Evennia-specific Wiki for your website.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Reorganizes the [Links](https://www.evennia.com/docs/1.0-dev/Links.html) page a bit for easier use, updates some of the descriptions, and gets rid of dead links.

I also added a link to the Discord relay code I made since it was requested, but I did that the last separate commit so I can roll it back easily if we just want the update/reorganization.