### PR TITLE
Update evennia-docker-start.sh

### DIFF
--- a/bin/unix/evennia-docker-start.sh
+++ b/bin/unix/evennia-docker-start.sh
@@ -9,7 +9,7 @@ PS1="evennia|docker \w $ "
 
 cmd="$@"
 output="Docker starting with argument '$cmd' ..."
-if test -z $cmd; then
+if test -z "$cmd"; then
     cmd="bash"
     output="No argument given, starting shell ..."
 fi


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixed an unquoted shell test in the docker entrypoint script. 

#### Motivation for adding to Evennia
This was generating a "sh: start: unknown operand" message in the startup log when the default "evennia start --log" args were passed in. This has no impact on the return status of the test itself, as it was always succeeding on an empty string and failing on a non-empty one.

#### Other info (issues closed, discussion etc)
