### PR TITLE
Fix Windows specific bugs

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -38,7 +38,7 @@ EVENNIA_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 
 import evennia  # noqa
 
-EVENNIA_LIB = os.path.join(os.path.dirname(os.path.abspath(evennia.__file__)))
+EVENNIA_LIB = os.path.join(EVENNIA_ROOT, "evennia")
 EVENNIA_SERVER = os.path.join(EVENNIA_LIB, "server")
 EVENNIA_TEMPLATE = os.path.join(EVENNIA_LIB, "game_template")
 EVENNIA_PROFILING = os.path.join(EVENNIA_SERVER, "profiling")
@@ -1227,7 +1227,7 @@ def evennia_version():
     version = "Unknown"
     try:
         version = evennia.__version__
-    except ImportError:
+    except (ImportError, AttributeError):
         # even if evennia is not found, we should not crash here.
         pass
     try:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Use alternate method of finding `EVENNIA_LIB` path, that works on Windows. Also catch an additional error that can happen on windows with `evennia.__version__`

#### Motivation for adding to Evennia

Allows Windows/Powershell etc users to successfully run `evennia --init` frrom a fresh `develop` branch checkout.

#### Other info (issues closed, discussion etc)

According to [the Python 3 docs](https://docs.python.org/3/reference/import.html#__file__) the `__file__` attribute is completely optional and can be left out by the import system depending on the Python implementation. Clearly something like that is happening on Windows here, but it doesn't matter because we can infer the directory we need from the already resolved `EVENNIA_ROOT` directory.

Fixes #2842