### PR TITLE
Add chown to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY . /usr/src/evennia
 
 # add the game source when rebuilding a new docker image from inside
 # a game dir
-ONBUILD COPY . /usr/src/game
+ONBUILD COPY --chown=evennia . /usr/src/game
 
 # make the game source hierarchy persistent with a named volume.
 # mount on-disk game location here when using the container


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When copying the user's game directory to a Dockerfile that includes both Evennia source and user game source, chown the game directory contents to the `evennia` user.

#### Motivation for adding to Evennia

The method of using Evennia dockerfiles as explained [here](https://www.evennia.com/docs/1.0-dev/Setup/Installation-Docker.html) works fine, since the Docker `--user` is `$UID:$GID` in the docker run command, so the user inside the container matches the one who owns the game files. This allows Evennia to arbitrarily create/remove/edit files in that game source tree.

However, if one wishes to build a standalone Docker image that can run on a container somewhere in the cloud, this does not suffice. Permissions errors are encountered by the running Evennia process, since the process runs as user `evennia` but copied files by default are owned by root.

#### Other info (issues closed, discussion etc)
