### PR TITLE
rpsystem: Add special-case handling for self-references.

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -202,7 +202,7 @@ _RE_RIGHT_BRACKETS = re.compile(r"\}+", _RE_FLAGS)
 _RE_REF = re.compile(r"\{+\#([0-9]+[\^\~tv]{0,1})\}+")
 
 # This regex is used to quickly reference one self in an emote.
-_RE_SELF_REF = re.compile(r"/me\b|@", _RE_FLAGS)
+_RE_SELF_REF = re.compile(r"(/me|@)(?=\W+)", _RE_FLAGS)
 
 # regex for non-alphanumberic end of a string
 _RE_CHAREND = re.compile(r"\W+$", _RE_FLAGS)
@@ -359,7 +359,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
     """
     # build a list of candidates with all possible referrable names
     # include 'me' keyword for self-ref
-    candidate_map = [(sender, "me")]
+    candidate_map = []
     for obj in candidates:
         # check if sender has any recogs for obj and add
         if hasattr(sender, "recog"):
@@ -391,10 +391,9 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
         case = _get_case_ref(matched.lstrip(_PREFIX)) if case_sensitive else ""
         key = f"#{sender.id}{case}"
         # replaced with ref
-        string = string.replace(matched,f"{{{key}}}")
+        string = _RE_SELF_REF.sub(f"{{{key}}}", string, count=1)
         mapping[key] = sender
-    
-    
+
     for marker_match in reversed(list(_RE_OBJ_REF_START.finditer(string))):
         # we scan backwards so we can replace in-situ without messing
         # up later occurrences. Given a marker match, query from

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -388,7 +388,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
     # first, find and replace any self-refs
     for self_match in list(_RE_SELF_REF.finditer(string)):
         matched = self_match.group()
-        case = _get_case_ref(matched.lstrip(_PREFIX)) if case_sensitive else "~"
+        case = _get_case_ref(matched.lstrip(_PREFIX)) if case_sensitive else ""
         key = f"#{sender.id}{case}"
         # replaced with ref
         string = string.replace(matched,f"{{{key}}}")
@@ -486,7 +486,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             errors.append(_EMOTE_NOMATCH_ERROR.format(ref=marker_match.group()))
         elif nmatches == 1:
             # a unique match - parse into intermediary representation
-            case = _get_case_ref(marker_match.group()) if case_sensitive else "~"
+            case = _get_case_ref(marker_match.group()) if case_sensitive else ""
             # recombine emote with matched text replaced by ref
             key = f"#{obj.id}{case}"
             string = f"{head}{{{key}}}{tail}"

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -97,6 +97,7 @@ recog02 = "Mr Receiver2"
 recog10 = "Mr Sender"
 emote = 'With a flair, /me looks at /first and /colliding sdesc-guy. She says "This is a test."'
 case_emote = "/Me looks at /first. Then, /me looks at /FIRST, /First and /Colliding twice."
+poss_emote = "/Me frowns at /first for trying to steal /me's test."
 
 
 class TestRPSystem(BaseEvenniaTest):
@@ -140,7 +141,7 @@ class TestRPSystem(BaseEvenniaTest):
             ),
         )
 
-    def parse_sdescs_and_recogs(self):
+    def test_parse_sdescs_and_recogs(self):
         speaker = self.speaker
         speaker.sdesc.add(sdesc0)
         self.receiver1.sdesc.add(sdesc1)
@@ -149,9 +150,9 @@ class TestRPSystem(BaseEvenniaTest):
         result = (
             'With a flair, {#9} looks at {#10} and {#11}. She says "This is a test."',
             {
-                "#11": "Another nice colliding sdesc-guy for tests",
-                "#10": "The first receiver of emotes.",
-                "#9": "A nice sender of emotes",
+                "#11": self.receiver2,
+                "#10": self.receiver1,
+                "#9": speaker,
             },
         )
         self.assertEqual(
@@ -161,6 +162,24 @@ class TestRPSystem(BaseEvenniaTest):
         self.speaker.recog.add(self.receiver1, recog01)
         self.assertEqual(
             rpsystem.parse_sdescs_and_recogs(speaker, candidates, emote, case_sensitive=False),
+            result,
+        )
+
+    def test_possessive_selfref(self):
+        speaker = self.speaker
+        speaker.sdesc.add(sdesc0)
+        self.receiver1.sdesc.add(sdesc1)
+        self.receiver2.sdesc.add(sdesc2)
+        candidates = (self.receiver1, self.receiver2)
+        result = (
+            "{#9} frowns at {#10} for trying to steal {#9}'s test.",
+            {
+                "#10": self.receiver1,
+                "#9": speaker,
+            },
+        )
+        self.assertEqual(
+            rpsystem.parse_sdescs_and_recogs(speaker, candidates, poss_emote, case_sensitive=False),
             result,
         )
 

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -146,13 +146,16 @@ class TestRPSystem(BaseEvenniaTest):
         speaker.sdesc.add(sdesc0)
         self.receiver1.sdesc.add(sdesc1)
         self.receiver2.sdesc.add(sdesc2)
+        id0 = f"#{speaker.id}"
+        id1 = f"#{self.receiver1.id}"
+        id2 = f"#{self.receiver2.id}"
         candidates = (self.receiver1, self.receiver2)
         result = (
-            'With a flair, {#9} looks at {#10} and {#11}. She says "This is a test."',
+            'With a flair, {'+id0+'} looks at {'+id1+'} and {'+id2+'}. She says "This is a test."',
             {
-                "#11": self.receiver2,
-                "#10": self.receiver1,
-                "#9": speaker,
+                id2: self.receiver2,
+                id1: self.receiver1,
+                id0: speaker,
             },
         )
         self.assertEqual(
@@ -170,12 +173,15 @@ class TestRPSystem(BaseEvenniaTest):
         speaker.sdesc.add(sdesc0)
         self.receiver1.sdesc.add(sdesc1)
         self.receiver2.sdesc.add(sdesc2)
+        id0 = f"#{speaker.id}"
+        id1 = f"#{self.receiver1.id}"
+        id2 = f"#{self.receiver2.id}"
         candidates = (self.receiver1, self.receiver2)
         result = (
-            "{#9} frowns at {#10} for trying to steal {#9}'s test.",
+            "{"+id0+"} frowns at {"+id1+"} for trying to steal {"+id0+"}'s test.",
             {
-                "#10": self.receiver1,
-                "#9": speaker,
+                id1: self.receiver1,
+                id0: speaker,
             },
         )
         self.assertEqual(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This changes `parse_sdescs_and_recogs` to actually use the self-reference regex to identify self-references. It also splits the logic for getting case refs out into a helper function.

#### Motivation for adding to Evennia
Bug fixing.

#### Other info (issues closed, discussion etc)
An issue with self-references which I'd patched out but apparently regressed during parser rewrites arose on discord, where `/me` would multimatch if there was anyone else with an sdesc or recog that starts with "me" (such as Melody, or merchant). Originally I'd resolved this by matching full words only, but that's not a desirable limitation.

To resolve things so you don't have multimatches on `/me` but can still reference a merchant with `/merch`, I've added an initial self-ref pass to the sdesc/recog parser, using the `_RE_SELF_REF` regex. This has the added benefit of actually making the `@` self-ref marker work, since as it turned out, the existing sdesc-matching method of finding the reference marker and iterating forward meant it was completely ignored and useless (since it doesn't _have_ the prefix marker in it at all).