### PR TITLE
enable dict subclasses serialization

### DIFF
--- a/evennia/typeclasses/tests.py
+++ b/evennia/typeclasses/tests.py
@@ -3,8 +3,8 @@ Unit tests for typeclass base system
 
 """
 from django.test import override_settings
-from evennia.utils.test_resources import BaseEvenniaTest, EvenniaTestCase
 from evennia.typeclasses import attributes
+from evennia.utils.test_resources import BaseEvenniaTest, EvenniaTestCase
 from mock import patch
 from parameterized import parameterized
 
@@ -13,12 +13,24 @@ from parameterized import parameterized
 # ------------------------------------------------------------
 
 
+class DictSubclass(dict):
+    pass
+
+
 class TestAttributes(BaseEvenniaTest):
     def test_attrhandler(self):
         key = "testattr"
         value = "test attr value "
         self.obj1.attributes.add(key, value)
         self.assertEqual(self.obj1.attributes.get(key), value)
+        self.obj1.db.testattr = value
+        self.assertEqual(self.obj1.db.testattr, value)
+
+        value = DictSubclass({"fo": "foo", "bar": "bar"})
+        self.obj1.db.testattr = value
+        self.assertEqual(self.obj1.db.testattr, value)
+
+        value = DictSubclass({"fo": "foo", "bar": "bar", "obj": self.obj2})
         self.obj1.db.testattr = value
         self.assertEqual(self.obj1.db.testattr, value)
 
@@ -33,6 +45,16 @@ class TestAttributes(BaseEvenniaTest):
         self.assertEqual(self.obj1.attributes.get(key), value)
         self.obj1.db.testattr = value
         self.assertEqual(self.obj1.db.testattr, value)
+        self.assertFalse(self.obj1.attributes.backend._cache)
+
+        value = DictSubclass({"fo": "foo", "bar": "bar"})
+        self.obj1.db.dict_subclass = value
+        self.assertEqual(self.obj1.db.dict_subclass, value)
+        self.assertFalse(self.obj1.attributes.backend._cache)
+
+        value = DictSubclass({"fo": "foo", "bar": "bar", "obj": self.obj2})
+        self.obj1.db.dict_subclass = value
+        self.assertEqual(self.obj1.db.dict_subclass, value)
         self.assertFalse(self.obj1.attributes.backend._cache)
 
     def test_weird_text_save(self):

--- a/evennia/utils/tests/test_gametime.py
+++ b/evennia/utils/tests/test_gametime.py
@@ -86,7 +86,6 @@ class TestGametime(TestCase):
 
     def test_schedule(self):
         callback = Mock()
-        del callback.items
         script = gametime.schedule(callback, day=19)
         self.timescripts.append(script)
         self.assertIsInstance(script, gametime.TimeScript)
@@ -95,7 +94,6 @@ class TestGametime(TestCase):
 
     def test_repeat_schedule(self):
         callback = Mock()
-        del callback.items
         script = gametime.schedule(callback, repeat=True, min=32)
         self.timescripts.append(script)
         self.assertIsInstance(script, gametime.TimeScript)

--- a/evennia/utils/tests/test_gametime.py
+++ b/evennia/utils/tests/test_gametime.py
@@ -86,6 +86,7 @@ class TestGametime(TestCase):
 
     def test_schedule(self):
         callback = Mock()
+        del callback.items
         script = gametime.schedule(callback, day=19)
         self.timescripts.append(script)
         self.assertIsInstance(script, gametime.TimeScript)
@@ -94,6 +95,7 @@ class TestGametime(TestCase):
 
     def test_repeat_schedule(self):
         callback = Mock()
+        del callback.items
         script = gametime.schedule(callback, repeat=True, min=32)
         self.timescripts.append(script)
         self.assertIsInstance(script, gametime.TimeScript)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR tentatively fix #2808 by letting un/pickling functions correctly identify dict subclasses and properly serialize them.

close #2808