### PR TITLE
Add optional fallback sdesc to rpsystem emote

### DIFF
--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -243,6 +243,26 @@ class TestRPSystem(BaseEvenniaTest):
             'receiver of emotes.|n and |mReceiver2|n. She says |w"This is a test."|n',
         )
 
+    def test_send_emote_fallback(self):
+        speaker = self.speaker
+        receiver1 = self.receiver1
+        receivers = [speaker, receiver1]
+        speaker.sdesc.add(sdesc0)
+        receiver1.sdesc.add(sdesc1)
+        speaker.msg = lambda text, **kwargs: setattr(self, "out0", text)
+        receiver1.msg = lambda text, **kwargs: setattr(self, "out1", text)
+        rpsystem.send_emote(speaker, receivers, emote, case_sensitive=False, fallback="something")
+        self.assertEqual(
+            self.out0[0],
+            "With a flair, |mSender|n looks at |bThe first receiver of emotes.|n "
+            'and |bsomething|n. She says |w"This is a test."|n',
+        )
+        self.assertEqual(
+            self.out1[0],
+            "With a flair, |bA nice sender of emotes|n looks at |mReceiver1|n and "
+            '|bsomething|n. She says |w"This is a test."|n',
+        )
+
     def test_send_case_sensitive_emote(self):
         """Test new case-sensitive rp-parsing"""
         speaker = self.speaker

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -96,6 +96,7 @@ recog01 = "Mr Receiver"
 recog02 = "Mr Receiver2"
 recog10 = "Mr Sender"
 emote = 'With a flair, /me looks at /first and /colliding sdesc-guy. She says "This is a test."'
+fallback_emote = '/Me is distracted from /first by /nomatch.'
 case_emote = "/Me looks at /first. Then, /me looks at /FIRST, /First and /Colliding twice."
 poss_emote = "/Me frowns at /first for trying to steal /me's test."
 
@@ -246,21 +247,26 @@ class TestRPSystem(BaseEvenniaTest):
     def test_send_emote_fallback(self):
         speaker = self.speaker
         receiver1 = self.receiver1
-        receivers = [speaker, receiver1]
+        receiver2 = self.receiver2
+        receivers = [speaker, receiver1, receiver2]
         speaker.sdesc.add(sdesc0)
         receiver1.sdesc.add(sdesc1)
+        receiver2.sdesc.add(sdesc2)
         speaker.msg = lambda text, **kwargs: setattr(self, "out0", text)
         receiver1.msg = lambda text, **kwargs: setattr(self, "out1", text)
-        rpsystem.send_emote(speaker, receivers, emote, case_sensitive=False, fallback="something")
+        receiver2.msg = lambda text, **kwargs: setattr(self, "out2", text)
+        rpsystem.send_emote(speaker, receivers, fallback_emote, fallback="something")
         self.assertEqual(
             self.out0[0],
-            "With a flair, |mSender|n looks at |bThe first receiver of emotes.|n "
-            'and |bsomething|n. She says |w"This is a test."|n',
+            "|mSender|n is distracted from |bthe first receiver of emotes.|n by something.",
         )
         self.assertEqual(
             self.out1[0],
-            "With a flair, |bA nice sender of emotes|n looks at |mReceiver1|n and "
-            '|bsomething|n. She says |w"This is a test."|n',
+            "|bA nice sender of emotes|n is distracted from |mReceiver1|n by something.",
+        )
+        self.assertEqual(
+            self.out2[0],
+            "|bA nice sender of emotes|n is distracted from |bthe first receiver of emotes.|n by something.",
         )
 
     def test_send_case_sensitive_emote(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds an additional kwarg to `parse_sdescs_and_recogs` (which can be passed through `send_emote`) as an optional generic fallback string. When provided to `send_emote`, any references that have zero matches will instead be replaced with that string.

(This should be easily backportable to v0.9.5 for anyone who wants it, as it doesn't touch the new search algorithm or the updated sdesc system.)

#### Motivation for adding to Evennia
Improving contribs

#### Other info (issues closed, discussion etc)
Implements #2383