### PR TITLE
Use `self.name` instead of `self.key` as fallback in `DefaultObject.get_numbered_name`

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1249,7 +1249,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         """
         plural_category = "plural_key"
-        key = kwargs.get("key", self.key)
+        key = kwargs.get("key", self.name)
         key = ansi.ANSIString(key)  # this is needed to allow inflection of colored names
         try:
             plural = _INFLECT.plural(key, count)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Simply changes self.key to self.name so that if get_numbered_name isn't overridden in the call, it will use the name property instead of key, this brings thing in line with other areas, so colorized object names can persist in get_numbered_name.

#### Motivation for adding to Evennia

I believe this is the only place that uses .key instead of .name, and I wanted the consistency of using .name so that other areas didn't need to be overridden to display object name colorization etc.

#### Other info (issues closed, discussion etc)

Not sure why it said before that my develop was behind main one, hopefully this time things are in sync?
