### PR TITLE
Catch RuntimeError in `DefaultObject.move_to`

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -927,7 +927,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         # Perform move
         try:
             self.location = destination
-        except Exception as err:
+        except (Exception, RuntimeError) as err:
             logerr(errtxt.format(err="location change"), err)
             return False
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
At the moment, attempting to use `obj.move_to(somewhere)` when `somewhere` happens to be the same as `obj` will throw a runtime error, which is not caught.

This makes sure that changing an object's location will catch runtime errors as well as exceptions.

#### Motivation for adding to Evennia
Better error handling