### PR TITLE
fix: xyzgrid spawn doesn't call at_object_creation

### DIFF
--- a/evennia/contrib/grid/xyzgrid/README.md
+++ b/evennia/contrib/grid/xyzgrid/README.md
@@ -53,28 +53,31 @@ Exits: northeast and east
         (then go back to your mygame/ folder)
 
    This will install all optional requirements of Evennia.
-2. Import and add the `evennia.contrib.commands.XYZGridCmdSet` to the
+2. Import and [add] the `evennia.contrib.grid.xyzgrid.commands.XYZGridCmdSet` to the
    `CharacterCmdset` cmdset in `mygame/commands.default_cmds.py`. Reload
    the server. This makes the `map`, `goto/path` and the modified `teleport` and
    `open` commands available in-game.
+
+[add]: docs/source/Command-Sets.md#defining-command-sets
+
 3. Edit `mygame/server/conf/settings.py` and add
 
-       EXTRA_LAUNCHER_COMMANDS['xyzgrid'] = 'evennia.contrib.launchcmd.xyzcommand'
-
-   and
-
-       PROTOTYPE_MODULES += [’evennia.contrib.grid.xyzgrid.prototypes’]
+       EXTRA_LAUNCHER_COMMANDS['xyzgrid'] = 'evennia.contrib.grid.xyzgrid.launchcmd.xyzcommand'
+       PROTOTYPE_MODULES += ['evennia.contrib.grid.xyzgrid.prototypes']
 
    This will add the new ability to enter `evennia xyzgrid <option>` on the
    command line.  It will also make the `xyz_room` and `xyz_exit` prototypes
    available for use as prototype-parents when spawning the grid.
+
 4. Run `evennia xyzgrid help` for available options.
+
 5. (Optional): By default, the xyzgrid will only spawn module-based
-   [prototypes](../Components/Prototypes.md). This is an optimization and usually makes sense
+   [prototypes]. This is an optimization and usually makes sense
    since the grid is entirely defined outside the game anyway. If you want to
    also make use of in-game (db-) created prototypes, add
    `XYZGRID_USE_DB_PROTOTYPES = True` to settings.
 
+[prototypes]: ../Components/Prototypes.md
 
 ## Overview
 

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 from random import randint
 from parameterized import parameterized
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from evennia.utils.test_resources import BaseEvenniaTest
 from . import xymap, xyzgrid, xymap_legend, xyzroom
 
@@ -1477,13 +1477,6 @@ class TestCallbacks(BaseEvenniaTest):
         super().tearDown()
         self.grid.delete()
 
-    # @override_settings(
-    #   XYZEXIT_PROTOTYPE_OVERRIDE={
-    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
-    #   },
-    #   XYZROOM_PROTOTYPE_OVERRIDE={
-    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
-    #   })
     def test_typeclassed_xyzroom_and_xyzexit_with_at_object_creation_are_called(self):
         map_data = dict(MAP_DATA)
         for prototype_key, prototype_value in map_data["prototypes"].items():

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -1522,4 +1522,4 @@ class TestCallbacks(BaseEvenniaTest):
 
         # Two rooms and 2 exits.
         self.assertEqual(mock_room_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])
-        # self.assertEqual(mock_exit_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])
+        self.assertEqual(mock_exit_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -1457,37 +1457,13 @@ MAP_DATA = {
   }
 }
 
-# @override_settings(
-#   XYZEXIT_PROTOTYPE_OVERRIDE= {
-#     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
-#   },
-#   XYZROOM_PROTOTYPE_OVERRIDE= {
-#     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
-#   }
-# )
 class TestCallbacks(BaseEvenniaTest):
-    # @override_settings(
-    #   XYZEXIT_PROTOTYPE_OVERRIDE={
-    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
-    #   },
-    #   XYZROOM_PROTOTYPE_OVERRIDE={
-    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
-    #   })
     def setUp(self):
         super().setUp()
         mock_room_callbacks.reset_mock()
         mock_exit_callbacks.reset_mock()
         
     def setup_grid(self, map_data):
