### PR TITLE
speedier format/_map()s

### DIFF
--- a/evennia/contrib/game_systems/crafting/crafting.py
+++ b/evennia/contrib/game_systems/crafting/crafting.py
@@ -625,7 +625,7 @@ class CraftingRecipe(CraftingRecipeBase):
         mapping["outputs"] = iter_to_str(self.output_names)
 
         # populate template and return
-        return message.format(**mapping)
+        return message.format_map(mapping)
 
     @classmethod
     def seed(cls, tool_kwargs=None, consumable_kwargs=None, location=None):

--- a/evennia/contrib/game_systems/crafting/tests.py
+++ b/evennia/contrib/game_systems/crafting/tests.py
@@ -190,7 +190,7 @@ class TestCraftingRecipe(BaseEvenniaTestCase):
         }
 
         result = recipe._format_message(msg, **kwargs)
-        self.assertEqual(result, msg.format(**expected))
+        self.assertEqual(result, msg.format_map(expected))
 
     def test_craft__success(self):
         """Test to create a result from the recipe"""

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -605,7 +605,7 @@ def send_emote(sender, receivers, emote, msg_type="pose", anonymous_add="first",
             }
         # map the language {##num} markers. This will convert the escaped sdesc markers on
         # the form {{#num}} to {#num} markers ready to sdesc-map in the next step.
-        sendemote = emote.format(**receiver_lang_mapping)
+        sendemote = emote.format_map(receiver_lang_mapping)
 
         # map the ref keys to sdescs
         receiver_sdesc_mapping = dict(
@@ -617,7 +617,11 @@ def send_emote(sender, receivers, emote, msg_type="pose", anonymous_add="first",
         )
 
         # do the template replacement of the sdesc/recog {#num} markers
-        receiver.msg(text=(sendemote.format(**receiver_sdesc_mapping), {"type": msg_type}), from_obj=sender, **kwargs)
+        receiver.msg(
+            text=(sendemote.format_map(receiver_sdesc_mapping), {"type": msg_type}),
+            from_obj=sender,
+            **kwargs,
+        )
 
 
 # ------------------------------------------------------------
@@ -1055,7 +1059,7 @@ class CmdPose(RPCommand):  # set current pose and default pose
                 (ref, obj.sdesc.get() if hasattr(obj, "sdesc") else obj.key)
                 for ref, obj in mapping.items()
             )
-            pose = parsed.format(**mapping)
+            pose = parsed.format_map(mapping)
 
             if len(target_name) + len(pose) > 60:
                 caller.msg(f"'{pose}' is too long.")

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -816,8 +816,8 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             )
 
             # director-stance replacements
-            outmessage = inmessage.format(
-                **{
+            outmessage = inmessage.format_map(
+                {
                     key: obj.get_display_name(looker=receiver)
                     if hasattr(obj, "get_display_name")
                     else str(obj)
@@ -2203,7 +2203,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 "speech": message,
             }
             self_mapping.update(custom_mapping)
-            self.msg(text=(msg_self.format(**self_mapping), {"type": msg_type}), from_obj=self)
+            self.msg(text=(msg_self.format_map(self_mapping), {"type": msg_type}), from_obj=self)
 
         if receivers and msg_receivers:
             receiver_mapping = {
@@ -2226,7 +2226,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 receiver_mapping.update(individual_mapping)
                 receiver_mapping.update(custom_mapping)
                 receiver.msg(
-                    text=(msg_receivers.format(**receiver_mapping), {"type": msg_type}),
+                    text=(msg_receivers.format_map(receiver_mapping), {"type": msg_type}),
                     from_obj=self,
                 )
 
@@ -2349,9 +2349,9 @@ class DefaultCharacter(DefaultObject):
             if not locks and account:
                 # Allow only the character itself and the creator account to puppet this character
                 # (and Developers).
-                locks = cls.lockstring.format(**{"character_id": obj.id, "account_id": account.id})
+                locks = cls.lockstring.format(character_id=obj.id, account_id=account.id)
             elif not locks and not account:
-                locks = cls.lockstring.format(**{"character_id": obj.id, "account_id": -1})
+                locks = cls.lockstring.format(character_id=obj.id, account_id=-1)
 
             obj.locks.add(locks)
 
@@ -2600,9 +2600,9 @@ class DefaultRoom(DefaultObject):
 
             # Add locks
             if not locks and account:
-                locks = cls.lockstring.format(**{"id": account.id})
+                locks = cls.lockstring.format(id=account.id)
             elif not locks and not account:
-                locks = cls.lockstring.format(**{"id": obj.id})
+                locks = cls.lockstring.format(id=obj.id)
 
             obj.locks.add(locks)
 
@@ -2808,9 +2808,9 @@ class DefaultExit(DefaultObject):
 
             # Set appropriate locks
             if not locks and account:
-                locks = cls.lockstring.format(**{"id": account.id})
+                locks = cls.lockstring.format(id=account.id)
             elif not locks and not account:
-                locks = cls.lockstring.format(**{"id": obj.id})
+                locks = cls.lockstring.format(id=obj.id)
             obj.locks.add(locks)
 
             # Record creator id and creation IP

--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -498,11 +498,11 @@ def _print_info(portal_info_dict, server_info_dict):
     pstr, sstr = "", ""
     if portal_info_dict:
         pdict = _prepare_dict(portal_info_dict)
-        pstr = _strip_empty_lines(PORTAL_INFO.format(**pdict))
+        pstr = _strip_empty_lines(PORTAL_INFO.format_map(pdict))
 
     if server_info_dict:
         sdict = _prepare_dict(server_info_dict)
-        sstr = _strip_empty_lines(SERVER_INFO.format(**sdict))
+        sstr = _strip_empty_lines(SERVER_INFO.format_map(sdict))
 
     info = pstr + ("\n\n" + sstr if sstr else "")
     maxwidth = max(len(line) for line in info.split("\n"))
@@ -1383,7 +1383,7 @@ def create_settings_file(init=True, secret_settings=False):
     with open(settings_path, "r") as f:
         settings_string = f.read()
 
-    settings_string = settings_string.format(**setting_dict)
+    settings_string = settings_string.format_map(setting_dict)
 
     with open(settings_path, "w") as f:
         f.write(settings_string)

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -1552,7 +1552,7 @@ def parse_nick_template(string, template_regex, outtemplate):
         matchdict = {
             key: value if value is not None else "" for key, value in match.groupdict().items()
         }
-        return True, outtemplate.format(**matchdict)
+        return True, outtemplate.format_map(matchdict)
     return False, string
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

I'll promise I'll not become a `timeit` zealot but after that:

```
In [3]: %timeit '{foo}'.format(**{'foo': 'bar', 'a': 1})
817 ns ± 6.67 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: %timeit '{foo}'.format_map({'foo': 'bar', 'a': 1})
495 ns ± 3.46 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %timeit '{foo}'.format(foo='bar', a=1)
620 ns ± 3.25 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

I've did a quick grep and made couple edits :)


thank you, regards