### PR TITLE
object.at_traverse() now passes the exit being traversed as a kwarg

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -866,6 +866,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         Keyword Args:
           Passed on to announce_move_to and announce_move_from hooks.
+          Exits will set the "exit" kwarg to themselves.
 
         Returns:
             result (bool): True/False depending on if there were problems with the move.
@@ -2889,7 +2890,7 @@ class DefaultExit(DefaultObject):
 
         """
         source_location = traversing_object.location
-        if traversing_object.move_to(target_location, move_type="traverse"):
+        if traversing_object.move_to(target_location, move_type="traverse", exit=self):
             self.at_post_traverse(traversing_object, source_location)
         else:
             if self.db.err_traverse:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The title kinda says it all.

#### Motivation for adding to Evennia
Because it's useful for rendering messages and other checks in the other hooks, and I cannot think of a single reason why this information is NOT being made available to the move_to chain via kwargs.

#### Other info (issues closed, discussion etc)
Easy peasy.