### PR TITLE
Fix `TagHandler.has` to return False for no-match

### DIFF
--- a/evennia/typeclasses/tags.py
+++ b/evennia/typeclasses/tags.py
@@ -419,7 +419,7 @@ class TagHandler(object):
         if key:
             for tag_str in make_iter(key):
                 tag_str = tag_str.strip().lower()
-                ret.extend(bool(tag) for tag in self._getcache(tag_str, category))
+                ret.append(bool(self._getcache(tag_str, category)))
         elif category:
             ret.extend(bool(tag) for tag in self._getcache(category=category))
         else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fix assumes that a search for a specific tag key with category will only ever return one tag, which to my knowledge is consistent with the rest of the code and intended functionality. As such, it appends a boolean for each tag+category combination representing whether a match was found, rather than extending the list with any found tags.

If that assumption is incorrect, then this'll need a different solution.

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Closes #2913