### PR TITLE
Added msg_type to rpsystem.send_emote()

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -513,7 +513,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
     return string, mapping
 
 
-def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
+def send_emote(sender, receivers, emote, msg_type = "pose", anonymous_add="first", **kwargs):
     """
     Main access function for distribute an emote.
 
@@ -523,6 +523,9 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
             will also form the basis for which sdescs are
             'valid' to use in the emote.
         emote (str): The raw emote string as input by emoter.
+        msg_type (str): The type of emote this is. "say" or "pose"
+            for example. This is arbitrary and used for generating
+            extra data for .msg(text) tuple.
         anonymous_add (str or None, optional): If `sender` is not
             self-referencing in the emote, this will auto-add
             `sender`'s data to the emote. Possible values are
@@ -599,7 +602,7 @@ def send_emote(sender, receivers, emote, anonymous_add="first", **kwargs):
         )
 
         # do the template replacement of the sdesc/recog {#num} markers
-        receiver.msg(sendemote.format(**receiver_sdesc_mapping), from_obj=sender, **kwargs)
+        receiver.msg(text=(sendemote.format(**receiver_sdesc_mapping), {"type": msg_type}), from_obj=sender, **kwargs)
 
 
 # ------------------------------------------------------------
@@ -910,7 +913,7 @@ class CmdSay(RPCommand):  # replaces standard say
         # calling the speech modifying hook
         speech = caller.at_pre_say(self.args)
         targets = self.caller.location.contents
-        send_emote(self.caller, targets, speech, anonymous_add=None)
+        send_emote(self.caller, targets, speech, msg_type="say", anonymous_add=None)
 
 
 class CmdSdesc(RPCommand):  # set/look at own sdesc

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -213,6 +213,7 @@ _RE_REF_LANG = re.compile(r"\{+\##([0-9]+)\}+")
 # this regex returns in groups (langname, say), where langname can be empty.
 _RE_LANGUAGE = re.compile(r"(?:\((\w+)\))*(\".+?\")")
 
+
 # the emote parser works in two steps:
 #  1) convert the incoming emote into an intermediary
 #     form with all object references mapped to ids.
@@ -375,7 +376,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
         match_index = marker_match.start()
         # split the emote string at the reference marker, to process everything after it
         head = string[:match_index]
-        tail = string[match_index + 1 :]
+        tail = string[match_index + 1:]
 
         if search_mode:
             # match the candidates against the whole search string after the marker
@@ -421,7 +422,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
             # save search string
             matched_text = "".join(tail[1:iend])
             # recombine remainder of emote back into a string
-            tail = "".join(tail[iend + 1 :])
+            tail = "".join(tail[iend + 1:])
 
         nmatches = len(bestmatches)
 
@@ -513,7 +514,7 @@ def parse_sdescs_and_recogs(sender, candidates, string, search_mode=False, case_
     return string, mapping
 
 
-def send_emote(sender, receivers, emote, msg_type = "pose", anonymous_add="first", **kwargs):
+def send_emote(sender, receivers, emote, msg_type="pose", anonymous_add="first", **kwargs):
     """
     Main access function for distribute an emote.
 
@@ -1256,19 +1257,19 @@ class ContribRPObject(DefaultObject):
         self.sdesc.add("Something")
 
     def search(
-        self,
-        searchdata,
-        global_search=False,
-        use_nicks=True,
-        typeclass=None,
-        location=None,
-        attribute_name=None,
-        quiet=False,
-        exact=False,
-        candidates=None,
-        nofound_string=None,
-        multimatch_string=None,
-        use_dbref=None,
+            self,
+            searchdata,
+            global_search=False,
+            use_nicks=True,
+            typeclass=None,
+            location=None,
+            attribute_name=None,
+            quiet=False,
+            exact=False,
+            candidates=None,
+            nofound_string=None,
+            multimatch_string=None,
+            use_dbref=None,
     ):
         """
         Returns an Object matching a search string/condition, taking
@@ -1352,10 +1353,10 @@ class ContribRPObject(DefaultObject):
             )
 
         if global_search or (
-            is_string
-            and searchdata.startswith("#")
-            and len(searchdata) > 1
-            and searchdata[1:].isdigit()
+                is_string
+                and searchdata.startswith("#")
+                and len(searchdata) > 1
+                and searchdata[1:].isdigit()
         ):
             # only allow exact matching if searching the entire database
             # or unique #dbrefs

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -197,17 +197,17 @@ class TestRPSystem(BaseEvenniaTest):
         receiver2.msg = lambda text, **kwargs: setattr(self, "out2", text)
         rpsystem.send_emote(speaker, receivers, emote, case_sensitive=False)
         self.assertEqual(
-            self.out0,
+            self.out0[0],
             "With a flair, |mSender|n looks at |bThe first receiver of emotes.|n "
             'and |bAnother nice colliding sdesc-guy for tests|n. She says |w"This is a test."|n',
         )
         self.assertEqual(
-            self.out1,
+            self.out1[0],
             "With a flair, |bA nice sender of emotes|n looks at |mReceiver1|n and "
             '|bAnother nice colliding sdesc-guy for tests|n. She says |w"This is a test."|n',
         )
         self.assertEqual(
-            self.out2,
+            self.out2[0],
             "With a flair, |bA nice sender of emotes|n looks at |bThe first "
             'receiver of emotes.|n and |mReceiver2|n. She says |w"This is a test."|n',
         )
@@ -226,19 +226,19 @@ class TestRPSystem(BaseEvenniaTest):
         receiver2.msg = lambda text, **kwargs: setattr(self, "out2", text)
         rpsystem.send_emote(speaker, receivers, case_emote)
         self.assertEqual(
-            self.out0,
+            self.out0[0],
             "|mSender|n looks at |bthe first receiver of emotes.|n. Then, |mSender|n "
             "looks at |bTHE FIRST RECEIVER OF EMOTES.|n, |bThe first receiver of emotes.|n "
             "and |bAnother nice colliding sdesc-guy for tests|n twice.",
         )
         self.assertEqual(
-            self.out1,
+            self.out1[0],
             "|bA nice sender of emotes|n looks at |mReceiver1|n. Then, "
             "|ba nice sender of emotes|n looks at |mReceiver1|n, |mReceiver1|n "
             "and |bAnother nice colliding sdesc-guy for tests|n twice.",
         )
         self.assertEqual(
-            self.out2,
+            self.out2[0],
             "|bA nice sender of emotes|n looks at |bthe first receiver of emotes.|n. "
             "Then, |ba nice sender of emotes|n looks at |bTHE FIRST RECEIVER OF EMOTES.|n, "
             "|bThe first receiver of emotes.|n and |mReceiver2|n twice.",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
the rpsystem contrib is currently stripping out the {"type": "say"} data which the default evennia say command flow creates.

Was easy to add this back in.

#### Motivation for adding to Evennia
Currently working on a project which depends on the text-tuple's data for things like speech.

And just think this should be restored.

#### Other info (issues closed, discussion etc)
Easy peasy.
