### PR TITLE
Fix extra/missing spaces in quell output (#2991)

### DIFF
--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -987,7 +987,7 @@ class CmdQuell(COMMAND_DEFAULT_CLASS):
         """Perform the command"""
         account = self.account
         permstr = (
-            account.is_superuser and " (superuser)" or "(%s)" % ", ".join(account.permissions.all())
+            account.is_superuser and "(superuser)" or "(%s)" % ", ".join(account.permissions.all())
         )
         if self.cmdstring in ("unquell", "unquell"):
             if not account.attributes.get("_quell"):
@@ -1011,7 +1011,7 @@ class CmdQuell(COMMAND_DEFAULT_CLASS):
                 cpermstr += "\nUse unquell to return to normal permission usage."
                 self.msg(cpermstr)
             else:
-                self.msg(f"Quelling Account permissions{permstr}. Use unquell to get them back.")
+                self.msg(f"Quelling Account permissions {permstr}. Use unquell to get them back.")
         self._recache_locks(account)
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes extra and missing spaces in output of quell command as detailed in #2991.

#### Other info

Does not address the other minor thing mentioned relating to the duplication in:
`if self.cmdstring in ("unquell", "unquell")`