### PR TITLE
Fix clothing creation instructions

### DIFF
--- a/docs/source/Contribs/Contrib-Clothing.md
+++ b/docs/source/Contribs/Contrib-Clothing.md
@@ -51,7 +51,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 From here, you can use the default builder commands to create clothes
 with which to test the system:
 
-    create a pretty shirt : evennia.contrib.game_systems.clothing.Clothing
+    create a pretty shirt : evennia.contrib.game_systems.clothing.ContribClothing
     set shirt/clothing_type = 'top'
     wear shirt
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fixes the instruction problems mentioned in #2846 - where the `Clothing` typeclass has been renamed to `ContribClothing` but the docs do not yet reflect this.

#### Motivation for adding to Evennia
Fixes #2846 

#### Other info (issues closed, discussion etc)
