### PR TITLE
Fix no_prefix bug

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -1060,7 +1060,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                 # normal message
                 message = f"{sender_string}: {message}"
 
-        if not kwargs.get("no_prefix") or not kwargs.get("emit"):
+        if not kwargs.get("no_prefix") and not kwargs.get("emit"):
             message = channel.channel_prefix() + message
 
         return message


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Corrects an `or` to an `and` so that it will only add a channel prefix if neither `no_prefix` nor `emit` are set `True`

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
#2998