### PR TITLE
Remove f-string with unbound variable in funcparser

### DIFF
--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -1153,7 +1153,7 @@ def funcparser_callable_search(*args, caller=None, access="control", **kwargs):
     if not targets:
         if return_list:
             return []
-        raise ParsingError(f"$search: Query '{query}' gave no matches.")
+        raise ParsingError(f"$search: Query '{args[0]}' gave no matches.")
 
     if len(targets) > 1 and not return_list:
         raise ParsingError(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The `$search()` bultin function of funcparser uses an f-string in an error message, but the local variable is not found. This bug was found when adding tests in #2918. It seems like the error string is from an older version of the code where the variable `query` was defined. Fix is to simply change the error message.

#### Motivation for adding to Evennia
Fixes bug

#### Other info (issues closed, discussion etc)
Fixes #2916