-        # from evennia.prototypes import prototypes as protlib
-        # for prototype_key in ('xyz_room', 'xyz_exit', 'xyzroom', 'xyzexit'):
-        #   proto = protlib.search_prototype(
-        #       prototype_key,
-        #       # require_single=True,
-        #       # no_db=True
-        #   )
-        #   print(prototype_key, 'found?', proto)
-
         self.grid, err = xyzgrid.XYZGrid.create("testgrid")
 
         def _log(msg):
@@ -1515,11 +1491,10 @@ class TestCallbacks(BaseEvenniaTest):
                 prototype_value["typeclass"] = "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom"
             if len(prototype_key) == 3:
                 prototype_value["typeclass"] = "evennia.contrib.grid.xyzgrid.tests.TestXyzExit"
-        print(map_data)
         self.setup_grid(map_data)
 
         self.grid.spawn()
 
-        # Two rooms and 2 exits.
+        # Two rooms and 2 exits, Each one should have gotten one `at_object_creation` callback.
         self.assertEqual(mock_room_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])
         self.assertEqual(mock_exit_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -1425,6 +1425,34 @@ class TestXyzExit(xyzroom.XYZExit):
   def at_object_creation(self):
     breakpoint()
 
+MAP_DATA = {
+  "map": """
+
+    + 0 1
+
+    0 #-#
+
+    + 0 1
+
+  """,
+  "zcoord": "map1",
+  "prototypes": {
+     ("*", "*"): {
+       "key": "room",
+       "desc": "A room.",
+       "prototype_parent": "xyz_room",
+     },
+     ("*", "*", "*"): {
+       "desc": "A passage.",
+       "prototype_parent": "xyz_exit",
+     }
+  },
+  "options": {
+    "map_visual_range": 1,
+    "map_mode": "scan",
+  }
+}
+
 # @override_settings(
 #   XYZEXIT_PROTOTYPE_OVERRIDE= {
 #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
@@ -1434,62 +1462,54 @@ class TestXyzExit(xyzroom.XYZExit):
 #   }
 # )
 class TestCallbacks(BaseEvenniaTest):
-    @override_settings(
-      XYZEXIT_PROTOTYPE_OVERRIDE={
-        "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
-      },
-      XYZROOM_PROTOTYPE_OVERRIDE={
-        "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
-      })
-    def setUp(self):
-        super().setUp()
+    # @override_settings(
+    #   XYZEXIT_PROTOTYPE_OVERRIDE={
+    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
+    #   },
+    #   XYZROOM_PROTOTYPE_OVERRIDE={
+    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
+    #   })
+    # def setUp(self):
+    #     super().setUp()
+    #     self.setup_grid(MAP_DATA)
         
-        from evennia.prototypes import prototypes as protlib
-        for prototype_key in ('xyz_room', 'xyz_exit', 'xyzroom', 'xyzexit'):
-          proto = protlib.search_prototype(
-              prototype_key,
-              # require_single=True,
-              # no_db=True
-          )
-          print(prototype_key, 'found?', proto)
+    def setup_grid(self, map_data):
+        # from evennia.prototypes import prototypes as protlib
+        # for prototype_key in ('xyz_room', 'xyz_exit', 'xyzroom', 'xyzexit'):
+        #   proto = protlib.search_prototype(
+        #       prototype_key,
+        #       # require_single=True,
+        #       # no_db=True
+        #   )
+        #   print(prototype_key, 'found?', proto)
 
-        self.map_data = {
-          "map": """
-
-            + 0 1
-
-            0 #-#
-
-            + 0 1
-
-          """,
-          "zcoord": "map1",
-          "prototypes": {
-             ("*", "*"): {
-               "key": "room",
-               "desc": "A room.",
-               "prototype_parent": "xyz_room",
-             },
-             ("*", "*", "*"): {
-               "desc": "A passage.",
-               "prototype_parent": "xyz_exit",
-             }
-          },
-          "options": {
-            "map_visual_range": 1,
-            "map_mode": "scan",
-          }
-        }
         self.grid, err = xyzgrid.XYZGrid.create("testgrid")
 
         def _log(msg):
              print(msg)
         self.grid.log = _log
 
-        self.grid.add_maps(self.map_data)
+        self.map_data = map_data
+        self.grid.add_maps(map_data)
 
     def tearDown(self):
         self.grid.delete()
 
+    # @override_settings(
+    #   XYZEXIT_PROTOTYPE_OVERRIDE={
+    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
+    #   },
+    #   XYZROOM_PROTOTYPE_OVERRIDE={
+    #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
+    #   })
     def test_dummy(self):
+        map_data = dict(MAP_DATA)
+        for prototype_key, prototype_value in map_data["prototypes"].items():
+            if len(prototype_key) == 2:
+                prototype_value["typeclass"] = "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom"
+            if len(prototype_key) == 3:
+                prototype_value["typeclass"] = "evennia.contrib.grid.xyzgrid.tests.TestXyzExit"
+        print(map_data)
+        self.setup_grid(map_data)
+
         self.grid.spawn()

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -3,6 +3,8 @@
 Tests for the XYZgrid system.
 
 """
+from unittest import mock
+from unittest.mock import patch
 
 from random import randint
 from parameterized import parameterized
@@ -1419,11 +1421,11 @@ class TestBuildExampleGrid(BaseEvenniaTest):
 
 class TestXyzRoom(xyzroom.XYZRoom):
   def at_object_creation(self):
-    breakpoint()
+    pass
 
 class TestXyzExit(xyzroom.XYZExit):
   def at_object_creation(self):
-    breakpoint()
+    pass
 
 MAP_DATA = {
   "map": """
@@ -1469,8 +1471,8 @@ class TestCallbacks(BaseEvenniaTest):
     #   XYZROOM_PROTOTYPE_OVERRIDE={
     #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
     #   })
-    # def setUp(self):
-    #     super().setUp()
+    def setUp(self):
+        super().setUp()
     #     self.setup_grid(MAP_DATA)
         
     def setup_grid(self, map_data):
@@ -1493,6 +1495,7 @@ class TestCallbacks(BaseEvenniaTest):
         self.grid.add_maps(map_data)
 
     def tearDown(self):
+        super().tearDown()
         self.grid.delete()
 
     # @override_settings(
@@ -1502,6 +1505,8 @@ class TestCallbacks(BaseEvenniaTest):
     #   XYZROOM_PROTOTYPE_OVERRIDE={
     #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
     #   })
+    # @patch('evennia.contrib.grid.xyzgrid.tests.TestXyzRoom')
+    # def test_dummy(self, MockTestXyzRoom):
     def test_dummy(self):
         map_data = dict(MAP_DATA)
         for prototype_key, prototype_value in map_data["prototypes"].items():

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -4,7 +4,6 @@ Tests for the XYZgrid system.
 
 """
 from unittest import mock
-from unittest.mock import patch
 
 from random import randint
 from parameterized import parameterized
@@ -1419,13 +1418,16 @@ class TestBuildExampleGrid(BaseEvenniaTest):
         self.assertTrue(room2b.db.desc.startswith("Sunlight sifts down"))
 
 
+mock_room_callbacks = mock.MagicMock()
+mock_exit_callbacks = mock.MagicMock()
+
 class TestXyzRoom(xyzroom.XYZRoom):
   def at_object_creation(self):
-    pass
+    mock_room_callbacks.at_object_creation()
 
 class TestXyzExit(xyzroom.XYZExit):
   def at_object_creation(self):
-    pass
+    mock_exit_callbacks.at_object_creation()
 
 MAP_DATA = {
   "map": """
@@ -1473,7 +1475,8 @@ class TestCallbacks(BaseEvenniaTest):
     #   })
     def setUp(self):
         super().setUp()
-    #     self.setup_grid(MAP_DATA)
+        mock_room_callbacks.reset_mock()
+        mock_exit_callbacks.reset_mock()
         
     def setup_grid(self, map_data):
         # from evennia.prototypes import prototypes as protlib
@@ -1505,9 +1508,7 @@ class TestCallbacks(BaseEvenniaTest):
     #   XYZROOM_PROTOTYPE_OVERRIDE={
     #     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
     #   })
-    # @patch('evennia.contrib.grid.xyzgrid.tests.TestXyzRoom')
-    # def test_dummy(self, MockTestXyzRoom):
-    def test_dummy(self):
+    def test_typeclassed_xyzroom_and_xyzexit_with_at_object_creation_are_called(self):
         map_data = dict(MAP_DATA)
         for prototype_key, prototype_value in map_data["prototypes"].items():
             if len(prototype_key) == 2:
@@ -1518,3 +1519,7 @@ class TestCallbacks(BaseEvenniaTest):
         self.setup_grid(map_data)
 
         self.grid.spawn()
+
+        # Two rooms and 2 exits.
+        self.assertEqual(mock_room_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])
+        # self.assertEqual(mock_exit_callbacks.at_object_creation.mock_calls, [mock.call(), mock.call()])

