### PR TITLE
Fix formatting on command suggestions

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -748,7 +748,7 @@ def cmdhandler(
                         )
                         if suggestions:
                             sysarg += _(" Maybe you meant {command}?").format(
-                                command=utils.list_to_string(suggestions, _("or"), addquote=True)
+                                command=utils.list_to_string(suggestions, endsep=_("or"), addquote=True)
                             )
                         else:
                             sysarg += _(' Type "help" for help.')


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the implicit `sep` argument to `list_to_string` to an explicit `endsep` key, to improve readability of command suggestions.

Previous:
> Command 'restart' is not available. Maybe you meant "stare"or "stretch" , and "saunter"?

Patched:
> Command 'restart' is not available. Maybe you meant "stare", "stretch" or "saunter"?

#### Motivation for adding to Evennia
Readying 1.0 for release