### PR TITLE
feat: consolidate new input tab buttons

### DIFF
--- a/evennia/web/static/webclient/css/goldenlayout.css
+++ b/evennia/web/static/webclient/css/goldenlayout.css
@@ -46,6 +46,7 @@ label {
 .lm_title {
     text-align: center;
     margin-right: 2px;
+    padding-right: 8px;
 }
 
 .lm_tab.lm_active {

--- a/evennia/web/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/static/webclient/js/plugins/goldenlayout.js
@@ -264,7 +264,19 @@ let goldenlayout = (function () {
     //
     // ensure only one handler is set up on the parent with once
     var registerInputTabChangeHandler = once(function (tab) {
-      tab.header.parent.on( "activeContentItemChanged", onActiveInputTabChange );
+        // Set up the control to add new tabs
+        let splitControl = $(
+          "<span class='lm_title' style='font-size: 1.5em;width: 1em;'>+</span>"
+        );
+
+        // Handler for adding a new tab
+        splitControl.click( tab, function (evnt) {
+            evnt.data.header.parent.addChild( newInputConfig );
+        });
+
+        // Position it after the tab list
+        $('ul.lm_tabs', tab.header.element).after(splitControl).css("position", "relative");
+        tab.header.parent.on( "activeContentItemChanged", onActiveInputTabChange );
     });
 
     //
@@ -382,19 +394,6 @@ let goldenlayout = (function () {
     //
     //
     var onInputCreate = function (tab) {
-        //HTML for the typeDropdown
-        let splitControl = $(
-            "<span class='lm_title' style='font-size: 1.5em;width: 1em;'>+</span>"
-        );
-
-        // track adding a new tab
-        splitControl.click( tab, function (evnt) {
-            evnt.data.header.parent.addChild( newInputConfig );
-        });
-
-        // Add the typeDropdown to the header
-        tab.element.append(  splitControl );
-
         registerInputTabChangeHandler(tab);
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Moves the `+` for adding new input tabs to the right of the input tabs, consolidating it into one button rather than one per open tab.

Old:
![image](https://user-images.githubusercontent.com/35088339/194767040-97fd9936-a4e2-4f98-a8e8-8fa6cf50fdf6.png)

New:
![image](https://user-images.githubusercontent.com/35088339/194767048-a32ef715-eb58-493c-a221-d8c6b96639ac.png)

#### Motivation for adding to Evennia

Makes the UI feel less cluttered and more aesthetically pleasing.

#### Other info (issues closed, discussion etc)

Feature requested in #2215
