### PR TITLE
fix: improve convert_urls

### DIFF
--- a/evennia/utils/tests/test_tagparsing.py
+++ b/evennia/utils/tests/test_tagparsing.py
@@ -250,13 +250,13 @@ class TestTextToHTMLparser(TestCase):
     def test_url_scheme_ftp(self):
         self.assertEqual(
             self.parser.convert_urls("ftp.example.com"),
-            '<a href="ftp.example.com" target="_blank">ftp.example.com</a>',
+            '<a href="//ftp.example.com" target="_blank">ftp.example.com</a>',
         )
 
     def test_url_scheme_www(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com"),
-            '<a href="www.example.com" target="_blank">www.example.com</a>',
+            '<a href="//www.example.com" target="_blank">www.example.com</a>',
         )
 
     def test_url_scheme_ftpproto(self):
@@ -280,7 +280,7 @@ class TestTextToHTMLparser(TestCase):
     def test_url_chars_slash(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com/homedir"),
-            '<a href="www.example.com/homedir" target="_blank">www.example.com/homedir</a>',
+            '<a href="//www.example.com/homedir" target="_blank">www.example.com/homedir</a>',
         )
 
     def test_url_chars_colon(self):
@@ -313,22 +313,16 @@ class TestTextToHTMLparser(TestCase):
             ' target="_blank">https://groups.google.com/forum/?fromgroups#!categories/evennia/ainneve</a>',
         )
 
-    def test_url_edge_leadingw(self):
-        self.assertEqual(
-            self.parser.convert_urls("wwww.example.com"),
-            'w<a href="www.example.com" target="_blank">www.example.com</a>',
-        )
-
     def test_url_edge_following_period_eol(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com."),
-            '<a href="www.example.com" target="_blank">www.example.com</a>.',
+            '<a href="//www.example.com" target="_blank">www.example.com</a>.',
         )
 
     def test_url_edge_following_period(self):
         self.assertEqual(
             self.parser.convert_urls("see www.example.com. "),
-            'see <a href="www.example.com" target="_blank">www.example.com</a>. ',
+            'see <a href="//www.example.com" target="_blank">www.example.com</a>. ',
         )
 
     def test_url_edge_brackets(self):
@@ -355,4 +349,10 @@ class TestTextToHTMLparser(TestCase):
             self.parser.convert_urls('</span>http://example.com/<span class="red">'),
             '</span><a href="http://example.com/" target="_blank">'
             'http://example.com/</a><span class="red">',
+        )
+
+    def test_non_url_with_www(self):
+        self.assertEqual(
+            self.parser.convert_urls('Awwww.this should not be highlighted'),
+            'Awwww.this should not be highlighted'
         )

--- a/evennia/utils/tests/test_tagparsing.py
+++ b/evennia/utils/tests/test_tagparsing.py
@@ -250,13 +250,13 @@ class TestTextToHTMLparser(TestCase):
     def test_url_scheme_ftp(self):
         self.assertEqual(
             self.parser.convert_urls("ftp.example.com"),
-            '<a href="//ftp.example.com" target="_blank">ftp.example.com</a>',
+            '<a href="http://ftp.example.com" target="_blank">ftp.example.com</a>',
         )
 
     def test_url_scheme_www(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com"),
-            '<a href="//www.example.com" target="_blank">www.example.com</a>',
+            '<a href="http://www.example.com" target="_blank">www.example.com</a>',
         )
 
     def test_url_scheme_ftpproto(self):
@@ -280,7 +280,7 @@ class TestTextToHTMLparser(TestCase):
     def test_url_chars_slash(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com/homedir"),
-            '<a href="//www.example.com/homedir" target="_blank">www.example.com/homedir</a>',
+            '<a href="http://www.example.com/homedir" target="_blank">www.example.com/homedir</a>',
         )
 
     def test_url_chars_colon(self):
@@ -316,13 +316,13 @@ class TestTextToHTMLparser(TestCase):
     def test_url_edge_following_period_eol(self):
         self.assertEqual(
             self.parser.convert_urls("www.example.com."),
-            '<a href="//www.example.com" target="_blank">www.example.com</a>.',
+            '<a href="http://www.example.com" target="_blank">www.example.com</a>.',
         )
 
     def test_url_edge_following_period(self):
         self.assertEqual(
             self.parser.convert_urls("see www.example.com. "),
-            'see <a href="//www.example.com" target="_blank">www.example.com</a>. ',
+            'see <a href="http://www.example.com" target="_blank">www.example.com</a>. ',
         )
 
     def test_url_edge_brackets(self):

--- a/evennia/utils/tests/test_tagparsing.py
+++ b/evennia/utils/tests/test_tagparsing.py
@@ -356,3 +356,9 @@ class TestTextToHTMLparser(TestCase):
             self.parser.convert_urls('Awwww.this should not be highlighted'),
             'Awwww.this should not be highlighted'
         )
