### PR TITLE
#2840 Add tzdata to requirements.txt to prevent stack traces

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ lunr == 0.6.0
 simpleeval <= 1.0
 uritemplate == 4.1.1
 Jinja2 < 3.1
+tzdata
 
 # try to resolve dependency issue in py3.7
 attrs >= 19.2.0


### PR DESCRIPTION
This PR addresses the findings of #2840 ; wherein on systems with Python 3.9+ that do not have a timezone set (containers) python attempts to fallback to use of `tzdata` for timestamps on `[MudInfo]` emits. Adding tzdata to dependencies ensures that Evennia works consistently on these systems.


#### Brief overview of PR changes/additions
Added `tzdata` to requirements.txt with no version pinning as tzdata is a timezone data package for Python and should never have compatability issues. Rather we would always want Python to leverage the latest tzdata changes in the event of timezone changes (for example, some timezones dropping daylight savings).

#### Motivation for adding to Evennia
Reducing friction for installs on container systems.

#### Other info (issues closed, discussion etc)

This will resolve #2840 once merged.
