### PR TITLE
fix help gender

### DIFF
--- a/evennia/contrib/game_systems/gendersub/gendersub.py
+++ b/evennia/contrib/game_systems/gendersub/gendersub.py
@@ -64,7 +64,7 @@ class SetGender(Command):
     Sets gender on yourself
 
     Usage:
-      @gender male||female||neutral||ambiguous
+      @gender male || female || neutral || ambiguous
 
     """
 


### PR DESCRIPTION
'help gender' uses escaped pipes to seperate options, but was not displaying correctly as written (without any white space between the options)

#### Brief overview of PR changes/additions

Added white space around escaped pipes.

#### Motivation for adding to Evennia

Fixes display of gender help from ```Usage: @gender male|femaleeutralhersmbiguous``` to ```Usage: @gender male | female | neutral | ambiguous```.

#### Other info (issues closed, discussion etc)

I had not opened a bug for this, so there is no issue to close.