### PR TITLE
Change get, drop, give, inv to use get_numbered_name()

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -371,8 +371,9 @@ class CmdInventory(COMMAND_DEFAULT_CLASS):
 
             table = self.styled_table(border="header")
             for item in items:
+                singular, _ = item.get_numbered_name(1, self.caller)
                 table.add_row(
-                    f"|C{item.name}|n",
+                    f"|C{singular}|n",
                     "{}|n".format(utils.crop(raw_ansi(item.db.desc or ""), width=50) or ""),
                 )
             string = f"|wYou are carrying:\n{table}"
@@ -424,8 +425,9 @@ class CmdGet(COMMAND_DEFAULT_CLASS):
         if not success:
             caller.msg("This can't be picked up.")
         else:
-            caller.msg(f"You pick up {obj.name}.")
-            caller.location.msg_contents(f"{caller.name} picks up {obj.name}.", exclude=caller)
+            singular, _ = obj.get_numbered_name(1, caller)
+            caller.msg(f"You pick up {singular}.")
+            caller.location.msg_contents(f"{caller.name} picks up {singular}.", exclude=caller)
             # calling at_get hook method
             obj.at_get(caller)
 
@@ -472,8 +474,9 @@ class CmdDrop(COMMAND_DEFAULT_CLASS):
         if not success:
             caller.msg("This couldn't be dropped.")
         else:
-            caller.msg("You drop %s." % (obj.name,))
-            caller.location.msg_contents(f"{caller.name} drops {obj.name}.", exclude=caller)
+            singular, _ = obj.get_numbered_name(1, caller)
+            caller.msg(f"You drop {singular}.")
+            caller.location.msg_contents(f"{caller.name} drops {singular}.", exclude=caller)
             # Call the object script's at_drop() method.
             obj.at_drop(caller)
 
@@ -510,11 +513,13 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
         target = caller.search(self.rhs)
         if not (to_give and target):
             return
+
+        singular, _ = to_give.get_numbered_name(1, caller)
         if target == caller:
-            caller.msg(f"You keep {to_give.key} to yourself.")
+            caller.msg(f"You keep {singular} to yourself.")
             return
         if not to_give.location == caller:
-            caller.msg(f"You are not holding {to_give.key}.")
+            caller.msg(f"You are not holding {singular}.")
             return
 
         # calling at_pre_give hook method
@@ -524,10 +529,10 @@ class CmdGive(COMMAND_DEFAULT_CLASS):
         # give object
         success = to_give.move_to(target, quiet=True, move_type="give")
         if not success:
-            caller.msg(f"You could not give {to_give.key}.")
+            caller.msg(f"You could not give {singular} to {target.key}.")
         else:
-            caller.msg(f"You give {to_give.key} to {target.key}.")
-            target.msg(f"{caller.key} gives you {to_give.key}.")
+            caller.msg(f"You give {singular} to {target.key}.")
+            target.msg(f"{caller.key} gives you {singular}.")
             # Call the object script's at_give() method.
             to_give.at_give(caller, target)
 

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -426,8 +426,7 @@ class CmdGet(COMMAND_DEFAULT_CLASS):
             caller.msg("This can't be picked up.")
         else:
             singular, _ = obj.get_numbered_name(1, caller)
-            caller.msg(f"You pick up {singular}.")
-            caller.location.msg_contents(f"{caller.name} picks up {singular}.", exclude=caller)
+            caller.location.msg_contents(f"$You() $conj(pick) up {singular}.", from_obj=caller)
             # calling at_get hook method
             obj.at_get(caller)
 
@@ -475,8 +474,7 @@ class CmdDrop(COMMAND_DEFAULT_CLASS):
             caller.msg("This couldn't be dropped.")
         else:
             singular, _ = obj.get_numbered_name(1, caller)
-            caller.msg(f"You drop {singular}.")
-            caller.location.msg_contents(f"{caller.name} drops {singular}.", exclude=caller)
+            caller.location.msg_contents(f"$You() $conj(drop) {singular}.", from_obj=caller)
             # Call the object script's at_drop() method.
             obj.at_drop(caller)
 

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -112,13 +112,13 @@ class TestGeneral(BaseEvenniaCommandTest):
         self.call(general.CmdNick(), "/list", "Defined Nicks:")
 
     def test_get_and_drop(self):
-        self.call(general.CmdGet(), "Obj", "You pick up Obj.")
-        self.call(general.CmdDrop(), "Obj", "You drop Obj.")
+        self.call(general.CmdGet(), "Obj", "You pick up an Obj.")
+        self.call(general.CmdDrop(), "Obj", "You drop an Obj.")
 
     def test_give(self):
         self.call(general.CmdGive(), "Obj to Char2", "You aren't carrying Obj.")
         self.call(general.CmdGive(), "Obj = Char2", "You aren't carrying Obj.")
-        self.call(general.CmdGet(), "Obj", "You pick up Obj.")
+        self.call(general.CmdGet(), "Obj", "You pick up an Obj.")
         self.call(general.CmdGive(), "Obj to Char2", "You give")
         self.call(general.CmdGive(), "Obj = Char", "You give", caller=self.char2)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changed the message output of `get`, `drop`, `give` and `inventory` to use "singular" from `get_numbered_name()`.

#### Motivation for adding to Evennia

This makes the output read a little more nicely. For example:

`Gollum drops ring.` -> `Gollum drops a ring.`
`You pick up ring.` -> `You pick up a ring.`
`You give ring to Gollum.` -> `You give a ring to Gollum.`

The message for a failure of `to_give.move_to()` has also been extended from (for example):

`You could not give ring.`

to:

`You could not give a ring to Sauron.`

##### Inventory

`inventory` output has changed from:

```
 ring  This thing is bad news.
```

to:

```
 a ring  This thing is bad news.
````

##### Other

- One of the lines in `drop` (475) was changed from old-style formatting to an f-string for consistency.
- Unit tests for default commands have been updated.
