### PR TITLE
Fixed a typo when printing help file matches for keywords that didn't…

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -627,7 +627,7 @@ class CmdHelp(COMMAND_DEFAULT_CLASS):
                     )
                     if suggestions:
                         help_text += (
-                            "\n... But matches where found within the help "
+                            "\n... But matches were found within the help "
                             "texts of the suggestions below."
                         )
                         suggestions = [


### PR DESCRIPTION
Fixed a typo when printing help file matches for keywords that didn't directly locate a help entry.

#### Brief overview of PR changes/additions
in evennia/commands/default/help.py (line 630):
Original String: "... But matches where found within the help texts of the suggestions below."
Corrected String: "... But matches were found within the help texts of the suggestions below."
#### Motivation for adding to Evennia
I figured this was a good oversight to correct, as someone who is still pretty new to Evennia but has the skills to fix small (but significant) issues.
#### Other info (issues closed, discussion etc)
