### PR TITLE
Update rpsystem contrib with new hooks

### DIFF
--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -89,7 +89,6 @@ class TestLanguage(BaseEvenniaTest):
 
 # Testing of emoting / sdesc / recog system
 
-
 sdesc0 = "A nice sender of emotes"
 sdesc1 = "The first receiver of emotes."
 sdesc2 = "Another nice colliding sdesc-guy for tests"
@@ -115,6 +114,17 @@ class TestRPSystem(BaseEvenniaTest):
         self.receiver2 = create_object(
             rpsystem.ContribRPCharacter, key="Receiver2", location=self.room
         )
+
+    def test_posed_contents(self):
+        self.obj1 = create_object(rpsystem.ContribRPObject, key="thing", location=self.room)
+        self.obj2 = create_object(rpsystem.ContribRPObject, key="thing", location=self.room)
+        self.obj3 = create_object(rpsystem.ContribRPObject, key="object", location=self.room)
+        room_display = self.room.return_appearance(self.speaker)
+        self.assertIn("An object and two things are here.", room_display)
+        self.obj3.db.pose = "is on the ground."
+        room_display = self.room.return_appearance(self.speaker)
+        self.assertIn("Two things are here.", room_display)
+        self.assertIn("An object is on the ground.", room_display)
 
     def test_sdesc_handler(self):
         self.speaker.sdesc.add(sdesc0)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Updates the appearance changes for `ContribRPObject` to use the new display hooks.

This also gave me the opportunity to add grouping of things (not characters) by pose, as well as re-add stacking, because it's quite annoying to look into a box and see:
> book is here.
> book is here.
> book is here.
> blue shirt is here.
> old key is here.
> pineapple upside-down cake lies upside down.

Now instead those contents will show as:
> Three books, a blue shirt and an old key are here.
> A pineapple upside-down cake lies upside down.

I also added a new test to verify this stacking works correctly.

#### Motivation for adding to Evennia
Preparing for 1.0 release