### PR TITLE
Fix text + prompt msg function

### DIFF
--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -270,11 +270,11 @@ class SessionHandler(dict):
             else:
                 rkwargs[key] = [[_validate(data)], {}]
             rkwargs[key][1]["options"] = dict(options)
-        # make sure that any "text" message will be processed first
-        # by putting it at the beginning
-        if "text" in rkwargs:
-            text = rkwargs.pop("text")
-            rkwargs = { "text": text } | rkwargs
+        # make sure that any "prompt" message will be processed last
+        # by moving it to the end
+        if "prompt" in rkwargs:
+            prompt = rkwargs.pop("prompt")
+            rkwargs["prompt"] = prompt
         return rkwargs
 
 

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -270,6 +270,11 @@ class SessionHandler(dict):
             else:
                 rkwargs[key] = [[_validate(data)], {}]
             rkwargs[key][1]["options"] = dict(options)
+        # make sure that any "text" message will be processed first
+        # by putting it at the beginning
+        if "text" in rkwargs:
+            text = rkwargs.pop("text")
+            rkwargs = { "text": text } | rkwargs
         return rkwargs
 
 

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -269,7 +269,7 @@ class SessionHandler(dict):
                     rkwargs[key] = [_validate(data), {}]
             else:
                 rkwargs[key] = [[_validate(data)], {}]
-            rkwargs[key][1]["options"] = options
+            rkwargs[key][1]["options"] = dict(options)
         return rkwargs
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes a pass-by-reference bug that resulted in msg text overriding prompt text. Also makes sure that msg text is processed before other cmd types in the msg (such as prompt).

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Closes #2783