### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.11-alpine
 LABEL maintainer="https://www.evennia.com"
 
 # install compilation environment
-RUN apk update && apk add bash gcc jpeg-dev musl-dev procps \
+RUN apk update && apk add --no-cache bash gcc jpeg-dev musl-dev procps \
 libffi-dev openssl-dev zlib-dev gettext \
 g++ gfortran python3-dev cmake openblas-dev
 
@@ -43,10 +43,10 @@ COPY ./setup.py /usr/src/evennia/
 COPY ./bin /usr/src/evennia/bin/
 
 # install dependencies
-RUN pip install --upgrade pip && \
-    pip install cryptography pyasn1 service_identity && \
-    pip install -e /usr/src/evennia --trusted-host pypi.python.org && \
-    pip install evennia[extra]
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir cryptography pyasn1 service_identity && \
+    pip install --no-cache-dir -e /usr/src/evennia --trusted-host pypi.python.org && \
+    pip install --no-cache-dir evennia[extra]
 
 # add the project source; this should always be done after all
 # expensive operations have completed to avoid prematurely
@@ -66,7 +66,7 @@ VOLUME /usr/src/game
 WORKDIR /usr/src/game
 
 # set bash prompt and pythonpath to evennia lib
-ENV PS1 "evennia|docker \w $ " 
+ENV PS1 "evennia|docker \w $ "
 ENV PYTHONPATH /usr/src/evennia
 
 # create and switch to a non-root user for runtime security


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.
* I added `--no-cache` flag to `apk add` to ensure that no useless information is kept inside the Docker image.


Impact on the image size:
* Image size before repair: 1.25 GB
* Image size after repair: 1.06 GB
* Difference: 195.49 MB (15.24%)

#### Motivation for adding to Evennia

It reduces the Docker image size, therefore it would make it slightly faster the download Evennia and take less space on the disk. 
