### PR TITLE
Update separator handling for `iter_to_str`

### DIFF
--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -57,13 +57,15 @@ class TestDedent(TestCase):
 class TestListToString(TestCase):
     """
     Default function header from utils.py:
-    list_to_string(inlist, endsep=", and", addquote=False)
+    list_to_string(inlist, sep=",", endsep=", and", addquote=False)
 
     Examples:
-     with default endsep:
+     with defaults:
         [1,2,3] -> '1, 2, and 3'
      with endsep==',':
         [1,2,3] -> '1, 2, 3'
+     with sep==';' and endsep==';':
+        [1,2,3] -> '1; 2; 3'
      with endsep=='and':
         [1,2,3] -> '1, 2 and 3'
      with addquote and endsep="and"
@@ -74,6 +76,7 @@ class TestListToString(TestCase):
         self.assertEqual("1, 2, and 3", utils.list_to_string([1, 2, 3]))
         self.assertEqual("1, 2, 3", utils.list_to_string([1, 2, 3], endsep=","))
         self.assertEqual("1, 2 and 3", utils.list_to_string([1, 2, 3], endsep="and"))
+        self.assertEqual("1; 2; 3", utils.list_to_string([1, 2, 3], sep=";", endsep=";"))
         self.assertEqual('"1", "2", "3"', utils.list_to_string([1, 2, 3], endsep=",", addquote=True))
         self.assertEqual(
             '"1", "2" and "3"', utils.list_to_string([1, 2, 3], endsep="and", addquote=True)

--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -57,21 +57,24 @@ class TestDedent(TestCase):
 class TestListToString(TestCase):
     """
     Default function header from utils.py:
-    list_to_string(inlist, endsep="and", addquote=False)
+    list_to_string(inlist, endsep=", and", addquote=False)
 
     Examples:
-     no endsep:
+     with default endsep:
+        [1,2,3] -> '1, 2, and 3'
+     with endsep==',':
         [1,2,3] -> '1, 2, 3'
      with endsep=='and':
         [1,2,3] -> '1, 2 and 3'
-     with addquote and endsep
+     with addquote and endsep="and"
         [1,2,3] -> '"1", "2" and "3"'
     """
 
     def test_list_to_string(self):
-        self.assertEqual("1, 2, 3", utils.list_to_string([1, 2, 3], endsep=""))
-        self.assertEqual('"1", "2", "3"', utils.list_to_string([1, 2, 3], endsep="", addquote=True))
         self.assertEqual("1, 2, and 3", utils.list_to_string([1, 2, 3]))
+        self.assertEqual("1, 2, 3", utils.list_to_string([1, 2, 3], endsep=","))
+        self.assertEqual("1, 2 and 3", utils.list_to_string([1, 2, 3], endsep="and"))
+        self.assertEqual('"1", "2", "3"', utils.list_to_string([1, 2, 3], endsep=",", addquote=True))
         self.assertEqual(
             '"1", "2" and "3"', utils.list_to_string([1, 2, 3], endsep="and", addquote=True)
         )

--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -68,6 +68,8 @@ class TestListToString(TestCase):
         [1,2,3] -> '1; 2; 3'
      with endsep=='and':
         [1,2,3] -> '1, 2 and 3'
+     with endsep=='':
+        [1,2,3] -> '1, 2 3'
      with addquote and endsep="and"
         [1,2,3] -> '"1", "2" and "3"'
     """
@@ -76,6 +78,7 @@ class TestListToString(TestCase):
         self.assertEqual("1, 2, and 3", utils.list_to_string([1, 2, 3]))
         self.assertEqual("1, 2, 3", utils.list_to_string([1, 2, 3], endsep=","))
         self.assertEqual("1, 2 and 3", utils.list_to_string([1, 2, 3], endsep="and"))
