### PR TITLE
Add 'search' lock for obj.search() and obj.get_visible_contents()

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -533,7 +533,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         )
 
         if use_locks:
-            results = [x for x in list(results) if x.access(self, "search")]
+            results = [x for x in list(results) if x.access(self, "search", default=True)]
         
         nresults = len(results)
         if stacked > 0 and nresults > 1:
@@ -1817,7 +1817,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
 
         def filter_visible(obj_list):
-            return [obj for obj in obj_list if obj != looker and obj.access(looker, "view") and obj.access(looker, "search")]
+            return [obj for obj in obj_list if obj != looker and obj.access(looker, "view") and obj.access(looker, "search", default=True)]
 
         return {
             "exits": filter_visible(self.contents_get(content_type="exit")),


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The PR adds checks for a 'search' lock for obj.search() and obj.get_visible_contents() which identifies whether the object should be searchable.

#### Motivation for adding to Evennia
Vanilla Evennia does not allow true hidden objects by default.

The 'view' lock will prevent the object being displayed in a room's description and stop the look command with "Could not view 'object(#9)'", where as attempting to look at a non-existant object returns 'Could not find '<object>''. Likewise, the 'get' lock will disallow getting with "Could not get 'object(#9)" instead of 'Could not find '<object>''. Both of which give away the existance of a hidden object.

The PR adds checks for a 'search' lock for obj.search() and obj.get_visible_contents() which identifies whether the object should be searchable. Where search = false, then the search command will ignore it, achieveing what the 'view' and 'get' locks do not. Because the get command uses search, search=false objects will not be gettable BUT because rooms use self.contents rather than search, they will still display search = false objects unless the 'view' lock is also false. I can see times when a visible object should not be subject to search and so they should be separate locks. However, something that is not searchable will
ordinarily not be visible. Therefore, obj.get_visible_contents() will remove objects that don't pass either test.

#### Other info (issues closed, discussion etc)
