### PR TITLE
Adding coverage settings to TOML and workflow

### DIFF
--- a/.github/workflows/github_action_test_suite.yml
+++ b/.github/workflows/github_action_test_suite.yml
@@ -26,6 +26,12 @@ jobs:
             TESTING_DB: "sqlite3"
             coverage-test: true
 
+    timeout-minutes: 35
+
+    env:
+      UNIT_TEST_SETTINGS: "--settings=settings --keepdb --parallel 4 --timing"
+      COVERAGE_TEST_SETTINGS: "--settings=settings --timing"
+
     steps:
       - uses: actions/checkout@v3
 
@@ -67,12 +73,7 @@ jobs:
         if: ${{ ! matrix.coverage-test }}
         working-directory: testing_mygame
         run: |
-          evennia test \
-            --settings=settings \
-            --keepdb \
-            --parallel 4 \
-            --timing \
-            evennia
+          evennia test ${{ env.UNIT_TEST_SETTINGS }} evennia
 
       # OBS - it's important to not run the coverage tests with --parallel, it messes up the coverage
       # calculation!
@@ -80,13 +81,8 @@ jobs:
         if: ${{ matrix.coverage-test }}
         working-directory: testing_mygame
         run: |
-          coverage run \
-            --source=evennia \
-            --omit=*/migrations/*,*/urls.py,*/test*.py,*.sh,*.txt,*.md,*.pyc,*.service \
-            ../bin/unix/evennia test \
-              --settings=settings \
-              --timing \
-              evennia
+          coverage run --rcfile=../pyproject.toml ../bin/unix/evennia test ${{ env.COVERAGE_TEST_SETTINGS }} evennia
+          coverage combine
           coverage xml
           coverage --version
           coverage report | grep TOTAL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,97 +5,116 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "evennia"
 version = "1.0"
-maintainers = [
-    { name="Griatch", email="griatch@gmail.com" },
-]
+maintainers = [{ name = "Griatch", email = "griatch@gmail.com" }]
 description = "A full-featured toolkit and server for text-based multiplayer games (MUDs, MU*, etc)."
 requires-python = ">=3.10"
