### PR TITLE
Ignore rotated log files

### DIFF
--- a/evennia/game_template/gitignore
+++ b/evennia/game_template/gitignore
@@ -21,6 +21,7 @@ __pycache__
 # Other
 *.swp
 *.log
+*.log.*
 *.pid
 *.restart
 *.db3


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a gitignore line to catch root-dir rotated log files (e.g. twistd.log.2)
