### PR TITLE
Fix access control check in $search() function

### DIFF
--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -1162,7 +1162,7 @@ def funcparser_callable_search(*args, caller=None, access="control", **kwargs):
         )
 
     for target in targets:
-        if not target.access(caller, target, access):
+        if not target.access(caller, access):
             raise ParsingError("$search Cannot add found entity - access failure.")
 
     return list(targets) if return_list else targets[0]

--- a/evennia/utils/tests/test_funcparser.py
+++ b/evennia/utils/tests/test_funcparser.py
@@ -528,6 +528,7 @@ class TestCallableSearch(test_resources.BaseEvenniaTest):
         """
         string = "$search(TestAccount, type=account)"
         expected = self.account
+        self.account.locks.add("control:id(%s)" % self.char1.dbref)
 
         ret = self.parser.parse(string, caller=self.char1, return_str=False, raise_errors=True)
         self.assertEqual(expected, ret)
@@ -539,6 +540,7 @@ class TestCallableSearch(test_resources.BaseEvenniaTest):
         """
         string = "$search(Script, type=script)"
         expected = self.script
+        self.script.locks.add("control:id(%s)" % self.char1.dbref)
 
         ret = self.parser.parse(string, caller=self.char1, return_str=False, raise_errors=True)
         self.assertEqual(expected, ret)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the access control check of the `$search()` callable in funcparser to actually perform the check. Previously, the call was being made with three arguments, which I believe made it so the check was being performed against `target` as the lock and the `access` parameter was being slurped into `*args` and ignored entirely.

#### Motivation for adding to Evennia
Fixes bug.

#### Other info (issues closed, discussion etc)
Fixes #2917