### PR TITLE
Fix missing `evennia.` in Menu Contrib Docs

### DIFF
--- a/docs/source/Contribs/Contrib-Menu-Login.md
+++ b/docs/source/Contribs/Contrib-Menu-Login.md
@@ -11,7 +11,7 @@ menu system `EvMenu` under the hood.
 To install, add this to `mygame/server/conf/settings.py`:
 
     CMDSET_UNLOGGEDIN = "evennia.contrib.base_systems.menu_login.UnloggedinCmdSet"
-    CONNECTION_SCREEN_MODULE = "contrib.base_systems.menu_login.connection_screens"
+    CONNECTION_SCREEN_MODULE = "evennia.contrib.base_systems.menu_login.connection_screens"
 
 Reload the server and reconnect to see the changes.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes the  `CONNECTION_SCREEN_MODULE` setting missing the `evennia.` which causes the doc instructions to throw a stack trace.

#### Motivation for adding to Evennia
Fixes #2844 

#### Other info (issues closed, discussion etc)