--- a/evennia/contrib/grid/xyzgrid/tests.py
+++ b/evennia/contrib/grid/xyzgrid/tests.py
@@ -6,7 +6,7 @@ Tests for the XYZgrid system.
 
 from random import randint
 from parameterized import parameterized
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from evennia.utils.test_resources import BaseEvenniaTest
 from . import xymap, xyzgrid, xymap_legend, xyzroom
 
@@ -1415,3 +1415,81 @@ class TestBuildExampleGrid(BaseEvenniaTest):
         self.assertTrue(room2a.db.desc.startswith("This is the entrance to"))
         self.assertEqual(room2b.key, "North-west corner of the atrium")
         self.assertTrue(room2b.db.desc.startswith("Sunlight sifts down"))
+
+
+class TestXyzRoom(xyzroom.XYZRoom):
+  def at_object_creation(self):
+    breakpoint()
+
+class TestXyzExit(xyzroom.XYZExit):
+  def at_object_creation(self):
+    breakpoint()
+
+# @override_settings(
+#   XYZEXIT_PROTOTYPE_OVERRIDE= {
+#     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
+#   },
+#   XYZROOM_PROTOTYPE_OVERRIDE= {
+#     "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
+#   }
+# )
+class TestCallbacks(BaseEvenniaTest):
+    @override_settings(
+      XYZEXIT_PROTOTYPE_OVERRIDE={
+        "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzExit",
+      },
+      XYZROOM_PROTOTYPE_OVERRIDE={
+        "typeclass": "evennia.contrib.grid.xyzgrid.tests.TestXyzRoom",
+      })
+    def setUp(self):
+        super().setUp()
+        
+        from evennia.prototypes import prototypes as protlib
+        for prototype_key in ('xyz_room', 'xyz_exit', 'xyzroom', 'xyzexit'):
+          proto = protlib.search_prototype(
+              prototype_key,
+              # require_single=True,
+              # no_db=True
+          )
+          print(prototype_key, 'found?', proto)
+
+        self.map_data = {
+          "map": """
+
+            + 0 1
+
+            0 #-#
+
+            + 0 1
+
+          """,
+          "zcoord": "map1",
+          "prototypes": {
+             ("*", "*"): {
+               "key": "room",
+               "desc": "A room.",
+               "prototype_parent": "xyz_room",
+             },
+             ("*", "*", "*"): {
+               "desc": "A passage.",
+               "prototype_parent": "xyz_exit",
+             }
+          },
+          "options": {
+            "map_visual_range": 1,
+            "map_mode": "scan",
+          }
+        }
+        self.grid, err = xyzgrid.XYZGrid.create("testgrid")
+
+        def _log(msg):
+             print(msg)
+        self.grid.log = _log
+
+        self.grid.add_maps(self.map_data)
+
+    def tearDown(self):
+        self.grid.delete()
+
+    def test_dummy(self):
+        self.grid.spawn()

