### PR TITLE
Fix DefaultExit overwriting prototype destination

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -2846,8 +2846,8 @@ class DefaultExit(DefaultObject):
             )
         )
 
-        # an exit should have a destination (this is replaced at creation time)
-        if self.location:
+        # an exit should have a destination - try to make sure it does
+        if self.location and not self.destination:
             self.destination = self.location
 
     def at_cmdset_get(self, **kwargs):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Since the spawner sets location and destination directly in the db rather than through the typeclass `create` method, Exits were having prototype-set destinations overwritten to location by `basetype_setup`.

This fixes that by checking for a pre-existing destination rather than assuming there isn't one.

#### Motivation for adding to Evennia
Bug fixing