### PR TITLE
Add a contrib for Containers

### DIFF
--- a/evennia/contrib/game_systems/containers/README.md
+++ b/evennia/contrib/game_systems/containers/README.md
@@ -1,5 +1,5 @@
 # Containers
-*Contribution by InspectorCaracal (2023)*
+Contribution by InspectorCaracal (2023)
 
 Adds the ability to put objects into other container objects by providing a container typeclass and extending certain base commands.
 
@@ -22,11 +22,11 @@ This will replace the default `look` and `get` commands with the container-frien
 
 ## Usage
 
-The contrib includes a `ContainerObject` typeclass which has all of the set-up necessary to be used as a container. To use, all you need to do is create an object in-game with that typeclass - it will automatically inherit anything you implemented in your base Object typeclass as well.
+The contrib includes a `ContribContainer` typeclass which has all of the set-up necessary to be used as a container. To use, all you need to do is create an object in-game with that typeclass - it will automatically inherit anything you implemented in your base Object typeclass as well.
 
-    create bag:game_systems.containers.ContainerObject
+    create bag:game_systems.containers.ContribContainer
 
-The contrib's `ContainerObject` comes with a capacity limit of a maximum number of items it can hold. This can be changed per individual object.
+The contrib's `ContribContainer` comes with a capacity limit of a maximum number of items it can hold. This can be changed per individual object.
 
 In code:
 ```py
@@ -42,14 +42,14 @@ You can also make any other objects usable as containers by setting the `get_fro
 
 ## Extending
 
-The `ContainerObject` class is intended to be usable as-is, but you can also inherit from it for your own container classes to extend its functionality. Aside from having the container lock pre-set on object creation, it comes with three main additions:
+The `ContribContainer` class is intended to be usable as-is, but you can also inherit from it for your own container classes to extend its functionality. Aside from having the container lock pre-set on object creation, it comes with three main additions:
 
 ### `capacity` property
 
-`ContainerObject.capacity` is an `AttributeProperty` - meaning you can access it in code with `obj.capacity` and also set it in game with `set obj/capacity = 5` - which represents the capacity of the container as an integer. You can override this with a more complex representation of capacity on your own container classes.
+`ContribContainer.capacity` is an `AttributeProperty` - meaning you can access it in code with `obj.capacity` and also set it in game with `set obj/capacity = 5` - which represents the capacity of the container as an integer. You can override this with a more complex representation of capacity on your own container classes.
 
 ### `at_pre_get_from` and `at_pre_put_in` methods
 
-These two methods on `ContainerObject` are called as extra checks when attempting to either get an object from, or put an object in, a container. The contrib's `ContainerObject.at_pre_get_from` doesn't do any additional validation by default, while `ContainerObject.at_pre_put_in` does a simple capacity check.
+These two methods on `ContribContainer` are called as extra checks when attempting to either get an object from, or put an object in, a container. The contrib's `ContribContainer.at_pre_get_from` doesn't do any additional validation by default, while `ContribContainer.at_pre_put_in` does a simple capacity check.
 
 You can override these methods on your own child class to do any additional capacity or access checks.

--- a/evennia/contrib/game_systems/containers/README.md
+++ b/evennia/contrib/game_systems/containers/README.md
@@ -1,0 +1,45 @@
+# Containers
+*Contribution by InspectorCaracal (2023)*
+
+Adds the ability to put objects into other container objects by providing a container typeclass and extending certain base commands.
+
+## Installation
+
+To install, import and add the `ContainerCmdSet` to `CharacterCmdSet` in your `default_cmdsets.py` file:
+
+```python
+from evennia.contrib.game_systems.containers import ContainerCmdSet
+
+class CharacterCmdSet(default_cmds.CharacterCmdSet):
+    # ...
+    
+    def at_cmdset_creation(self):
+        # ...
+        self.add(ContainerCmdSet)
+```
+
+This will replace the default `look` and `get` commands with the container-friendly versions provided by the contrib.
+
+## Usage
+
+The contrib includes a `ContainerObject` typeclass which has all of the set-up necessary to be used as a container. To use, all you need to do is create an object in-game with that typeclass - it will automatically inherit anything you implemented in your base Object typeclass as well.
+
+    create bag:evennia.contrib.game_systems.containers.ContainerObject
+
+To make any other objects usable as containers, all you need to do is set the `get_from` lock type on it.
+
+    lock mysterious box = get_from:true()
+
+## Extending
+
+The `ContainerObject` class is intended to be usable as-is, but you can also inherit from it for your own container classes to extend its functionality. Aside from having the container lock pre-set on object creation, it comes with three main additions:
+
+### `capacity` property
+
+`ContainerObject.capacity` is an `AttributeProperty` - meaning you can access it in code with `obj.capacity` and also set it in game with `set obj/capacity = 5` - which represents the capacity of the container as an integer. You can override this with a more complex representation of capacity on your own container classes.
+
+### `at_pre_get_from` and `at_pre_put_in` methods
+
+These two methods on `ContainerObject` are called as extra checks when attempting to either get an object from, or put an object in, a container. The contrib's `Container.at_pre_get_from` doesn't do any additional validation by default, while `ContainerObject.at_pre_put_in` does a simple capacity check.
+
+You can override these methods on your own child class to do any additional capacity or access checks.

