### PR TITLE
Fix for the excessive Discord reconnects

### DIFF
--- a/evennia/server/portal/discord.py
+++ b/evennia/server/portal/discord.py
@@ -201,7 +201,7 @@ class DiscordWebsocketServerFactory(WebSocketClientFactory, protocol.Reconnectin
             reason (str): The reason for the failure.
 
         """
-        if self.do_retry or not self.bot:
+        if self.do_retry and self.bot:
             self.retry(connector)
 
     def reconnect(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I committed and pushed the wrong logic check when patching the retry bug, which has been causing excessive session connections. This is the correct one.

#### Motivation for adding to Evennia
fixing my own bugs

#### Additional context
Closes #3015 
