### PR TITLE
upgrade to 1.0: instruct how to fix deprecation errors

### DIFF
--- a/docs/source/Setup/Installation-Upgrade.md
+++ b/docs/source/Setup/Installation-Upgrade.md
@@ -30,6 +30,9 @@ game dir, continue below.
 anything you want to keep), you can _delete_ it entirely.
 - Copy `evennia/evennia/game_template/web` to `mygame/` (e.g. using `cp -Rf` or a file manager). This new `web` folder
 replaces the old one and has a very different structure.
+- Replace/comment out import and calls to
+[deprecated `django.conf.urls`](https://docs.djangoproject.com/en/3.2/ref/urls/#url). If needed, a replacement is
+[available here](https://docs.djangoproject.com/en/4.0/ref/urls/#django.urls.re_path).
 - `evennia migrate`
 - `evennia start`
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When upgrading from 0.9.5 to 1.0 django errors out because a deprecation in urlpatterns utils. This PR gives instructions on how to fix the error that would come up in eg. `evennia migrate`:

```
  File "/home/oggei/dev/evennia/zero-dot/web/urls.py", line 7, in <module>
    from django.conf.urls import url, include
ImportError: cannot import name 'url' from 'django.conf.urls' (/home/oggei/.pyenv/versions/3.9.13/envs/evennia/lib/python3.9/site-packages/django/conf/urls/__init__.py)
```

HTH, regards