### PR TITLE
In funcparser, make $round() actually return value

### DIFF
--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -799,7 +799,7 @@ def funcparser_callable_round(*args, **kwargs):
     num, *significant = args
     significant = significant[0] if significant else 0
     try:
-        round(num, significant)
+        return round(num, significant)
     except Exception:
         if kwargs.get("raise_errors"):
             raise


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The `funcparser_callable_round` which provides the builtin `$round` needs to return the calculated value.

#### Motivation for adding to Evennia
Fix bug

#### Other info (issues closed, discussion etc)
Fixes #2912