### PR TITLE
Webclient copy fix

### DIFF
--- a/evennia/web/static/webclient/js/plugins/default_in.js
+++ b/evennia/web/static/webclient/js/plugins/default_in.js
@@ -17,6 +17,14 @@ let defaultInPlugin = (function () {
             inputfield = $("#inputfield:focus");
         }
 
+        // Allows you to copy from panels.
+        // Ignore textfocus if Ctrl + C (Or Mac Command Key + C Pressed.)
+        if ((event.ctrlKey || event.metaKey) && event.keyCode == 67) {
+            return;
+        } else {
+            // Continue
+        }
+        
         // check for important keys
         switch (event.which) {
             case  9:  // ignore tab key -- allows normal focus control


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fix/address #6211. Add the ability to copy text from webclient panels using Ctrl + C, (or Cmd + c on Mac.)

#### Motivation for adding to Evennia

Requested by #6211 , I also thought it would be a good idea to have the ability to copy text without having focus shifted to an input panel automatically.

#### Other info (issues closed, discussion etc)
