### PR TITLE
#2915 Remove assert that verifies that a Script is a subclass of DefaultScript during global script discovering

### DIFF
--- a/evennia/utils/containers.py
+++ b/evennia/utils/containers.py
@@ -19,7 +19,6 @@ from evennia.utils import logger
 from evennia.utils.utils import callables_from_module, class_from_module
 
 SCRIPTDB = None
-_BASE_SCRIPT_TYPECLASS = None
 
 
 class Container:
@@ -201,17 +200,12 @@ class GlobalScriptContainer(Container):
         initialized.
 
         """
-        global _BASE_SCRIPT_TYPECLASS
-        if not _BASE_SCRIPT_TYPECLASS:
-            _BASE_SCRIPT_TYPECLASS = class_from_module(settings.BASE_SCRIPT_TYPECLASS)
-
         if self.typeclass_storage is None:
             self.typeclass_storage = {}
             for key, data in list(self.loaded_data.items()):
                 try:
                     typeclass = data.get("typeclass", settings.BASE_SCRIPT_TYPECLASS)
                     script_typeclass = class_from_module(typeclass)
-                    assert issubclass(script_typeclass, _BASE_SCRIPT_TYPECLASS)
                     self.typeclass_storage[key] = script_typeclass
                 except Exception:
                     logger.log_trace(

--- a/evennia/utils/tests/test_containers.py
+++ b/evennia/utils/tests/test_containers.py
@@ -4,6 +4,7 @@ from evennia.utils import containers
 from django.conf import settings
 from django.test import override_settings
 from evennia.utils.utils import class_from_module
+from evennia.scripts.scripts import DefaultScript
 
 _BASE_SCRIPT_TYPECLASS = class_from_module(settings.BASE_SCRIPT_TYPECLASS)
 
@@ -19,6 +20,10 @@ class WorseScript(_BASE_SCRIPT_TYPECLASS):
   @property
   def objects(self):
     from evennia import module_that_doesnt_exist
+
+class QuestionableScript(DefaultScript):
+  """Does NOT derive from settings.BASE_SCRIPT_TYPECLASS so it would fail."""
+  pass
 
 class TestGlobalScriptContainer(unittest.TestCase):
 
@@ -64,6 +69,15 @@ class TestGlobalScriptContainer(unittest.TestCase):
 
   @override_settings(GLOBAL_SCRIPTS={'script_name': {'typeclass': 'evennia.utils.tests.test_containers.BadScript'}})
   def test_start_with_bad_typeclassed_script_skips_it(self):
+    gsc = containers.GlobalScriptContainer()
+
+    gsc.start()
+
+    self.assertEqual(len(gsc.typeclass_storage), 0)
+    self.assertNotIn('script_name', gsc.typeclass_storage)
+
+  @override_settings(GLOBAL_SCRIPTS={'script_name': {'typeclass': 'evennia.utils.tests.test_containers.QuestionableScript'}})
+  def test_start_with_questionably_subclassed_script_skips_it(self):
     gsc = containers.GlobalScriptContainer()
 
     gsc.start()

--- a/evennia/utils/tests/test_containers.py
+++ b/evennia/utils/tests/test_containers.py
@@ -78,6 +78,9 @@ class TestGlobalScriptContainer(unittest.TestCase):
 
   @override_settings(GLOBAL_SCRIPTS={'script_name': {'typeclass': 'evennia.utils.tests.test_containers.QuestionableScript'}})
   def test_start_with_questionably_subclassed_script_skips_it(self):
+    # Make sure _BASE_SCRIPT_TYPECLASS is NOT DefaultScript but it's a subclass
+    assert issubclass(_BASE_SCRIPT_TYPECLASS, DefaultScript) and _BASE_SCRIPT_TYPECLASS != DefaultScript
+
     gsc = containers.GlobalScriptContainer()
 
     gsc.start()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove assert that verifies that a Script is a subclass of DefaultScript during global script discovering

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
#2915 
Previous PR #2882