### PR TITLE
Fix `iter_to_str` endsep behavior with two items

### DIFF
--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -93,6 +93,7 @@ class TestListToString(TestCase):
             '"1", "2" and "3"', utils.list_to_string([1, 2, 3], endsep="and", addquote=True)
         )
         self.assertEqual("1 and 2", utils.list_to_string([1, 2]))
+        self.assertEqual("1, 2", utils.list_to_string([1, 2], endsep=","))
 
 
 class TestMLen(TestCase):

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -448,7 +448,7 @@ def iter_to_str(iterable, sep=",", endsep=", and", addquote=False):
         iterable = tuple(str(val) for val in iterable)
 
     if endsep:
-        if endsep.startswith(sep):
+        if endsep.startswith(sep) and endsep != sep:
             # oxford comma alternative
             endsep = endsep[1:] if len_iter < 3 else endsep
         elif endsep[0] not in punctuation:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Corrects `iter_to_str` so that it will keep joining punctuation on the end separator when the end separator is the same as the internal separator, and adds a test to prevent this error in the future.

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Resolves #3050