--- a/evennia/contrib/grid/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/grid/xyzgrid/xymap_legend.py
@@ -302,6 +302,7 @@ class MapNode:
         to their destinations.
 
         """
+        # breakpoint()
         global NodeTypeclass
         if not NodeTypeclass:
             from .xyzroom import XYZRoom as NodeTypeclass

--- a/evennia/contrib/grid/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/grid/xyzgrid/xymap_legend.py
@@ -401,6 +401,7 @@ class MapNode:
                     continue
 
                 exitnode = self.links[direction]
+                # TODO: Use specified Typeclass
                 exi, err = ExitTypeclass.create(
                     key,
                     xyz=xyz,

--- a/evennia/contrib/grid/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/grid/xyzgrid/xymap_legend.py
@@ -401,8 +401,13 @@ class MapNode:
                     continue
 
                 exitnode = self.links[direction]
-                # TODO: Use specified Typeclass
-                exi, err = ExitTypeclass.create(
+                prot = maplinks[key.lower()][3].prototype
+                typeclass = prot.get("typeclass", "")
+                self.log(f"  spawning/updating exit xyz={xyz}, direction={key} ({typeclass})")
+
+                Typeclass = class_from_module(typeclass,
+                    fallback="evennia.contrib.grid.xyzgrid.xyzroom.XYZExit")
+                exi, err = Typeclass.create(
                     key,
                     xyz=xyz,
                     xyz_destination=exitnode.get_spawn_xyz(),
@@ -410,15 +415,8 @@ class MapNode:
                 )
                 if err:
                     raise RuntimeError(err)
+
                 linkobjs[key.lower()] = exi
-                prot = maplinks[key.lower()][3].prototype
-                tclass = prot["typeclass"]
-                tclass = (
-                    f" ({tclass})"
-                    if tclass != "evennia.contrib.grid.xyzgrid.xyzroom.XYZExit"
-                    else ""
-                )
-                self.log(f"  spawning/updating exit xyz={xyz}, direction={key}{tclass}")
 
         # apply prototypes to catch any changes
         for key, linkobj in linkobjs.items():

--- a/evennia/contrib/grid/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/grid/xyzgrid/xymap_legend.py
@@ -24,7 +24,7 @@ from django.core import exceptions as django_exceptions
 from evennia.prototypes import spawner
 from evennia.utils.utils import class_from_module
 
-from .utils import MAPSCAN, REVERSE_DIRECTIONS, MapParserError, BIGVAL
+from .utils import MAPSCAN, REVERSE_DIRECTIONS, MapParserError, BIGVAL, MapError
 
 NodeTypeclass = None
 ExitTypeclass = None
@@ -402,11 +402,12 @@ class MapNode:
 
                 exitnode = self.links[direction]
                 prot = maplinks[key.lower()][3].prototype
-                typeclass = prot.get("typeclass", "")
+                typeclass = prot.get("typeclass")
+                if typeclass is None:
+                    raise MapError(f"The prototype {self.prototype} for this node has no 'typeclass' key.", self)
                 self.log(f"  spawning/updating exit xyz={xyz}, direction={key} ({typeclass})")
 
-                Typeclass = class_from_module(typeclass,
-                    fallback="evennia.contrib.grid.xyzgrid.xyzroom.XYZExit")
+                Typeclass = class_from_module(typeclass)
                 exi, err = Typeclass.create(
                     key,
                     xyz=xyz,

--- a/evennia/contrib/grid/xyzgrid/xymap_legend.py
+++ b/evennia/contrib/grid/xyzgrid/xymap_legend.py
@@ -319,10 +319,11 @@ class MapNode:
         except django_exceptions.ObjectDoesNotExist:
             # create a new entity, using the specified typeclass (if there's one) and
             # with proper coordinates etc
-            typeclass = self.prototype.get("typeclass", "")
+            typeclass = self.prototype.get("typeclass")
+            if typeclass is None:
+                raise MapError(f"The prototype {self.prototype} for this node has no 'typeclass' key.", self)
             self.log(f"  spawning room at xyz={xyz} ({typeclass})")
-            Typeclass = class_from_module(typeclass,
-                fallback="evennia.contrib.grid.xyzgrid.xyzroom.XYZRoom")
+            Typeclass = class_from_module(typeclass)
             nodeobj, err = Typeclass.create(self.prototype.get("key", "An empty room"), xyz=xyz)
             if err:
                 raise RuntimeError(err)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Fix installation instructions
- Use specified typeclass in prototype (if any) to instantiate xyz rooms and exits.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
#2695 