--- a/evennia/contrib/game_systems/containers/README.md
+++ b/evennia/contrib/game_systems/containers/README.md
@@ -18,7 +18,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(ContainerCmdSet)
 ```
 
-This will replace the default `look` and `get` commands with the container-friendly versions provided by the contrib.
+This will replace the default `look` and `get` commands with the container-friendly versions provided by the contrib as well as add a new `put` command.
 
 ## Usage
 
@@ -26,7 +26,17 @@ The contrib includes a `ContainerObject` typeclass which has all of the set-up n
 
     create bag:game_systems.containers.ContainerObject
 
-To make any other objects usable as containers, all you need to do is set the `get_from` lock type on it.
+The contrib's `ContainerObject` comes with a capacity limit of a maximum number of items it can hold. This can be changed per individual object.
+
+In code:
+```py
+obj.capacity = 5
+```
+In game:
+
+    set box/capacity = 5
+
+You can also make any other objects usable as containers by setting the `get_from` lock type on it.
 
     lock mysterious box = get_from:true()
 

--- a/evennia/contrib/game_systems/containers/README.md
+++ b/evennia/contrib/game_systems/containers/README.md
@@ -24,7 +24,7 @@ This will replace the default `look` and `get` commands with the container-frien
 
 The contrib includes a `ContainerObject` typeclass which has all of the set-up necessary to be used as a container. To use, all you need to do is create an object in-game with that typeclass - it will automatically inherit anything you implemented in your base Object typeclass as well.
 
-    create bag:evennia.contrib.game_systems.containers.ContainerObject
+    create bag:game_systems.containers.ContainerObject
 
 To make any other objects usable as containers, all you need to do is set the `get_from` lock type on it.
 
@@ -40,6 +40,6 @@ The `ContainerObject` class is intended to be usable as-is, but you can also inh
 
 ### `at_pre_get_from` and `at_pre_put_in` methods
 
-These two methods on `ContainerObject` are called as extra checks when attempting to either get an object from, or put an object in, a container. The contrib's `Container.at_pre_get_from` doesn't do any additional validation by default, while `ContainerObject.at_pre_put_in` does a simple capacity check.
+These two methods on `ContainerObject` are called as extra checks when attempting to either get an object from, or put an object in, a container. The contrib's `ContainerObject.at_pre_get_from` doesn't do any additional validation by default, while `ContainerObject.at_pre_put_in` does a simple capacity check.
 
 You can override these methods on your own child class to do any additional capacity or access checks.

--- a/evennia/contrib/game_systems/containers/__init__.py
+++ b/evennia/contrib/game_systems/containers/__init__.py
@@ -1,0 +1,1 @@
+from .containers import ContainerCmdSet, ContainerObject

--- a/evennia/contrib/game_systems/containers/__init__.py
+++ b/evennia/contrib/game_systems/containers/__init__.py
@@ -1,1 +1,1 @@
-from .containers import ContainerCmdSet, ContainerObject
+from .containers import ContainerCmdSet, ContribContainer  # noqa

--- a/evennia/contrib/game_systems/containers/containers.py
+++ b/evennia/contrib/game_systems/containers/containers.py
@@ -190,7 +190,9 @@ class CmdContainerGet(CmdGet):
         if caller == obj:
             self.msg("You can't get yourself.")
             return
-        if not obj.access(caller, "get"):
+
+        # check if this object can be gotten
+        if not obj.access(caller, "get") or not obj.at_pre_get(caller):
             if obj.db.get_err_msg:
                 self.msg(obj.db.get_err_msg)
             else:
@@ -199,9 +201,7 @@ class CmdContainerGet(CmdGet):
 
         # calling possible at_pre_get_from hook on location
         if hasattr(location, "at_pre_get_from") and not location.at_pre_get_from(caller, obj):
-            return
-        # calling at_pre_get hook method
-        if not obj.at_pre_get(caller):
+            self.msg("You can't get that.")
             return
 
         success = obj.move_to(caller, quiet=True, move_type="get")
@@ -270,10 +270,12 @@ class CmdPut(CmdDrop):
 
         # Call the object script's at_pre_drop() method.
         if not obj.at_pre_drop(caller):
+            self.msg("You can't put that down.")
             return
 
         # Call the container's possible at_pre_put_in method.
         if hasattr(container, "at_pre_put_in") and not container.at_pre_put_in(caller, obj):
+            self.msg("You can't put that there.")
             return
 
         success = obj.move_to(container, quiet=True, move_type="drop")

--- a/evennia/contrib/game_systems/containers/containers.py
+++ b/evennia/contrib/game_systems/containers/containers.py
@@ -27,8 +27,8 @@ or implement the same locks/hooks in your own typeclasses.
 
 `ContainerObject` implements the following new methods:
 
-    at_pre_get_from(self, getter, target, **kwargs) - called with the pre-get hooks
-    at_pre_put_in(self, putter, target, **kwargs)   - called with the pre-put hooks
+    at_pre_get_from(getter, target, **kwargs) - called with the pre-get hooks
+    at_pre_put_in(putter, target, **kwargs)   - called with the pre-put hooks
 """
 from django.conf import settings
 
@@ -70,19 +70,19 @@ class ContainerObject(_BASE_OBJECT_TYPECLASS):
 
     def at_pre_put_in(self, putter, target, **kwargs):
         """
-        This will be called when something attempts to get another object FROM this object,
-        rather than when getting this object itself.
+        This will be called when something attempts to put another object into this object.
 
         Args:
-            getter (Object): The actor attempting to take something from this object.
-            target (Object): The thing this object contains that is being removed.
+            putter (Object): The actor attempting to put something in this object.
+            target (Object): The thing being put into this object.
 
         NOTE:
             To add more complex capacity checks, modify this method on your child typeclass.
         """
         # check if we're already at capacity
         if len(self.contents) >= self.capacity:
-            putter.msg(f"You can't fit anything else in {self.get_numbered_name(1, putter)[0]}.")
+            singular, _ = self.get_numbered_name(1, putter)
+            putter.msg(f"You can't fit anything else in {singular}.")
             return False
 
         return True
@@ -209,7 +209,7 @@ class CmdContainerGet(CmdGet):
 
 class CmdPut(CmdDrop):
     """
-    put something down
+    put an object into something else
 
     Usage:
       put <obj> in <container>

--- a/evennia/contrib/game_systems/containers/containers.py
+++ b/evennia/contrib/game_systems/containers/containers.py
@@ -1,0 +1,290 @@
+"""
+Containers
+
+Contribution by InspectorCaracal (2023)
+
+Adds the ability to put objects into other container objects by providing a container typeclass and extending certain base commands.
+
+To install, import and add the `ContainerCmdSet` to `CharacterCmdSet` in your `default_cmdsets.py` file:
+
+    from evennia.contrib.game_systems.containers import ContainerCmdSet
+
+    class CharacterCmdSet(default_cmds.CharacterCmdSet):
+        # ...
+        
+        def at_cmdset_creation(self):
+            # ...
+            self.add(ContainerCmdSet)
+
+The ContainerCmdSet includes:
+
+ - a modified `look` command to look at or inside objects
+ - a modified `get` command to get objects from your location or inside objects
+ - a new `put` command to put objects from your inventory into other objects
+
+Create objects with the `ContainerObject` typeclass to easily create containers,
+or implement the same locks/hooks in your own typeclasses.
+
+`ContainerObject` implements the following new methods:
+
+    at_pre_get_from(self, getter, target, **kwargs) - called with the pre-get hooks
+    at_pre_put_in(self, putter, target, **kwargs)   - called with the pre-put hooks
+"""
+from django.conf import settings
+
+from evennia import AttributeProperty, CmdSet, DefaultObject
+from evennia.commands.default.general import CmdLook, CmdGet, CmdDrop
+from evennia.utils import class_from_module
+
+# establish the right inheritance for container objects
+_BASE_OBJECT_TYPECLASS = class_from_module(settings.BASE_OBJECT_TYPECLASS, DefaultObject)
+
+
+class ContainerObject(_BASE_OBJECT_TYPECLASS):
+    """
+    A type of Object which can be used as a container.
+
+    It implements a very basic "size" limitation that is just a flat number of objects.
+    """
+
+    # This defines how many objects the container can hold.
+    capacity = AttributeProperty(default=20)
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        # adds a lock permission to allow items to be put inside or taken out
+        # by default, a lock type not being explicitly set will fail access checks, so normal
+        # objects without the get_from type set will fail get_from access checks
+        self.locks.add("get_from:true()")
+
+    def at_pre_get_from(self, getter, target, **kwargs):
+        """
+        This will be called when something attempts to get another object FROM this object,
+        rather than when getting this object itself.
+
+        Args:
+            getter (Object): The actor attempting to take something from this object.
+            target (Object): The thing this object contains that is being removed.
+        """
+        return True
+
+    def at_pre_put_in(self, putter, target, **kwargs):
+        """
+        This will be called when something attempts to get another object FROM this object,
+        rather than when getting this object itself.
+
+        Args:
+            getter (Object): The actor attempting to take something from this object.
+            target (Object): The thing this object contains that is being removed.
+
+        NOTE:
+            To add more complex capacity checks, modify this method on your child typeclass.
+        """
+        # check if we're already at capacity
+        if len(self.contents) >= self.capacity:
+            putter.msg(f"You can't fit anything else in {self.get_numbered_name(1, putter)[0]}.")
+            return False
+
+        return True
+
+
+class CmdContainerLook(CmdLook):
+    """
+    look at location or object
+
+    Usage:
+      look
+      look <obj>
+      look <obj> in <container>
+      look *<account>
+
+    Observes your location or objects in your vicinity.
+    """
+
+    rhs_split = (" in ",)
+
+    def func(self):
+        """
+        Handle the looking.
+        """
+        caller = self.caller
+        # by default, we don't look in anything
+        container = None
+
+        if not self.args:
+            target = caller.location
+            if not target:
+                self.msg("You have no location to look at!")
+                return
+        elif self.rhs:
+            # we are looking in something, find that first
+            container = caller.search(self.rhs)
+            if not container:
+                return
+
+        target = caller.search(self.lhs, location=container)
+        if not target:
+            return
+
+        desc = caller.at_look(target)
+        # add the type=look to the outputfunc to make it
+        # easy to separate this output in client.
+        self.msg(text=(desc, {"type": "look"}), options=None)
+
+
+class CmdContainerGet(CmdGet):
+    """
+    pick up something
+
+    Usage:
+      get <obj>
+      get <obj> from <container>
+
+    Picks up an object from your location or a container and puts it in
+    your inventory.
+    """
+
+    rhs_split = (" from ",)
+
+    def func(self):
+        caller = self.caller
+        # by default, we get from the caller's location
+        location = caller.location
+
+        if not self.args:
+            self.msg("Get what?")
+            return
+
+        # check for a container as the location to get from
+        if self.rhs:
+            location = caller.search(self.rhs)
+            if not location:
+                return
+            # check access lock
+            if not location.access(caller, "get_from"):
+                # supports custom error messages on individual containers
+                if location.db.get_from_err_msg:
+                    self.msg(location.db.get_from_err_msg)
+                else:
+                    self.msg("You can't get things from that.")
+                return
+
+        obj = caller.search(self.lhs, location=location)
+        if not obj:
+            return
+        if caller == obj:
+            self.msg("You can't get yourself.")
+            return
+        if not obj.access(caller, "get"):
+            if obj.db.get_err_msg:
+                self.msg(obj.db.get_err_msg)
+            else:
+                self.msg("You can't get that.")
+            return
+
+        # calling possible at_pre_get_from hook on location
+        if hasattr(location, "at_pre_get_from") and not location.at_pre_get_from(caller, obj):
+            return
+        # calling at_pre_get hook method
+        if not obj.at_pre_get(caller):
+            return
+
+        success = obj.move_to(caller, quiet=True, move_type="get")
+        if not success:
+            self.msg("This can't be picked up.")
+        else:
+            singular, _ = obj.get_numbered_name(1, caller)
+            if location == caller.location:
+                # we're picking it up from the area
+                caller.location.msg_contents(f"$You() $conj(pick) up {singular}.", from_obj=caller)
+            else:
+                # we're getting it from somewhere else
+                container_name, _ = location.get_numbered_name(1, caller)
+                caller.location.msg_contents(
+                    f"$You() $conj(get) {singular} from {container_name}.", from_obj=caller
+                )
+            # calling at_get hook method
+            obj.at_get(caller)
+
+
+class CmdPut(CmdDrop):
+    """
+    put something down
+
+    Usage:
+      put <obj> in <container>
+
+    Lets you put an object from your inventory into another
+    object in the vicinity.
+    """
+
+    key = "put"
+    rhs_split = ("=", " in ", " on ")
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            self.msg("Put what in where?")
+            return
+
+        if not self.rhs:
+            super().func()
+            return
+
+        obj = caller.search(
+            self.lhs,
+            location=caller,
+            nofound_string=f"You aren't carrying {self.args}.",
+            multimatch_string=f"You carry more than one {self.args}:",
+        )
+        if not obj:
+            return
+
+        container = caller.search(self.rhs)
+        if not container:
+            return
+
+        # check access lock
+        if not container.access(caller, "get_from"):
+            # supports custom error messages on individual containers
+            if container.db.put_err_msg:
+                self.msg(container.db.put_err_msg)
+            else:
+                self.msg("You can't get things from that.")
+            return
+
+        # Call the object script's at_pre_drop() method.
+        if not obj.at_pre_drop(caller):
+            return
+
+        # Call the container's possible at_pre_put_in method.
+        if hasattr(container, "at_pre_put_in") and not container.at_pre_put_in(caller, obj):
+            return
+
+        success = obj.move_to(container, quiet=True, move_type="drop")
+        if not success:
+            self.msg("This couldn't be dropped.")
+        else:
+            obj_name, _ = obj.get_numbered_name(1, caller)
+            container_name, _ = container.get_numbered_name(1, caller)
+            caller.location.msg_contents(
+                f"$You() $conj(put) {obj_name} in {container_name}.", from_obj=caller
+            )
+            # Call the object script's at_drop() method.
+            obj.at_drop(caller)
+
+
+class ContainerCmdSet(CmdSet):
+    """
+    Extends the basic `look` and `get` commands to support containers,
+    and adds an additional `put` command.
+    """
+
+    key = "Container CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+
+        self.add(CmdContainerLook)
+        self.add(CmdContainerGet)
+        self.add(CmdPut)

--- a/evennia/contrib/game_systems/containers/containers.py
+++ b/evennia/contrib/game_systems/containers/containers.py
@@ -73,6 +73,9 @@ class ContribContainer(_BASE_OBJECT_TYPECLASS):
 
         Returns:
             boolean: Whether the object `target` should be gotten or not.
+
+        Notes:
+            If this method returns False/None, the getting is cancelled before it is even started.
         """
         return True
 
@@ -87,7 +90,8 @@ class ContribContainer(_BASE_OBJECT_TYPECLASS):
         Returns:
             boolean: Whether the object `target` should be put down or not.
 
-        Note:
+        Notes:
+            If this method returns False/None, the putting is cancelled before it is even started.
             To add more complex capacity checks, modify this method on your child typeclass.
         """
         # check if we're already at capacity
@@ -261,7 +265,7 @@ class CmdPut(CmdDrop):
             if container.db.put_err_msg:
                 self.msg(container.db.put_err_msg)
             else:
-                self.msg("You can't get things from that.")
+                self.msg("You can't put things in that.")
             return
 
         # Call the object script's at_pre_drop() method.

--- a/evennia/contrib/game_systems/containers/tests.py
+++ b/evennia/contrib/game_systems/containers/tests.py
@@ -1,0 +1,38 @@
+from evennia import create_object
+from evennia.utils.test_resources import BaseEvenniaTest, BaseEvenniaCommandTest  # noqa
+from .containers import ContainerObject, CmdContainerGet, CmdContainerLook, CmdPut
+
+
+class TestContainer(BaseEvenniaTest):
+    def setUp(self):
+        super().setUp()
+        # create a container to test with
+        self.container = create_object(key="Box", typeclass=ContainerObject, location=self.room1)
+
+    def test_capacity(self):
+        # limit capacity to 1
+        self.container.capacity = 1
+        self.assertTrue(self.container.at_pre_put_in(self.char1, self.obj1))
+        # put Obj2 in container to hit max capacity
+        self.obj2.location = self.container
+        self.assertFalse(self.container.at_pre_put_in(self.char1, self.obj1))
+
+
+class TestContainerCmds(BaseEvenniaCommandTest):
+    def setUp(self):
+        super().setUp()
+        # create a container to test with
+        self.container = create_object(key="Box", typeclass=ContainerObject, location=self.room1)
+
+    def test_look_in(self):
+        # make sure the object is in the container so we can look at it
+        self.obj1.location = self.container
+        self.call(CmdContainerLook(), "obj in box", "Obj")
+
+    def test_get_and_put(self):
+        # get normally
+        self.call(CmdContainerGet(), "Obj", "You pick up an Obj.")
+        # put in the container
+        self.call(CmdPut(), "obj in box", "You put an Obj in a Box.")
+        # get from the container
+        self.call(CmdContainerGet(), "obj from box", "You get an Obj from a Box.")

--- a/evennia/contrib/game_systems/containers/tests.py
+++ b/evennia/contrib/game_systems/containers/tests.py
@@ -36,3 +36,16 @@ class TestContainerCmds(BaseEvenniaCommandTest):
         self.call(CmdPut(), "obj in box", "You put an Obj in a Box.")
         # get from the container
         self.call(CmdContainerGet(), "obj from box", "You get an Obj from a Box.")
+
+    def test_locked_get_put(self):
+        # lock container
+        self.container.locks.add("get_from:false()")
+        # move object to container to try getting
+        self.obj1.location = self.container
+        self.call(CmdContainerGet(), "obj from box", "You can't get things from that.")
+        # move object to character to try putting
+        self.obj1.location = self.char1
+        self.call(CmdPut(), "obj in box", "You can't put things in that.")
+        
+        
+        

--- a/evennia/contrib/game_systems/containers/tests.py
+++ b/evennia/contrib/game_systems/containers/tests.py
@@ -28,6 +28,9 @@ class TestContainerCmds(BaseEvenniaCommandTest):
         # make sure the object is in the container so we can look at it
         self.obj1.location = self.container
         self.call(CmdContainerLook(), "obj in box", "Obj")
+        # move it into a non-container object and look at it there too
+        self.obj1.location = self.obj2
+        self.call(CmdContainerLook(), "obj in obj2", "Obj")
 
     def test_get_and_put(self):
         # get normally
@@ -47,5 +50,13 @@ class TestContainerCmds(BaseEvenniaCommandTest):
         self.obj1.location = self.char1
         self.call(CmdPut(), "obj in box", "You can't put things in that.")
         
-        
+    def test_at_capacity_put(self):
+        # set container capacity
+        self.container.capacity = 1
+        # move object to container to fill capacity
+        self.obj2.location = self.container
+        # move object to character to try putting
+        self.obj1.location = self.char1
+        self.call(CmdPut(), "obj in box", "You can't fit anything else in a Box.")
+
         

--- a/evennia/contrib/game_systems/containers/tests.py
+++ b/evennia/contrib/game_systems/containers/tests.py
@@ -1,13 +1,13 @@
 from evennia import create_object
 from evennia.utils.test_resources import BaseEvenniaTest, BaseEvenniaCommandTest  # noqa
-from .containers import ContainerObject, CmdContainerGet, CmdContainerLook, CmdPut
+from .containers import ContribContainer, CmdContainerGet, CmdContainerLook, CmdPut
 
 
 class TestContainer(BaseEvenniaTest):
     def setUp(self):
         super().setUp()
         # create a container to test with
-        self.container = create_object(key="Box", typeclass=ContainerObject, location=self.room1)
+        self.container = create_object(key="Box", typeclass=ContribContainer, location=self.room1)
 
     def test_capacity(self):
         # limit capacity to 1
@@ -22,7 +22,7 @@ class TestContainerCmds(BaseEvenniaCommandTest):
     def setUp(self):
         super().setUp()
         # create a container to test with
-        self.container = create_object(key="Box", typeclass=ContainerObject, location=self.room1)
+        self.container = create_object(key="Box", typeclass=ContribContainer, location=self.room1)
 
     def test_look_in(self):
         # make sure the object is in the container so we can look at it


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This contrib adds several commands and a typeclass to implement a basic, but extensible, container mechanic.

The cmdset includes extended versions of `look` and `get` to allow looking at or getting objects that are in another object, as well as a new `put` command that allows you to put an object inside a container. These commands reference a new access type, `get_from`, to determine whether an object can be used as a container or not.

The `ContainerObject` typeclass provided has the `get_from` lock set to true by default and also implements a very basic capacity check, along with two new hooks used by the `get` and `put` commands: `at_pre_get_from` and `at_pre_put_in`.

#### Motivation for adding to Evennia
Nearly everyone wanting to build a game with Evennia has wanted containers of some sort. This contrib is intended to fill that need, particularly for those with minimal to no coding experience, while also being useful for those who want to implement more complicated container functionality.