-readme = { file="README.md", content-type="text/markdown" }
-license = { text="BSD" }
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { text = "BSD" }
 keywords = [
-    "MUD", "MUSH", "MUX", "MMO", "text-only", "multiplayer", "online", "rpg", "game", "engine",
-    "framework", "text", "adventure", "telnet", "websocket", "blind", "accessible", "ascii",
-    "utf-8", "terminal", "online", "server", "beginner", "tutorials"
+  "MUD",
+  "MUSH",
+  "MUX",
+  "MMO",
+  "text-only",
+  "multiplayer",
+  "online",
+  "rpg",
+  "game",
+  "engine",
+  "framework",
+  "text",
+  "adventure",
+  "telnet",
+  "websocket",
+  "blind",
+  "accessible",
+  "ascii",
+  "utf-8",
+  "terminal",
+  "online",
+  "server",
+  "beginner",
+  "tutorials",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: JavaScript",
-    "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: BSD License",
-    "Environment :: Console",
-    "Environment :: Web Environment",
-    "Framework :: Django",
-    "Framework :: Twisted",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Education",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: POSIX :: Linux",
-    "Topic :: Database",
-    "Topic :: Education",
-    "Topic :: Games/Entertainment :: Multi-User Dungeons (MUD)",
-    "Topic :: Games/Entertainment :: Puzzle Games",
-    "Topic :: Games/Entertainment :: Role-Playing",
-    "Topic :: Games/Entertainment :: Simulation",
-    "Topic :: Software Development :: Libraries :: Application Frameworks",
-    "Topic :: Internet :: WWW/HTTP :: WSGI :: Server"
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: JavaScript",
+  "Development Status :: 5 - Production/Stable",
+  "License :: OSI Approved :: BSD License",
+  "Environment :: Console",
+  "Environment :: Web Environment",
+  "Framework :: Django",
+  "Framework :: Twisted",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Education",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Topic :: Database",
+  "Topic :: Education",
+  "Topic :: Games/Entertainment :: Multi-User Dungeons (MUD)",
+  "Topic :: Games/Entertainment :: Puzzle Games",
+  "Topic :: Games/Entertainment :: Role-Playing",
+  "Topic :: Games/Entertainment :: Simulation",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
+  "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
 ]
 dependencies = [
-    # core dependencies
-    "django >= 4.1.3, < 4.2",
-    "twisted >= 22.10, < 23",
-    "pytz >= 2022.6",
-    "djangorestframework >= 3.14, < 3.15",
-    "pyyaml >= 6.0",
-    "django-filter == 2.4",
-    "django-sekizai == 2.0.0",
-    "inflect >= 5.2.0",
-    "autobahn >= 20.7.1, < 21.0.0",
-    "lunr == 0.6.0",
-    "simpleeval <= 1.0",
-    "uritemplate == 4.1.1",
-    "Jinja2 < 3.1",
-    "tzdata >= 2022.6",
-    # for unit tests and code formatting
-    "mock >= 4.0.3",
-    "model_mommy >= 2.0",
-    "anything ==0.2.1",
-    "black >= 22.6",
-    "isort >= 5.10",
-    "parameterized ==0.8.1",
+  # core dependencies
+  "django >= 4.1.3, < 4.2",
+  "twisted >= 22.10, < 23",
+  "pytz >= 2022.6",
+  "djangorestframework >= 3.14, < 3.15",
+  "pyyaml >= 6.0",
+  "django-filter == 2.4",
+  "django-sekizai == 2.0.0",
+  "inflect >= 5.2.0",
+  "autobahn >= 20.7.1, < 21.0.0",
+  "lunr == 0.6.0",
+  "simpleeval <= 1.0",
+  "uritemplate == 4.1.1",
+  "Jinja2 < 3.1",
+  "tzdata >= 2022.6",
+  # for unit tests and code formatting
+  "mock >= 4.0.3",
+  "model_mommy >= 2.0",
+  "anything ==0.2.1",
+  "black >= 22.6",
+  "isort >= 5.10",
+  "parameterized ==0.8.1",
 ]
 
 [project.optional-dependencies]
 
 extra = [
-    # contrib optional dependencies
-    # install with 'pip install evennia[extra]`
+  # contrib optional dependencies
+  # install with 'pip install evennia[extra]`
 
-    # crypto libraries for ssh support
-    "cryptography >= 2.8",
-    "pyasn1 >= 0.4.8",
-    "bcrypt >= 3.1.7",
+  # crypto libraries for ssh support
+  "cryptography >= 2.8",
+  "pyasn1 >= 0.4.8",
+  "bcrypt >= 3.1.7",
 
-    # Telnet-SSL support
-    "pyopenssl >= 19.1",
-    "service_identity >= 18.1.0",
+  # Telnet-SSL support
+  "pyopenssl >= 19.1",
+  "service_identity >= 18.1.0",
 
-    # AWS storage contrib
-    "boto3 >= 1.4.4",
-    "botocore >= 1.15",
+  # AWS storage contrib
+  "boto3 >= 1.4.4",
+  "botocore >= 1.15",
 
-    # Jupyter Notebook support
-    "jupyter >= 1.0.0",
-    "ipython >= 7.19.0",
-    "django-extensions >= 3.1.0",
+  # Jupyter Notebook support
+  "jupyter >= 1.0.0",
+  "ipython >= 7.19.0",
+  "django-extensions >= 3.1.0",
 
-    # xyzroom contrib
-    "scipy == 1.9.3",
+  # xyzroom contrib
+  "scipy == 1.9.3",
 
-    # Git contrib
-    "gitpython >= 3.1.27"
+  # Git contrib
+  "gitpython >= 3.1.27",
 ]
 
 [project.urls]
@@ -133,3 +152,20 @@ exclude = '''
 
   )
 '''
+
+[tool.coverage]
+
+[tool.coverage.run]
+concurrency = ["multiprocessing"]
+parallel = true
+source = ["evennia"]
+omit = [
+  "*/migrations/*",
+  "*/urls.py",
+  "*/test*.py",
+  "*.sh",
+  "*.txt",
+  "*.md",
+  "*.pyc",
+  "*.service",
+]


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds `[tool.coverage.run]` to `pyproject.toml` based on the workflow settings used for running `coverage`.  ~~It also includes a tentative fix to allow coverage testing to run in parallel.~~  (Removed due to `coverage` producing warnings I can't seem to resolve yet.)

A unit testing run now has a max timeout of 35 minutes (for each run).  This is for the PostgreSQL issue where sometimes it will stall until the full six hours elapse.  That's not good.

Also put in environment variables to allow prettier command lines for the actual test commands.  Remember, I'm neurotic.

#### Motivation for adding to Evennia
To consolidate the settings into `pyproject.toml` which is one of its purposes.

#### Other info (issues closed, discussion etc)
The massive diff in the `pyproject.toml` is a side-effect of the TOML extension I'm using for VSCode which automatically formats it to have smaller indentations, spaces between `=` and such.