### PR TITLE
Use filter_family instead of filter

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -263,7 +263,6 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
         caller = self.caller
         # first see if this is a personal alias
         channelname = caller.nicks.get(key=channelname, category="channel") or channelname
-
         # always try the exact match first.
         channels = CHANNEL_DEFAULT_TYPECLASS.objects.channel_search(channelname, exact=True)
 

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -7,7 +7,7 @@ import re
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.text import slugify
-from evennia.comms.managers import ChannelManager
+from evennia.comms.managers import ChannelDBManager
 from evennia.comms.models import ChannelDB
 from evennia.typeclasses.models import TypeclassBase
 from evennia.utils import create, logger
@@ -50,7 +50,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
 
     """
 
-    objects = ChannelManager()
+    objects = ChannelDBManager()
 
     # channel configuration
 

--- a/evennia/comms/managers.py
+++ b/evennia/comms/managers.py
@@ -440,12 +440,12 @@ class ChannelDBManager(TypedObjectManager):
                 return dbref_match
 
         if exact:
-            channels = self.filter(
+            channels = self.filter_family(
                 Q(db_key__iexact=ostring)
                 | Q(db_tags__db_tagtype__iexact="alias", db_tags__db_key__iexact=ostring)
             ).distinct()
         else:
-            channels = self.filter(
+            channels = self.filter_family(
                 Q(db_key__icontains=ostring)
                 | Q(db_tags__db_tagtype__iexact="alias", db_tags__db_key__icontains=ostring)
             ).distinct()

--- a/evennia/comms/managers.py
+++ b/evennia/comms/managers.py
@@ -440,12 +440,12 @@ class ChannelDBManager(TypedObjectManager):
                 return dbref_match
 
         if exact:
-            channels = self.filter_family(
+            channels = self.filter(
                 Q(db_key__iexact=ostring)
                 | Q(db_tags__db_tagtype__iexact="alias", db_tags__db_key__iexact=ostring)
             ).distinct()
         else:
-            channels = self.filter_family(
+            channels = self.filter(
                 Q(db_key__icontains=ostring)
                 | Q(db_tags__db_tagtype__iexact="alias", db_tags__db_key__icontains=ostring)
             ).distinct()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changing the use of filter to filter_family in search_channel

#### Motivation for adding to Evennia

It's possible to create a channel using a custom typeclass, however you cannot search for the channel once it's created using the current functionality. This change allows search_channel to find the channel once it's been created.

#### Other info (issues closed, discussion etc)
