### PR TITLE
Fix zombie Discord sessions

### DIFF
--- a/evennia/server/portal/discord.py
+++ b/evennia/server/portal/discord.py
@@ -323,6 +323,7 @@ class DiscordClient(WebSocketClientProtocol, _BASE_SESSION_CLASS):
             reason (str or None): Close reason as sent by the WebSocket peer.
 
         """
+        self.sessionhandler.disconnect(self)
         if self.nextHeartbeatCall:
             self.nextHeartbeatCall.cancel()
             self.nextHeartbeatCall = None
@@ -424,7 +425,6 @@ class DiscordClient(WebSocketClientProtocol, _BASE_SESSION_CLASS):
             reason (str or None): Motivation for the disconnection.
 
         """
-        self.sessionhandler.disconnect(self)
         self.sendClose(self.CLOSE_STATUS_CODE_NORMAL, reason)
 
     def identify(self, *args, **kwargs):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes the latest duplicate sessions issue by disconnecting sessions from the session handler on *all* closed connections, not just evennia-side disconnections.

#### Other info (issues closed, discussion etc)
Resolves #3077