### PR TITLE
Coverage test debugging

### DIFF
--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: testing_mygame
         run: |
           coverage run \
-            --source=../evennia \
+            --source=**/site-packages/evennia \
             --parallel-mode \
             --debug=sys,trace \
             --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
@@ -96,6 +96,7 @@ jobs:
               --parallel 4 \
               --timing \
               evennia
+          coverage combine
           coverage xml
           coverage --version
           coverage report | grep TOTAL

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -87,7 +87,8 @@ jobs:
         working-directory: testing_mygame
         run: |
           coverage run \
-            --source=*/site-packages/evennia,../evennia \
+            --source=*/evennia/* \
+            --parallel-mode
             --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
             ../bin/unix/evennia test \
               --settings=settings \

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -26,6 +26,12 @@ jobs:
             TESTING_DB: "sqlite3"
             coverage-test: true
 
+    # TODO: Remove(?) in the future
+    # REASON FOR ADD: PostgreSQL jobs are sometimes stalling until GitHub's timeout of 6 hours.
+    # Timeout chosen based on coverage test runs seeming to last around 20-25 minutes.
+    # -dvo
+    timeout-minutes: 35
+
     steps:
       - uses: actions/checkout@v3
 
@@ -82,9 +88,12 @@ jobs:
         run: |
           coverage run \
             --source=../evennia \
+            --parallel-mode \
+            --debug=sys,trace \
             --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
             ../bin/unix/evennia test \
               --settings=settings \
+              --parallel 4 \
               --timing \
               evennia
           coverage xml

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -87,9 +87,7 @@ jobs:
         working-directory: testing_mygame
         run: |
           coverage run \
-            --source=*/site-packages/evennia/* \
-            --parallel-mode \
-            --debug=sys,trace \
+            --source=*/site-packages/evennia,../evennia \
             --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
             ../bin/unix/evennia test \
               --settings=settings \

--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: testing_mygame
         run: |
           coverage run \
-            --source=**/site-packages/evennia \
+            --source=*/site-packages/evennia/* \
             --parallel-mode \
             --debug=sys,trace \
             --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR investigates what's going on with Coverage testing.

It also adds a hard limit of 35 minutes to unit test runs to compensate for the occasional PostgreSQL runs stalling for the entire six hours (GitHub's default timeout length).

#### Motivation for adding to Evennia
I'm trying to help with the workload of fixing things randomly going wrong. :)

#### Other info (issues closed, discussion etc)
Work in progress, likely will have several commits and may be closed at random.

beep boop