### PR TITLE
Update wilderness contrib for 1.0

### DIFF
--- a/evennia/contrib/grid/wilderness/README.md
+++ b/evennia/contrib/grid/wilderness/README.md
@@ -5,7 +5,7 @@ Contribution by titeuf87, 2017
 This contrib provides a wilderness map without actually creating a large number
 of rooms - as you move, you instead end up back in the same room but its description 
 changes. This means you can make huge areas with little database use as
-long as the rooms are relatively similar (name/desc changing).
+long as the rooms are relatively similar (e.g. only the names/descs changing).
 
 ## Installation
 
@@ -29,6 +29,9 @@ All coordinates used by the wilderness map are in the format of `(x, y)`
 tuples. x goes from left to right and y goes from bottom to top. So `(0, 0)`
 is the bottom left corner of the map.
 
+> You can also add a wilderness by defining a WildernessScript in your GLOBAL_SCRIPT
+> settings. If you do, make sure define the map provider.
+
 ## Customisation
 
 The defaults, while useable, are meant to be customised. When creating a
@@ -37,8 +40,13 @@ python object that is smart enough to create the map.
 
 The default provider, `WildernessMapProvider`, just creates a grid area that
 is unlimited in size.
-This `WildernessMapProvider` can be subclassed to create more interesting
+
+`WildernessMapProvider` can be subclassed to create more interesting
 maps and also to customize the room/exit typeclass used.
+
+The `WildernessScript` also has an optional `preserve_items` property, which
+when set to `True` will not recycle rooms that contain any objects. By default,
+a wilderness room is recycled whenever there are no players left in it.
 
 There is also no command that allows players to enter the wilderness. This
 still needs to be added: it can be a command or an exit, depending on your
@@ -94,7 +102,7 @@ class PyramidMapProvider(wilderness.WildernessMapProvider):
         desc = "This is a room in the pyramid."
         if y == 3 :
             desc = "You can see far and wide from the top of the pyramid."
-        room.db.desc = desc
+        room.ndb.desc = desc
 ```
 
 Now we can use our new pyramid-shaped wilderness map. From inside Evennia we
@@ -105,9 +113,13 @@ create a new wilderness (with the name "default") but using our new map provider
 
 ## Implementation details
 
-When a character moves into the wilderness, they get their own room. If they
-move, instead of moving the character, the room changes to match the new
-coordinates.  If a character meets another character in the wilderness, then
-their room merges. When one of the character leaves again, they each get their
-own separate rooms.  Rooms are created as needed. Unneeded rooms are stored away
-to avoid the overhead cost of creating new rooms again in the future.
+When a character moves into the wilderness, they get their own room. If
+they move, instead of moving the character, the room changes to match the
+new coordinates.
+
+If a character meets another character in the wilderness, then their room
+merges. When one of the character leaves again, they each get their own
+separate rooms.
+
+Rooms are created as needed. Unneeded rooms are stored away to avoid the
+overhead cost of creating new rooms again in the future.

--- a/evennia/contrib/grid/wilderness/tests.py
+++ b/evennia/contrib/grid/wilderness/tests.py
@@ -136,3 +136,30 @@ class TestWilderness(BaseEvenniaTest):
         for direction, correct_loc in directions.items():
             new_loc = wilderness.get_new_coordinates(loc, direction)
             self.assertEqual(new_loc, correct_loc, direction)
+
+    def test_preserve_items(self):
+        wilderness.create_wilderness()
+        w = self.get_wilderness_script()
+
+        # move char and obj to wilderness
+        wilderness.enter_wilderness(self.char1)
+        wilderness.enter_wilderness(self.obj1)
+
+        # move to a new room
+        w.move_obj(self.char1, (1, 1))
+        # the room should be remapped and 0,0 should not exist
+        self.assertTrue((0, 0) not in w.db.rooms)
+        self.assertEqual(1, len(w.db.rooms))
+        # verify obj1 moved to None
+        self.assertIsNone(self.obj1.location)
+
+        # now change to preserve items
+        w.preserve_items = True
+        wilderness.enter_wilderness(self.obj1, (1, 1))
+        # move the character again
+        w.move_obj(self.char1, (0, 1))
+        # check that the previous room was preserved
+        self.assertIn((1, 1), w.db.rooms)
+        self.assertEqual(2, len(w.db.rooms))
+        # and verify that obj1 is still at 1,1
+        self.assertEqual(self.obj1.location, w.db.rooms[(1, 1)])

--- a/evennia/contrib/grid/wilderness/tests.py
+++ b/evennia/contrib/grid/wilderness/tests.py
@@ -36,14 +36,14 @@ class TestWilderness(BaseEvenniaTest):
         wilderness.enter_wilderness(self.char1)
         self.assertIsInstance(self.char1.location, wilderness.WildernessRoom)
         w = self.get_wilderness_script()
-        self.assertEqual(w.db.itemcoordinates[self.char1], (0, 0))
+        self.assertEqual(w.itemcoordinates[self.char1], (0, 0))
 
     def test_enter_wilderness_custom_coordinates(self):
         wilderness.create_wilderness()
         wilderness.enter_wilderness(self.char1, coordinates=(1, 2))
         self.assertIsInstance(self.char1.location, wilderness.WildernessRoom)
         w = self.get_wilderness_script()
-        self.assertEqual(w.db.itemcoordinates[self.char1], (1, 2))
+        self.assertEqual(w.itemcoordinates[self.char1], (1, 2))
 
     def test_enter_wilderness_custom_name(self):
         name = "customnname"
@@ -133,6 +133,6 @@ class TestWilderness(BaseEvenniaTest):
             "west": (0, 1),
             "northwest": (0, 2),
         }
-        for (direction, correct_loc) in directions.items():  # Not compatible with Python 3
+        for direction, correct_loc in directions.items():
             new_loc = wilderness.get_new_coordinates(loc, direction)
             self.assertEqual(new_loc, correct_loc, direction)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The wilderness contrib is currently a bit buggy in 1.0, with ndb properties not being reapplied on reload, hooks not being called properly on `@teleport`ing out, and probably other things relating to the causes of those issues.

This fixes those hooks and updates/cleans up a few other things, e.g. using (the relatively new) AttributeProperty instead of `@property` wrappers.

I also added a new property, `preserve_items`, to allow for recycling rooms only when they're _actually_ empty rather than just when there are no players present. By default it behaves exactly the same as before, recycling any rooms that have no players.

#### Motivation for adding to Evennia
preparing for 1.0
