### PR TITLE
Improving at_server_startstop modules

### DIFF
--- a/evennia/game_template/server/conf/at_server_startstop.py
+++ b/evennia/game_template/server/conf/at_server_startstop.py
@@ -7,6 +7,7 @@ allows for customizing the server operation as desired.
 
 This module must contain at least these global functions:
 
+at_server_init()
 at_server_start()
 at_server_stop()
 at_server_reload_start()
@@ -16,6 +17,11 @@ at_server_cold_stop()
 
 """
 
+def at_server_init():
+    """
+    This is called first as the server is starting up, regardless of how.
+    """
+    pass
 
 def at_server_start():
     """

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -46,8 +46,8 @@ _SA = object.__setattr__
 # a file with a flag telling the server to restart after shutdown or not.
 SERVER_RESTART = os.path.join(settings.GAME_DIR, "server", "server.restart")
 
-# module containing hook methods called during start_stop
-SERVER_STARTSTOP_MODULE = mod_import(settings.AT_SERVER_STARTSTOP_MODULE)
+# modules containing hook methods called during start_stop
+SERVER_STARTSTOP_MODULES = [mod_import(m) for m in make_iter(settings.AT_SERVER_STARTSTOP_MODULE) if isinstance(m, str)]
 
 # modules containing plugin services
 SERVER_SERVICES_PLUGIN_MODULES = make_iter(settings.SERVER_SERVICES_PLUGIN_MODULES)
@@ -413,6 +413,8 @@ class Evennia:
             for typeclass_db in TypedObject.__subclasses__()
         ]
 
+        self.at_server_init()
+
         # call correct server hook based on start file value
         if mode == "reload":
             logger.log_msg("Server successfully reloaded.")
@@ -525,14 +527,23 @@ class Evennia:
 
     # server start/stop hooks
 
+    def at_server_init(self):
+        """
+        This is called first when the server is starting, before any other hooks, regardless of how it's starting.
+        """
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_init"):
+                m.at_server_init()
+
     def at_server_start(self):
         """
         This is called every time the server starts up, regardless of
         how it was shut down.
 
         """
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_start()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_start"):
+                m.at_server_start()
 
     def at_server_stop(self):
         """
@@ -540,16 +551,18 @@ class Evennia:
         of it is fore a reload, reset or shutdown.
 
         """
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_stop()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_stop"):
+                m.at_server_stop()
 
     def at_server_reload_start(self):
         """
         This is called only when server starts back up after a reload.
 
         """
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_reload_start()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_reload_start"):
+                m.at_server_reload_start()
 
     def at_post_portal_sync(self, mode):
         """
@@ -589,8 +602,9 @@ class Evennia:
         This is called only time the server stops before a reload.
 
         """
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_reload_stop()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_reload_stop"):
+                m.at_server_reload_stop()
 
     def at_server_cold_start(self):
         """
@@ -618,16 +632,18 @@ class Evennia:
                     if character:
                         character.delete()
                 guest.delete()
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_cold_start()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_cold_start"):
+                m.at_server_cold_start()
 
     def at_server_cold_stop(self):
         """
         This is called only when the server goes down due to a shutdown or reset.
 
         """
-        if SERVER_STARTSTOP_MODULE:
-            SERVER_STARTSTOP_MODULE.at_server_cold_stop()
+        for m in SERVER_STARTSTOP_MODULES:
+            if hasattr(m, "at_server_cold_stop"):
+                m.at_server_cold_stop()
 
 
 # ------------------------------------------------------------

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -47,7 +47,8 @@ _SA = object.__setattr__
 SERVER_RESTART = os.path.join(settings.GAME_DIR, "server", "server.restart")
 
 # modules containing hook methods called during start_stop
-SERVER_STARTSTOP_MODULES = [mod_import(m) for m in make_iter(settings.AT_SERVER_STARTSTOP_MODULE) if isinstance(m, str)]
+SERVER_STARTSTOP_MODULES = [mod_import(mod) for mod in make_iter(settings.AT_SERVER_STARTSTOP_MODULE)
+                            if isinstance(mod, str)]
 
 # modules containing plugin services
 SERVER_SERVICES_PLUGIN_MODULES = make_iter(settings.SERVER_SERVICES_PLUGIN_MODULES)
@@ -531,9 +532,9 @@ class Evennia:
         """
         This is called first when the server is starting, before any other hooks, regardless of how it's starting.
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_init"):
-                m.at_server_init()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_init"):
+                mod.at_server_init()
 
     def at_server_start(self):
         """
@@ -541,9 +542,9 @@ class Evennia:
         how it was shut down.
 
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_start"):
-                m.at_server_start()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_start"):
+                mod.at_server_start()
 
     def at_server_stop(self):
         """
@@ -551,18 +552,18 @@ class Evennia:
         of it is fore a reload, reset or shutdown.
 
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_stop"):
-                m.at_server_stop()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_stop"):
+                mod.at_server_stop()
 
     def at_server_reload_start(self):
         """
         This is called only when server starts back up after a reload.
 
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_reload_start"):
-                m.at_server_reload_start()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_reload_start"):
+                mod.at_server_reload_start()
 
     def at_post_portal_sync(self, mode):
         """
@@ -602,9 +603,9 @@ class Evennia:
         This is called only time the server stops before a reload.
 
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_reload_stop"):
-                m.at_server_reload_stop()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_reload_stop"):
+                mod.at_server_reload_stop()
 
     def at_server_cold_start(self):
         """
@@ -632,18 +633,18 @@ class Evennia:
                     if character:
                         character.delete()
                 guest.delete()
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_cold_start"):
-                m.at_server_cold_start()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_cold_start"):
+                mod.at_server_cold_start()
 
     def at_server_cold_stop(self):
         """
         This is called only when the server goes down due to a shutdown or reset.
 
         """
-        for m in SERVER_STARTSTOP_MODULES:
-            if hasattr(m, "at_server_cold_stop"):
-                m.at_server_cold_stop()
+        for mod in SERVER_STARTSTOP_MODULES:
+            if hasattr(mod, "at_server_cold_stop"):
+                mod.at_server_cold_stop()
 
 
 # ------------------------------------------------------------

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -389,6 +389,8 @@ AT_INITIAL_SETUP_HOOK_MODULE = "server.conf.at_initial_setup"
 # Module containing your custom at_server_start(), at_server_reload() and
 # at_server_stop() methods. These methods will be called every time
 # the server starts, reloads and resets/stops respectively.
+# Now supports a list of python paths or a single string.
+# If it's a list, each module's hooks will be called by list order.
 AT_SERVER_STARTSTOP_MODULE = "server.conf.at_server_startstop"
 # List of one or more module paths to modules containing a function start_
 # plugin_services(application). This module will be called with the main


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Altered AT_SERVER_STARTSTOP_MODULE to alternatively take a list of module paths instead of a string.

Added an at_server_init function which is always called first before any other "start" variants to handle specialized loading. (It's weird that reload_start or cold start is called before normal start but there's nothing that happens first for initial loading of resources or config or whatnot...)

#### Motivation for adding to Evennia
Main reason I thought of it was for helping Athanor - it has its own load process it handles, but it'd be great if this then called the mygame at_server_startstop... at that point I realized, it'd be even better if Evennia just had one more hook and also the ability to optionally call multiple modules in sequence... and that it can be done without overcomplicating anything.

#### Other info (issues closed, discussion etc)
Everything seems to work.