### PR TITLE
Update Beginner-Tutorial-Python-basic-introduction.md

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Python-basic-introduction.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Python-basic-introduction.md
@@ -425,7 +425,7 @@ the room it is in.
 
 On the game command-line, let's create a mirror:
 
-    > create/drop mirror:contrib.tutorial_examples.mirror.TutorialMirror
+    > create/drop mirror:contrib.tutorials.mirror.TutorialMirror
 
 ```{sidebar} Creating objects
 


### PR DESCRIPTION
updated in the actual readme, but in the link it states:
> create/drop mirror:contrib.tutorial_examples.mirror.TutorialMirror 
where in fact it should now say: 
> create/drop mirror:contrib.tutorials.mirror.TutorialMirror

#### Brief overview of PR changes/additions
updating tutorial syntax

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