+        self.assertEqual("1, 2 3", utils.list_to_string([1, 2, 3], endsep=""))
         self.assertEqual("1; 2; 3", utils.list_to_string([1, 2, 3], sep=";", endsep=";"))
         self.assertEqual('"1", "2", "3"', utils.list_to_string([1, 2, 3], endsep=",", addquote=True))
         self.assertEqual(

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -372,6 +372,7 @@ def iter_to_str(iterable, sep=",", endsep=", and", addquote=False):
         iterable (any): Usually an iterable to print. Each element must be possible to
             present with a string. Note that if this is a generator, it will be
             consumed by this operation.
+        sep (str, optional): The string to use as a separator for each item in the iterable.
         endsep (str, optional): The last item separator will be replaced with this value.
         addquote (bool, optional): This will surround all outgoing
             values with double quotes.
@@ -389,7 +390,9 @@ def iter_to_str(iterable, sep=",", endsep=", and", addquote=False):
         '1, 2, 3'
         >>> list_to_string([1,2,3], ensdep='and')
         '1, 2 and 3'
-        >>> list_to_string([1,2,3], endsep=', and', addquote=True)
+        >>> list_to_string([1,2,3], sep=';', endsep=';')
+        '1; 2; 3'
+        >>> list_to_string([1,2,3], addquote=True)
         '"1", "2", and "3"'
         ```
 

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -362,7 +362,7 @@ def columnize(string, columns=2, spacing=4, align="l", width=None):
     return "\n".join(rows)
 
 
-def iter_to_str(iterable, endsep=", and", addquote=False):
+def iter_to_str(iterable, sep=",", endsep=", and", addquote=False):
     """
     This pretty-formats an iterable list as string output, adding an optional
     alternative separator to the second to last entry.  If `addquote`
@@ -404,7 +404,7 @@ def iter_to_str(iterable, endsep=", and", addquote=False):
     else:
         iterable = tuple(str(val) for val in iterable)
 
-    if endsep.startswith(","):
+    if endsep.startswith(sep):
         # oxford comma alternative
         endsep = endsep[1:] if len_iter < 3 else endsep
     elif endsep:
@@ -416,7 +416,7 @@ def iter_to_str(iterable, endsep=", and", addquote=False):
     elif len_iter == 2:
         return f"{endsep} ".join(str(v) for v in iterable)
     else:
-        return ", ".join(str(v) for v in iterable[:-1]) + f"{endsep} {iterable[-1]}"
+        return f"{sep} ".join(str(v) for v in iterable[:-1]) + f"{endsep} {iterable[-1]}"
 
 
 # legacy aliases

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -372,8 +372,7 @@ def iter_to_str(iterable, endsep=", and", addquote=False):
         iterable (any): Usually an iterable to print. Each element must be possible to
             present with a string. Note that if this is a generator, it will be
             consumed by this operation.
-        endsep (str, optional): If set, the last item separator will
-            be replaced with this value.
+        endsep (str, optional): The last item separator will be replaced with this value.
         addquote (bool, optional): This will surround all outgoing
             values with double quotes.
 
@@ -381,13 +380,12 @@ def iter_to_str(iterable, endsep=", and", addquote=False):
         str: The list represented as a string.
 
     Notes:
-        Default is to use 'Oxford comma', like 1, 2, 3, and 4. To remove, give
-        `endsep` as just `and`.
+        Default is to use 'Oxford comma', like 1, 2, 3, and 4.
 
     Examples:
 
         ```python
-        >>> list_to_string([1,2,3], endsep='')
+        >>> list_to_string([1,2,3], endsep=',')
         '1, 2, 3'
         >>> list_to_string([1,2,3], ensdep='and')
         '1, 2 and 3'
@@ -412,9 +410,6 @@ def iter_to_str(iterable, endsep=", and", addquote=False):
     elif endsep:
         # normal space-separated end separator
         endsep = " " + str(endsep).strip()
-    else:
-        # no separator given - use comma
-        endsep = ","
 
     if len_iter == 1:
         return str(iterable[0])

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -388,6 +388,8 @@ def iter_to_str(iterable, sep=",", endsep=", and", addquote=False):
         ```python
         >>> list_to_string([1,2,3], endsep=',')
         '1, 2, 3'
+        >>> list_to_string([1,2,3], endsep='')
+        '1, 2 3'
         >>> list_to_string([1,2,3], ensdep='and')
         '1, 2 and 3'
         >>> list_to_string([1,2,3], sep=';', endsep=';')


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the behavior when `endsep=''` to actually have no final separator instead of presuming a comma. While I feel this is a valuable change, it would affect any code that uses the empty string as a way to simply erase the "and" from the default format, causing a minor break in backwards compatibility.

Also, since I was there, I expanded the functionality slightly to allow for defining a custom separator. _This_ change has no effect on existing usage and would be fully backwards-compatible.

#### Motivation for adding to Evennia and Other Info
Fulfilling #2785 