### PR TITLE
Adding notification when discord bot session begins

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -312,7 +312,7 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
 
         """
         if not channel.access(self.caller, "send"):
-            caller.msg(f"You are not allowed to send messages to channel {channel}")
+            self.caller.msg(f"You are not allowed to send messages to channel {channel}")
             return
 
         # avoid unsafe tokens in message
@@ -1980,6 +1980,7 @@ class CmdDiscord2Chan(COMMAND_DEFAULT_CLASS):
                 self.msg("The Discord bot is already running.")
             else:
                 discord_bot.start()
+                self.msg("Starting the Discord bot session.")
             return
 
         if "guild" in self.switches:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixing a caller reference to self.caller in comms.py
Adding a line notifying the user that the discord bot session is starting (previously there was no echo)

#### Motivation for adding to Evennia
Informational

#### Other info (issues closed, discussion etc)
N/A