### PR TITLE
fix: set_gamedir use provided path and SETTINGS_DOTPATH

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1371,8 +1371,8 @@ def set_gamedir(path):
     global GAMEDIR
 
     Ndepth = 10
-    settings_path = os.path.join("server", "conf", "settings.py")
-    os.chdir(GAMEDIR)
+    settings_path = SETTINGS_DOTPATH.replace(".", os.sep) + ".py"
+    os.chdir(path)
     for i in range(Ndepth):
         gpath = os.getcwd()
         if "server" in os.listdir(gpath):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

Noticed init_game_directory didn't properly detect correct root game directory when passed a path somewhere inside the directory. Traced it to this function ignoring the passed path and going off of current working directory.

#### Other info (issues closed, discussion etc)

`evennia test evennia` reported 1582 tests passed and 38 skipped
