### PR TITLE
fix: NickHandler.nickreplace not to strip raw_input

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -1737,7 +1737,7 @@ class NickHandler(AttributeHandler):
                 regex = re.compile(nick_regex, re.I + re.DOTALL + re.U)
                 self._regex_cache[nick_regex] = regex
 
-            is_match, raw_string = parse_nick_template(raw_string.strip(), regex, template)
+            is_match, raw_string = parse_nick_template(raw_string, regex, template)
             if is_match:
                 break
         return raw_string


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This modifies NickHandler.nickreplace so it does not also strip whitespace from raw_string. 

#### Motivation for adding to Evennia

Leading whitespace is necessary when using the py command in interactive mode.

#### Other info (issues closed, discussion etc)

Fixes #3035 

Ran `evennia test evennia` and it ran 1582 tests ran: 38 skipped, rest OK