### PR TITLE
Change channel command key.

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -209,8 +209,8 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
 
     """
 
-    key = "@channel"
-    aliases = ["@chan", "@channels"]
+    key = "channel"
+    aliases = ["chan", "channels"]
     help_category = "Comms"
     # these cmd: lock controls access to the channel command itself
     # the admin: lock controls access to /boot/ban/unban switches
@@ -777,7 +777,6 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
             maxwidth=_DEFAULT_WIDTH,
         )
         for chan in subscribed:
-
             locks = "-"
             chanid = "-"
             if chan.access(self.caller, "control"):
@@ -1158,7 +1157,6 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
             reason = reason[0].strip() if reason else ""
 
             for chan in channels:
-
                 if not chan.access(caller, "control"):
                     self.msg(f"You need 'control'-access to boot a user from {chan.key}.")
                     return

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -31,14 +31,7 @@ from evennia import (
 from evennia.commands import cmdparser
 from evennia.commands.cmdset import CmdSet
 from evennia.commands.command import Command, InterruptCommand
-from evennia.commands.default import (
-    account,
-    admin,
-    batchprocess,
-    building,
-    comms,
-    general,
-)
+from evennia.commands.default import account, admin, batchprocess, building, comms, general
 from evennia.commands.default import help as help_module
 from evennia.commands.default import syscommands, system, unloggedin
 from evennia.commands.default.cmdset_character import CharacterCmdSet
@@ -47,7 +40,6 @@ from evennia.prototypes import prototypes as protlib
 from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import create, gametime, utils
 from evennia.utils.test_resources import BaseEvenniaCommandTest  # noqa
-from evennia.utils.test_resources import BaseEvenniaTest, EvenniaCommandTest
 
 # ------------------------------------------------------------
 # Command testing
@@ -83,7 +75,9 @@ class TestGeneral(BaseEvenniaCommandTest):
     def test_pose(self):
         self.char2.msg = Mock()
         self.call(general.CmdPose(), "looks around", "Char looks around")
-        self.char2.msg.assert_called_with(text=('Char looks around', {'type': 'pose'}), from_obj=self.char1)
+        self.char2.msg.assert_called_with(
+            text=("Char looks around", {"type": "pose"}), from_obj=self.char1
+        )
 
     def test_nick(self):
         self.call(
@@ -173,7 +167,6 @@ class TestGeneral(BaseEvenniaCommandTest):
 
 
 class TestHelp(BaseEvenniaCommandTest):
-
     maxDiff = None
 
     def setUp(self):
@@ -584,7 +577,6 @@ class TestAccount(BaseEvenniaCommandTest):
         ]
     )
     def test_ooc_look(self, multisession_mode, auto_puppet, max_nr_chars, expected_result):
-
         self.account.db._playable_characters = [self.char1]
         self.account.unpuppet_all()
 
@@ -1563,7 +1555,6 @@ class TestBuilding(BaseEvenniaCommandTest):
         )
 
     def test_script_multi_delete(self):
-
         script1 = create.create_script()
         script2 = create.create_script()
         script3 = create.create_script()
@@ -1873,6 +1864,7 @@ class TestCommsChannel(BaseEvenniaCommandTest):
     def test_channel__unsub(self):
         self.call(self.cmdchannel(), "/unsub testchannel", "You un-subscribed")
         self.assertFalse(self.char1 in self.channel.subscriptions.all())
+        self.assertEqual(self.char1.nicks.nickreplace("testchannel Hello"), "testchannel Hello")
 
     def test_channel__alias__unalias(self):
         """Add and then remove a channel alias"""
@@ -2084,7 +2076,6 @@ class TestBatchProcess(BaseEvenniaCommandTest):
 
 
 class CmdInterrupt(Command):
-
     key = "interrupt"
 
     def parse(self):

--- a/evennia/comms/tests.py
+++ b/evennia/comms/tests.py
@@ -1,6 +1,18 @@
+from django.test import SimpleTestCase
+
 from evennia import DefaultChannel
+from evennia.commands.default.comms import CmdChannel
 from evennia.utils.create import create_message
 from evennia.utils.test_resources import BaseEvenniaTest
+
+
+class TestCommsNickMatchesCommand(SimpleTestCase):
+    def test(self):
+        """
+        Verifies that the nick being set by DefaultChannel matches the channel
+        command key.
+        """
+        self.assertTrue(DefaultChannel.channel_msg_nick_replacement.startswith(CmdChannel.key))
 
 
 class ObjectCreationTest(BaseEvenniaTest):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change CmdChannel to use `channel` as its command key rather than `@channel`. This fixes an issue with nicks generated at channel subscription.

#### Motivation for adding to Evennia
Fix buggy interaction with CMD_IGNORE_PREFIXES.

#### Other info (issues closed, discussion etc)
Resolves #3120