### PR TITLE
Prevent recreation of same-named channels

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -489,9 +489,8 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
 
     def create_channel(self, name, description, typeclass=None, aliases=None):
         """
-        Create a new channel. Its name must not previously exist
-        (users can alias as needed). Will also connect to the
-        new channel.
+        Create a new channel. Its name must not previously exist (case agnostic)
+        (users can alias as needed). Will also connect to the new channel.
 
         Args:
             name (str): The new channel name/key.
@@ -880,7 +879,6 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
 
         if "create" in switches:
             # create a new channel
-
             if not self.access(caller, "manage"):
                 self.msg("You don't have access to use channel/create.")
                 return
@@ -937,7 +935,7 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
                 )
             elif len(found_channels) > 1:
                 errors.append(
-                    "Multiple possible channel matches/alias for '{channel_name}':\n"
+                    f"Multiple possible channel matches/alias for '{channel_name}':\n"
                     + ", ".join(chan.key for chan in found_channels)
                 )
             else:

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -392,20 +392,21 @@ class Evennia:
         from evennia.utils.create import create_channel
 
         superuser = AccountDB.objects.get(id=1)
+
         # mudinfo
         mudinfo_chan = settings.CHANNEL_MUDINFO
-        if mudinfo_chan:
-            if not ChannelDB.objects.filter(db_key=mudinfo_chan["key"]):
-                channel = create_channel(**mudinfo_chan)
-                channel.connect(superuser)
+        if mudinfo_chan and not ChannelDB.objects.filter(db_key__iexact=mudinfo_chan["key"]):
+            channel = create_channel(**mudinfo_chan)
+            channel.connect(superuser)
         # connectinfo
-        connectinfo_chan = settings.CHANNEL_MUDINFO
-        if connectinfo_chan:
-            if not ChannelDB.objects.filter(db_key=mudinfo_chan["key"]):
-                channel = create_channel(**connectinfo_chan)
+        connectinfo_chan = settings.CHANNEL_CONNECTINFO
+        if connectinfo_chan and not ChannelDB.objects.filter(
+            db_key__iexact=connectinfo_chan["key"]
+        ):
+            channel = create_channel(**connectinfo_chan)
         # default channels
         for chan_info in settings.DEFAULT_CHANNELS:
-            if not ChannelDB.objects.filter(db_key=chan_info["key"]):
+            if not ChannelDB.objects.filter(db_key__iexact=chan_info["key"]):
                 channel = create_channel(**chan_info)
                 channel.connect(superuser)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changed filtering to be inexact for checking against existing channels in `server.create_default_channels()`
Changed duplicate reference from `connectinfo_chan = settings.CHANNEL_MUDINFO` to point at `settings.CHANNEL_CONNECTINFO` (this was previously causing connect messages to always show up in the mudinfo channel)
Fixed f-string

#### Motivation for adding to Evennia
Bug fix

#### Other info (issues closed, discussion etc)
Fix for https://github.com/evennia/evennia/issues/3106

I would argue that all such filtering should occur within the create_channel method (which is called by both `server.create_default_channels()` and the `CmdChannel` in-game command), but for the sake of minimizing changes I didn't do it. 