+
+    def test_invalid_www_url(self):
+        self.assertEqual(
+            self.parser.convert_urls('www.t'),
+            'www.t'
+        )

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -88,8 +88,9 @@ class TextToHTMLparser(object):
         re.S | re.M | re.I,
     )
     re_url = re.compile(
-        r'(?<!=")((?:ftp|www|https?)\W+(?:(?!\.(?:\s|$)|&\w+;)[^"\',;$*^\\(){}<>\[\]\s])+)(\.(?:\s|$)|&\w+;|)'
+        r'(?<!=")(\b(?:ftp|www|https?)\W+(?:(?!\.(?:\s|$)|&\w+;)[^"\',;$*^\\(){}<>\[\]\s])+)(\.(?:\s|$)|&\w+;|)'
     )
+    re_protocol = re.compile(r'^(?:ftp|https?)://')
     re_mxplink = re.compile(r"\|lc(.*?)\|lt(.*?)\|le", re.DOTALL)
     re_mxpurl = re.compile(r"\|lu(.*?)\|lt(.*?)\|le", re.DOTALL)
 
@@ -147,9 +148,19 @@ class TextToHTMLparser(object):
             text (str): Processed text.
 
         """
-        # -> added target to output prevent the web browser from attempting to
-        # change pages (and losing our webclient session).
-        return self.re_url.sub(r'<a href="\1" target="_blank">\1</a>\2', text)
+        m = self.re_url.search(text)
+        if m:
+          href = m.group(1)
+          label = href
+          # if there is no protocol (i.e. starts with www) prefix with // so the link isn't treated as relative
+          if not self.re_protocol.match(href):
+            href = "//" + href
+          rest = m.group(2)
+          # -> added target to output prevent the web browser from attempting to
+          # change pages (and losing our webclient session).
+          return text[:m.start()] + f'<a href="{href}" target="_blank">{label}</a>{rest}' + text[m.end():]
+        else:
+          return text
 
     def sub_mxp_links(self, match):
         """

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -91,6 +91,7 @@ class TextToHTMLparser(object):
         r'(?<!=")(\b(?:ftp|www|https?)\W+(?:(?!\.(?:\s|$)|&\w+;)[^"\',;$*^\\(){}<>\[\]\s])+)(\.(?:\s|$)|&\w+;|)'
     )
     re_protocol = re.compile(r'^(?:ftp|https?)://')
+    re_valid_no_protocol = re.compile(r'^(?:www|ftp)\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b[-a-zA-Z0-9@:%_\+.~#?&//=]*')
     re_mxplink = re.compile(r"\|lc(.*?)\|lt(.*?)\|le", re.DOTALL)
     re_mxpurl = re.compile(r"\|lu(.*?)\|lt(.*?)\|le", re.DOTALL)
 
@@ -152,8 +153,11 @@ class TextToHTMLparser(object):
         if m:
           href = m.group(1)
           label = href
-          # if there is no protocol (i.e. starts with www) prefix with // so the link isn't treated as relative
+          # if there is no protocol (i.e. starts with www or ftp)
+          # prefix with // so the link isn't treated as relative
           if not self.re_protocol.match(href):
+            if not self.re_valid_no_protocol.match(href):
+              return text
             href = "//" + href
           rest = m.group(2)
           # -> added target to output prevent the web browser from attempting to

--- a/evennia/utils/text2html.py
+++ b/evennia/utils/text2html.py
@@ -154,11 +154,11 @@ class TextToHTMLparser(object):
           href = m.group(1)
           label = href
           # if there is no protocol (i.e. starts with www or ftp)
-          # prefix with // so the link isn't treated as relative
+          # prefix with http:// so the link isn't treated as relative
           if not self.re_protocol.match(href):
             if not self.re_valid_no_protocol.match(href):
               return text
-            href = "//" + href
+            href = "http://" + href
           rest = m.group(2)
           # -> added target to output prevent the web browser from attempting to
           # change pages (and losing our webclient session).


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds a boundary character `\b` before URLs to cut down on false positives.
- Prefixes urls without a protocol with `//` to prevent browsers opening them as relative links on the webclient's domain. (Maybe this should just be `https://` rather than using the protocol-relative `//`? Opinions welcome!)
- Prevent urls with no protocols that are too short or long to be valid URLs according to the RFC from being converted to links
- Updates tests for urls without protocols, removes leading-w test, adds new test for boundary character requirement

#### Motivation for adding to Evennia
- Links of the form "www.example.com" currently open relative to the webclient URL, which is not expected behavior.
- Cuts down on false positives by requiring a non-word character before a url, so `www.example` will turn into a link on its own, but it won't highlight it in `Awww.example is cute`.

#### Other info (issues closed, discussion etc)
Relates to #2883, #1974
