### PR TITLE
Ignore .vscode config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ nosetests.xml
 # PyCharm config
 .idea
 
+# VSCode config
+.vscode
+
 # Windows files generated during setup
 evennia.bat
 twistd.bat


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Add a single line to .gitignore, to ignore config files for Microsoft VSCode (a common IDE).

#### Motivation for adding to Evennia

Makes it easier to develop Evennia for developers using VSCode

#### Other info (issues closed, discussion etc)

Follows the example of "PyCharm config" and has a similar implementation
