### PR TITLE
fix: use more widely supported unicode characters in webclient

### DIFF
--- a/evennia/web/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/static/webclient/js/plugins/goldenlayout.js
@@ -318,9 +318,9 @@ let goldenlayout = (function () {
     //
     var onTabCreate = function (tab) {
         //HTML for the typeDropdown
-        let renameDropdownControl = $("<span class='lm_title' style='font-size: 1.5em;width: 0.5em;'>&#129170;</span>");
-        let typeDropdownControl   = $("<span class='lm_title' style='font-size: 1.0em;width: 1em;'>&#11201;</span>");
-        let updateDropdownControl = $("<span class='lm_title' style='font-size: 1.0em;width: 1em;'>&#11208;</span>");
+        let renameDropdownControl = $("<span class='lm_title' style='font-size: 1.5em;width: 0.5em;'>&#9656;</span>");
+        let typeDropdownControl   = $("<span class='lm_title' style='font-size: 1.0em;width: 1em;'>&#9670;</span>");
+        let updateDropdownControl = $("<span class='lm_title' style='font-size: 1.0em;width: 1em;'>&#9656;</span>");
         let splitControl          = $("<span class='lm_title' style='font-size: 1.5em;width: 1em;'>+</span>");
         // track dropdowns when the associated control is clicked
         renameDropdownControl.click( tab, renameDropdown ); 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Updates the unicode characters used in the webclient menu to more widely-supported similar ones.

#### Motivation for adding to Evennia

The current characters do not display correctly on OSX.

#### Other info (issues closed, discussion etc)

Fixes #2181
