### PR TITLE
Remove typeclass from default channels setting

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -818,7 +818,6 @@ DEFAULT_CHANNELS = [
         "aliases": ("pub",),
         "desc": "Public discussion",
         "locks": "control:perm(Admin);listen:all();send:all()",
-        "typeclass": BASE_CHANNEL_TYPECLASS,
     }
 ]
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes the "typeclass" key from the `DEFAULT_CHANNELS` setting.

Due to the way Python loads modules, the line in question results in the default channels *always* being created with the typeclass "typeclasses.channels.Channel" regardless of your game settings. Since the initial creation of those default channels uses the game-settings default typeclass by default, there is no need to specify it here - it just causes issues when trying to set your own defaults.

#### Motivation for adding to Evennia
Bug fixing