### PR TITLE
Unit testing workflow updates

### DIFF
--- a/.github/actions/setup-database.yml
+++ b/.github/actions/setup-database.yml
@@ -1,0 +1,89 @@
+# evennia/setup-database
+
+# Use this action in a workflow for when you need to do initialization of database services
+# (such as with PostgreSQL and MySQL) before you initiate unit tests that will employ that
+# database service.
+
+# NOTE: This action was written for use with the core Evennia workflows ONLY.
+
+name: Set up Database
+author: dvoraen
+description: "Activates the database server for the passed in service and ensures it's ready for use."
+
+inputs:
+  database:
+    description: "Database service being initialized."
+    type: string
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    # - name: Set up SQLite
+    #   if: inputs.database == "sqlite3"
+
+    - name: Set up PostgreSQL server
+      if: inputs.database == "postgresql"
+      uses: harmon758/postgresql-action@v1
+      with:
+        postgresql version: "11"
+        postgresql db: "evennia"
+        postgresql user: "evennia"
+        postgresql password: "password"
+
+    - name: Wait for PostgreSQL to activate
+      if: inputs.database == "postgresql" && success()
+      run: |
+        while ! pg_isready -h 127.0.0.1 -q >/dev/null 2>&1
+        do
+          sleep 1
+          echo -n .
+        done
+        echo
+      shell: bash
+
+    - name: Set up MySQL server
+      if: inputs.database == "mysql"
+      uses: mirromutth/mysql-action@v1.1
+      with:
+        host port: 3306
+        # character set server: 'utf8mb4'
+        # collation server: 'utf8mb4_unicode_ci'
+        character set server: "utf8"
+        collation server: "utf8_general_ci"
+        mysql database: "evennia"
+        mysql user: "evennia"
+        mysql password: "password"
+        mysql root password: root_password
+
+    - name: Wait for MySQL to activate
+      if: inputs.database == "mysql" && success()
+      run: |
+        while ! mysqladmin ping -h 127.0.0.1 -u root -proot_password -s >/dev/null 2>&1
+        do
+          sleep 1
+          echo -n .
+        done
+        echo
+      shell: bash
+
+    - name: Set up MySQL Privileges
+      if: inputs.database == "mysql" && success()
+      run: |
+        cat <<EOF | mysql -u root -proot_password -h 127.0.0.1 mysql
+          create user 'evennia'@'%' identified by 'password';
+          grant all on \`evennia%\`.* to 'evennia'@'%';
+          grant process on *.* to 'evennia'@'%';
+          flush privileges
+        EOF
+      shell: bash
+
+    # get logs from db start
+    - name: Database container logs
+      if: (inputs.database == 'postgresql' || inputs.database == 'mysql') && success()
+      uses: jwalton/gh-docker-logs@v2
+
+    - name: Check running containers
+      if: (inputs.database == 'postgresql' || inputs.database == 'mysql') && success()
+      run: docker ps -a

--- a/.github/actions/setup-database.yml
+++ b/.github/actions/setup-database.yml
@@ -48,8 +48,8 @@ runs:
       uses: mirromutth/mysql-action@v1.1
       with:
         host port: 3306
-        # character set server: 'utf8mb4'
-        # collation server: 'utf8mb4_unicode_ci'
+        # character set server: "utf8mb4"
+        # collation server: "utf8mb4_unicode_ci"
         character set server: "utf8"
         collation server: "utf8_general_ci"
         mysql database: "evennia"
@@ -81,9 +81,9 @@ runs:
 
     # get logs from db start
     - name: Database container logs
-      if: ${{ inputs.database == 'postgresql' || inputs.database == 'mysql' }}
+      if: ${{ inputs.database == "postgresql" || inputs.database == "mysql" }}
       uses: jwalton/gh-docker-logs@v2
 
     - name: Check running containers
-      if: ${{ inputs.database == 'postgresql' || inputs.database == 'mysql' }}
+      if: ${{ inputs.database == "postgresql" || inputs.database == "mysql" }}
       run: docker ps -a

--- a/.github/actions/setup-database.yml
+++ b/.github/actions/setup-database.yml
@@ -20,9 +20,6 @@ runs:
   using: "composite"
 
   steps:
-    # - name: Set up SQLite
-    #   if: inputs.database == "sqlite3"
-
     - name: Set up PostgreSQL server
       if: ${{ inputs.database == "postgresql" }}
       uses: harmon758/postgresql-action@v1

--- a/.github/actions/setup-database.yml
+++ b/.github/actions/setup-database.yml
@@ -4,9 +4,9 @@
 # (such as with PostgreSQL and MySQL) before you initiate unit tests that will employ that
 # database service.
 
-# NOTE: This action was written for use with the core Evennia workflows ONLY.
+# NOTE: This action was intended for use with the core Evennia workflows ONLY.
 
-name: Set up Database
+name: Set up Evennia database service
 author: dvoraen
 description: "Activates the database server for the passed in service and ensures it's ready for use."
 
@@ -24,7 +24,7 @@ runs:
     #   if: inputs.database == "sqlite3"
 
     - name: Set up PostgreSQL server
-      if: inputs.database == "postgresql"
+      if: ${{ inputs.database == "postgresql" }}
       uses: harmon758/postgresql-action@v1
       with:
         postgresql version: "11"
@@ -33,7 +33,7 @@ runs:
         postgresql password: "password"
 
     - name: Wait for PostgreSQL to activate
-      if: inputs.database == "postgresql" && success()
+      if: ${{ inputs.database == "postgresql" }}
       run: |
         while ! pg_isready -h 127.0.0.1 -q >/dev/null 2>&1
         do
@@ -44,7 +44,7 @@ runs:
       shell: bash
 
     - name: Set up MySQL server
-      if: inputs.database == "mysql"
+      if: ${{ inputs.database == "mysql" }}
       uses: mirromutth/mysql-action@v1.1
       with:
         host port: 3306
@@ -58,7 +58,7 @@ runs:
         mysql root password: root_password
 
     - name: Wait for MySQL to activate
-      if: inputs.database == "mysql" && success()
+      if: ${{ inputs.database == "mysql" }}
       run: |
         while ! mysqladmin ping -h 127.0.0.1 -u root -proot_password -s >/dev/null 2>&1
         do
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - name: Set up MySQL Privileges
-      if: inputs.database == "mysql" && success()
+      if: ${{ inputs.database == "mysql" }}
       run: |
         cat <<EOF | mysql -u root -proot_password -h 127.0.0.1 mysql
           create user 'evennia'@'%' identified by 'password';
@@ -81,9 +81,9 @@ runs:
 
     # get logs from db start
     - name: Database container logs
-      if: (inputs.database == 'postgresql' || inputs.database == 'mysql') && success()
+      if: ${{ inputs.database == 'postgresql' || inputs.database == 'mysql' }}
       uses: jwalton/gh-docker-logs@v2
 
     - name: Check running containers
-      if: (inputs.database == 'postgresql' || inputs.database == 'mysql') && success()
+      if: ${{ inputs.database == 'postgresql' || inputs.database == 'mysql' }}
       run: docker ps -a

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -95,7 +95,7 @@ jobs:
       # it's also not critical if pushing to either service fails (happens for PRs since env is not
       # available outside of the evennia org)
       - name: Send data to Coveralls
-        if: ${{ matrix.coverage-test && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') }}
+        if: ${{ matrix.coverage-test && (github.ref == "refs/heads/master" || github.ref == "refs/heads/develop") }}
         continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -107,6 +107,7 @@ jobs:
     name: Deploy Docker Image
     needs: test
     runs-on: ubuntu-latest
+    if: ${{ github.repository == "evennia/evennia" }}
     steps:
       - uses: actions/checkout@v3
 
@@ -117,14 +118,14 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
+        if: ${{ github.ref == "refs/heads/master" || github.ref == "refs/heads/develop" }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push for master
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == "refs/heads/master" }}
         id: docker_build_master
         uses: docker/build-push-action@v3
         with:
@@ -132,7 +133,7 @@ jobs:
           tags: evennia/evennia:latest
 
       - name: Build and push for develop
-        if: ${{ github.ref == 'refs/heads/develop' }}
+        if: ${{ github.ref == "refs/heads/develop" }}
         id: docker_build_develop
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -5,188 +5,135 @@ name: test-suite
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [master, develop]
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   pull_request:
-    branches: [ master, develop ]
+    branches: [master, develop]
 
 jobs:
-  build:
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
-        TESTING_DB: ['sqlite3', 'postgresql', 'mysql']
+        python-version: ["3.9", "3.10", "3.11"]
+        TESTING_DB: ["sqlite3", "postgresql", "mysql"]
+        include:
+          - coverage-test: false
+          - coverage-test: true
+            python-version: "3.10"
+            TESTING_DB: "sqlite3"
 
     steps:
+      - uses: actions/checkout@v3
 
-    - uses: actions/checkout@v3
+      - name: Set up database (${{ matrix.TESTING_DB }})
+        uses: ./.github/actions/setup-database
+        with:
+          database: ${{ matrix.TESTING_DB }}
+        timeout-minutes: 5
 
-    - name: Set up PostgreSQL server
-      uses: harmon758/postgresql-action@v1
-      if: ${{ matrix.TESTING_DB == 'postgresql' }}
-      with:
-        postgresql version: '11'
-        postgresql db: 'evennia'
-        postgresql user: 'evennia'
-        postgresql password: 'password'
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
 
-    - name: Set up MySQL server
-      uses: mirromutth/mysql-action@v1.1
-      if: ${{ matrix.TESTING_DB == 'mysql'}}
-      with:
-        host port: 3306
-        # character set server: 'utf8mb4'
-        # collation server: 'utf8mb4_unicode_ci'
-        character set server: 'utf8'
-        collation server: 'utf8_general_ci'
-        mysql database: 'evennia'
-        mysql user: 'evennia'
-        mysql password: 'password'
-        mysql root password: root_password
+      - name: Install package dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install psycopg2-binary==2.9.5   # req by postgresql
+          pip install mysqlclient
+          pip install coveralls
+          pip install tblib
+          pip install .
+          pip install .[extra]
 
-    # wait for db to activate
-    - name: wait for db to activate
-      if: matrix.TESTING_DB == 'postgresql' || matrix.TESTING_DB == 'mysql'
-      run: |
+      - name: Initialize evennia
+        run: |
+          evennia --init testing_mygame
+          cp .github/workflows/${{ matrix.TESTING_DB }}_settings.py testing_mygame/server/conf/settings.py
+          cd testing_mygame
+          evennia migrate
+          evennia collectstatic --noinput
 
-        if [ ${{ matrix.TESTING_DB }} = mysql ]
-        then
-          while ! mysqladmin ping -h 127.0.0.1 -u root -proot_password -s >/dev/null 2>&1
-          do
-            sleep 1
-            echo -n .
-          done
-          echo
-        else
-          while ! pg_isready -h 127.0.0.1 -q >/dev/null 2>&1
-          do
-            sleep 1
-            echo -n .
-          done
-          echo
-        fi
+      # OBS - it's important to not run the coverage tests with --parallel, it messes up the coverage
+      # calculation!
+      - name: Run test suite with coverage
+        if: matrix.coverage-test
+        working-directory: testing_mygame
+        run: |
+          coverage run \
+            --source=../evennia \
+            --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
+            ../bin/unix/evennia test \
+              --settings=settings \
+              --timing \
+              evennia
+          coverage xml
+          coverage --version
+          coverage report | grep TOTAL
 
-    - name: mysql privileges
-      if: matrix.TESTING_DB == 'mysql'
-      run: |
-
-        cat <<EOF | mysql -u root -proot_password -h 127.0.0.1 mysql
-          create user 'evennia'@'%' identified by 'password';
-          grant all on \`evennia%\`.* to 'evennia'@'%';
-          grant process on *.* to 'evennia'@'%';
-          flush privileges
-        EOF
-
-    # get logs from db start
-    - name: Database container logs
-      if: matrix.TESTING_DB == 'postgresql' || matrix.TESTING_DB == 'mysql'
-      uses: jwalton/gh-docker-logs@v2
-
-    - name: Check running containers
-      if: matrix.TESTING_DB == 'postgresql' || matrix.TESTING_DB == 'mysql'
-      run: docker ps -a
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          pyproject.toml 
-
-    - name: Install package dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install wheel
-        pip install psycopg2-binary==2.9.5   # req by postgresql
-        pip install mysqlclient
-        pip install coveralls
-        pip install tblib
-        pip install .
-        pip install .[extra]
-
-    - name: Initialize evennia
-      run: |
-        evennia --init testing_mygame
-        cp .github/workflows/${{ matrix.TESTING_DB }}_settings.py testing_mygame/server/conf/settings.py
-        cd testing_mygame
-        evennia migrate
-        evennia collectstatic --noinput
-
-    # OBS - it's important to not run the coverage tests with --parallel, it messes up the coverage
-    # calculation! 
-    - name: Run test suite with coverage
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10'
-      working-directory: testing_mygame
-      run: |
-        coverage run \
-          --source=../evennia \
-          --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
-          ../bin/unix/evennia test \
+      # For other runs, run tests in parallel
+      - name: Run test suite
+        if: ! matrix.coverage-test
+        working-directory: testing_mygame
+        run: |
+          evennia test \
             --settings=settings \
+            --keepdb \
+            --parallel 4 \
             --timing \
             evennia
-        coverage xml
-        coverage --version
-        coverage report | grep TOTAL
 
-    # For other runs, run tests in parallel
-    - name: Run test suite
-      if: matrix.TESTING_DB != 'sqlite3' || matrix.python-version != '3.10'
-      working-directory: testing_mygame
-      run: |
-        evennia test \
-          --settings=settings \
-          --keepdb \
-          --parallel 4 \
-          --timing \
-          evennia
-
-    # we only want to run coverall once, so we only do it for one of the matrix combinations
-    # it's also not critical if pushing to either service fails (happens for PRs since env is not
-    # available outside of the evennia org)
-    - name: Send data to Coveralls
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
-      continue-on-error: true
-      env:
+      # we only want to run coverall once, so we only do it for one of the matrix combinations
+      # it's also not critical if pushing to either service fails (happens for PRs since env is not
+      # available outside of the evennia org)
+      - name: Send data to Coveralls
+        if: matrix.coverage-test && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
+        continue-on-error: true
+        env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        cd testing_mygame
-        coveralls
+        run: |
+          cd testing_mygame
+          coveralls
 
-    # docker setup and push
-    -
-      name: Set up QEMU
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10'
-      uses: docker/setup-qemu-action@v2
-    -
-      name: Set up Docker Buildx
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10'
-      uses: docker/setup-buildx-action@v2
-    -
-      name: Login to DockerHub
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    -
-      name: Build and push for master
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10' && github.ref == 'refs/heads/master'
-      id: docker_build_master
-      uses: docker/build-push-action@v3
-      with:
-        push: true
-        tags: evennia/evennia:latest
-    -
-      name: Build and push for develop
-      if: matrix.TESTING_DB == 'sqlite3' && matrix.python-version == '3.10' && github.ref == 'refs/heads/develop'
-      id: docker_build_develop
-      uses: docker/build-push-action@v3
-      with:
-        push: true
-        tags: evennia/evennia:develop
+  deploy:
+    name: Deploy Docker Image
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push for master
+        if: github.ref == 'refs/heads/master'
+        id: docker_build_master
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: evennia/evennia:latest
+
+      - name: Build and push for develop
+        if: github.ref == 'refs/heads/develop'
+        id: docker_build_develop
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: evennia/evennia:develop

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -22,10 +22,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
         TESTING_DB: ["sqlite3", "postgresql", "mysql"]
         include:
-          - coverage-test: false
-          - coverage-test: true
-            python-version: "3.10"
+          - python-version: "3.10"
             TESTING_DB: "sqlite3"
+            coverage-test: true
 
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +65,7 @@ jobs:
       # OBS - it's important to not run the coverage tests with --parallel, it messes up the coverage
       # calculation!
       - name: Run test suite with coverage
-        if: matrix.coverage-test
+        if: ${{ matrix.coverage-test }}
         working-directory: testing_mygame
         run: |
           coverage run \
@@ -82,7 +81,7 @@ jobs:
 
       # For other runs, run tests in parallel
       - name: Run test suite
-        if: ! matrix.coverage-test
+        if: ! ${{ matrix.coverage-test }}
         working-directory: testing_mygame
         run: |
           evennia test \
@@ -92,11 +91,11 @@ jobs:
             --timing \
             evennia
 
-      # we only want to run coverall once, so we only do it for one of the matrix combinations
+      # we only want to run coverall once, so we only do it for the designated matrix combination(s)
       # it's also not critical if pushing to either service fails (happens for PRs since env is not
       # available outside of the evennia org)
       - name: Send data to Coveralls
-        if: matrix.coverage-test && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
+        if: ${{ matrix.coverage-test && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') }}
         continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -109,6 +108,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -116,14 +117,14 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push for master
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         id: docker_build_master
         uses: docker/build-push-action@v3
         with:
@@ -131,7 +132,7 @@ jobs:
           tags: evennia/evennia:latest
 
       - name: Build and push for develop
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' }}
         id: docker_build_develop
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -62,6 +62,18 @@ jobs:
           evennia migrate
           evennia collectstatic --noinput
 
+      # For non-coverage tests, run them in parallel.
+      - name: Run test suite
+        if: ! ${{ matrix.coverage-test }}
+        working-directory: testing_mygame
+        run: |
+          evennia test \
+            --settings=settings \
+            --keepdb \
+            --parallel 4 \
+            --timing \
+            evennia
+
       # OBS - it's important to not run the coverage tests with --parallel, it messes up the coverage
       # calculation!
       - name: Run test suite with coverage
@@ -78,18 +90,6 @@ jobs:
           coverage xml
           coverage --version
           coverage report | grep TOTAL
-
-      # For other runs, run tests in parallel
-      - name: Run test suite
-        if: ! ${{ matrix.coverage-test }}
-        working-directory: testing_mygame
-        run: |
-          evennia test \
-            --settings=settings \
-            --keepdb \
-            --parallel 4 \
-            --timing \
-            evennia
 
       # we only want to run coverall once, so we only do it for the designated matrix combination(s)
       # it's also not critical if pushing to either service fails (happens for PRs since env is not

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -64,7 +64,7 @@ jobs:
 
       # For non-coverage tests, run them in parallel.
       - name: Run test suite
-        if: ! ${{ matrix.coverage-test }}
+        if: ${{ ! matrix.coverage-test }}
         working-directory: testing_mygame
         run: |
           evennia test \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR updates the unit testing and Docker deployment jobs to be more modular and possibly extensible.

#### Motivation for adding to Evennia
To make the workflows more modularized and potentially extensible.

#### Other info (issues closed, discussion etc)

##### Issues
- I don't know how to test these workflows. :)  My thought was that I would have to branch off my `new_workflows` branch and create a test workflow to manually invoke them, but I wasn't sure if that was an effective solution.
  - The Docker deploy job is untestable by me because I don't have a DockerHub login, for example, plus it specifically looks for a push/PR to `master` and `develop` and that seemed like it would be ripe for trouble if I made artificial commits for testing. :)
- I'm unclear whether you need to use `actions/checkout` for a second job in a workflow (see `jobs.deploy` for what I mean).  GitHub Docs suggests yes, because a job runs in isolation on its own runner, which makes me think that it can't see the file system associated with another job.

##### Changelog
- Database server/service setup has been placed into its own action, and a `.github/actions` folder was created for such code if more become necessary in the future.  This was done mostly so that a lot of steps could be factored out of the primary workflow and the primary workflow becomes "just the facts, ma'am".  I'm being the maid, in other words.
- A timeout limit of 5 minutes was placed on the database setup action in the primary workflow.  If PostgreSQL or MySQL fail to activate, they would force the workflow to run for the entire *six hours* (the default timeout value) before being cancelled by GitHub.  In looking through past workflows on `develop`, typically it would be ready within 10 seconds.
- The coverage test can now be explicitly marked in the `jobs.test.matrix.include` part of the workflow.
  - The unit testing code now checks for the presence of the "is this a coverage test?" flag rather than hardcodes the specific Python version and database type.  I figured this was more extensible and easier to maintain than digging through all the `if` conditions if it should change in the future.  I say extensible because you can just designate version/database combinations as coverage tests in the `jobs.test.matrix.include` at will rather than need to modify conditions elsewhere.
- The build-and-push steps for deploying `master` and `develop` to the Docker image were put into their own job, which is dependent upon the unit tests job succeeding.  This was more my interpretation of making the workflow more modular.  Deployment is dependent on unit testing, but it's not directly involved with it, if that makes sense.  It does its own thing, so I stuck it into its own thing/job.  It also only triggers if the source repo is evennia/evennia.  This is so that forks don't end up with DockerHub job failures that aren't really relevant to them; forks shouldn't be deploying images to Docker, only the source repo.