### PR TITLE
Fix for REST API endpoints

### DIFF
--- a/evennia/web/api/views.py
+++ b/evennia/web/api/views.py
@@ -112,10 +112,7 @@ class CharacterViewSet(ObjectDBViewSet):
 
     """
 
-    queryset = DefaultCharacter.objects.typeclass_search(
-        DefaultCharacter.path, include_children=True
-    )
-    list_serializer_class = serializers.ObjectListSerializer
+    queryset = DefaultCharacter.objects.all_family()
 
 
 class RoomViewSet(ObjectDBViewSet):
@@ -124,8 +121,7 @@ class RoomViewSet(ObjectDBViewSet):
 
     """
 
-    queryset = DefaultRoom.objects.typeclass_search(DefaultRoom.path, include_children=True)
-    list_serializer_class = serializers.ObjectListSerializer
+    queryset = DefaultRoom.objects.all_family()
 
 
 class ExitViewSet(ObjectDBViewSet):
@@ -135,8 +131,7 @@ class ExitViewSet(ObjectDBViewSet):
 
     """
 
-    queryset = DefaultExit.objects.typeclass_search(DefaultExit.path, include_children=True)
-    list_serializer_class = serializers.ObjectListSerializer
+    queryset = DefaultExit.objects.all_family()
 
 
 class AccountDBViewSet(TypeclassViewSetMixin, ModelViewSet):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the queryset property of the endpoint views to use the `all_family()` method in order to correctly find all child typeclasses.

#### Motivation for adding to Evennia
Bug fixing.

#### Other info (issues closed, discussion etc)
Resolves #2872