### PR TITLE
rpsystem: Always include aliases as candidates

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -350,7 +350,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             candidate_map.append((obj, obj.sdesc.get()))
         # if no sdesc, include key plus aliases instead
         else:
-            candidate_map.append((obj, obj.key)
+            candidate_map.append((obj, obj.key))
         candidate_map.extend([(obj, alias) for alias in obj.aliases.all()])
 
     # escape mapping syntax on the form {#id} if it exists already in emote,

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -350,7 +350,8 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             candidate_map.append((obj, obj.sdesc.get()))
         # if no sdesc, include key plus aliases instead
         else:
-            candidate_map.extend([(obj, obj.key)] + [(obj, alias) for alias in obj.aliases.all()])
+            candidate_map.append((obj, obj.key)
+        candidate_map.extend([(obj, alias) for alias in obj.aliases.all()])
 
     # escape mapping syntax on the form {#id} if it exists already in emote,
     # if so it is replaced with just "id".


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixing a minor oversight with moving the rpsystem contrib to have sdescs on all Objects.

The original logic had an either/or check for "sdesc" versus "key+aliases", so now that objects have valid sdescs, all object aliases were being ignored, rendering the aliases generated for item stacking via `get_numbered_name` (along with any other aliases one might generate) unusable. This changes that to an either/or check for "sdesc" versus "key", and adds any aliases regardless.

Since characters don't generally have aliases, it doesn't affect the character side of things.

#### Motivation for adding to Evennia
Bug fixes