### PR TITLE
Add matching_exit() to DefaultExit

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -3133,3 +3133,25 @@ class DefaultExit(DefaultObject):
 
         """
         traversing_object.msg(_("You cannot go there."))
+
+    def matching_exit(self, as_list=False):
+        """
+        Get the exits that pair with this one in its destination room
+        (i.e. returns to its location)
+
+        Args:
+            as_list (bool): Whether to return available results as a
+                            list or single matching exit.
+
+        Returns:
+            list, exit (Exit), or None: The matching exit(s).
+        """
+        no_match = [] if as_list else None
+        if not self.destination:
+            return no_match
+        matching_exits = [x for x in self.destination.exits if x.destination == self.location]
+        if not matching_exits:
+            return no_match
+        if as_list:
+            return matching_exits
+        return matching_exits[0]

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -3134,24 +3134,19 @@ class DefaultExit(DefaultObject):
         """
         traversing_object.msg(_("You cannot go there."))
 
-    def matching_exit(self, as_list=False):
+    def get_return_exit(self, return_all=False):
         """
         Get the exits that pair with this one in its destination room
         (i.e. returns to its location)
 
         Args:
-            as_list (bool): Whether to return available results as a
-                            list or single matching exit.
+            return_all (bool): Whether to return available results as a
+                               list or single matching exit.
 
         Returns:
-            list, exit (Exit), or None: The matching exit(s).
+            queryset or exit (Exit): The matching exit(s).
         """
-        no_match = [] if as_list else None
-        if not self.destination:
-            return no_match
-        matching_exits = [x for x in self.destination.exits if x.destination == self.location]
-        if not matching_exits:
-            return no_match
-        if as_list:
-            return matching_exits
-        return matching_exits[0]
+        query = ObjectDB.objects.filter(db_location=self.destination, db_destination=self.location)
+        if return_all:
+            return query
+        return query.first()

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -69,6 +69,23 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertEqual(description, obj.db.desc)
         self.assertEqual(obj.db.creator_ip, self.ip)
 
+    def test_exit_get_return_exit(self):
+        ex1, _ = DefaultExit.create("north", self.room1, self.room2, account=self.account)
+        single_return_exit = ex1.get_return_exit()
+        all_return_exit = ex1.get_return_exit(return_all=True)
+        self.assertEqual(single_return_exit, None)
+        self.assertEqual(len(all_return_exit), 0)
+
+        ex2, _ = DefaultExit.create("south", self.room2, self.room1, account=self.account)
+        single_return_exit = ex1.get_return_exit()
+        all_return_exit = ex1.get_return_exit(return_all=True)
+        self.assertEqual(single_return_exit, ex2)
+        self.assertEqual(len(all_return_exit), 1)
+
+        ex3, _ = DefaultExit.create("also_south", self.room2, self.room1, account=self.account)
+        all_return_exit = ex1.get_return_exit(return_all=True)
+        self.assertEqual(len(all_return_exit), 2)
+
     def test_urls(self):
         "Make sure objects are returning URLs"
         self.assertTrue(self.char1.get_absolute_url())


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The addition of the matching_exit() function. It takes as_list as a parameter to return the matching exit(s) as a list or single Exit. "Matching exits" being the 'return' exit, i.e. if you go 'north' to go somewhere and 'south' to return, **north**.matching_exit() would give you **south**.

#### Motivation for adding to Evennia
Useful little utility for exits.

#### Other info (issues closed, discussion etc)
