### PR TITLE
Fix traceback in XYZRoom

### DIFF
--- a/evennia/contrib/grid/xyzgrid/xyzroom.py
+++ b/evennia/contrib/grid/xyzgrid/xyzroom.py
@@ -463,7 +463,10 @@ class XYZRoom(DefaultRoom):
             )
 
             sessions = looker.sessions.get()
-            client_width, _ = sessions[0].get_client_size() if sessions else CLIENT_DEFAULT_WIDTH
+            if sessions:
+                client_width, _ = sessions[0].get_client_size()
+            else:
+                client_width = CLIENT_DEFAULT_WIDTH
 
             map_width = xymap.max_x
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Expands an if/else statement since the two assignments are not assigning equivalent types. (One is a tuple, the other is an integer.)

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
The traceback in question occurs when falling back to default settings:
```
.\evennia\contrib\grid\xyzgrid\xyzroom.py", line 466, in return_appearance
    client_width, _ = sessions[0].get_client_size() if sessions else CLIENT_DEFAULT_WIDTH
TypeError: cannot unpack non-iterable int object
```