### PR TITLE
enable dependencies cache in CI

### DIFF
--- a/.github/workflows/github_action_build_docs.yml
+++ b/.github/workflows/github_action_build_docs.yml
@@ -30,9 +30,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install doc-building dependencies
         run: |

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -92,9 +92,13 @@ jobs:
       run: docker ps -a
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          requirements.txt
+          requirements_extra.txt
 
     - name: Install package dependencies
       run: |


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR enable requirements' caching in either test and docs CI pipelines. It also bumps action's version because why not ;)

#### Motivation for adding to Evennia

speedups, survive to third-party sites outages