### PR TITLE
Contrib providing an events calendar

### DIFF
--- a/evennia/contrib/base_systems/events_calendar/README.md
+++ b/evennia/contrib/base_systems/events_calendar/README.md
@@ -1,0 +1,137 @@
+# Events Calendar
+*Contribution by InspectorCaracal (2023)*
+
+A system for viewing and managing community events for your game.
+
+## Installation
+
+> This contrib requires extra dependencies. Install with `pip install evennia[extra]` or `pip install python-dateutil`
+
+The main components of the events system are the `Event` class and the `EventCalendar` global script. You'll need to create the `EventCalendar` global script for any of the provided commands to work.
+
+The recommended method is to add it to the `GLOBAL_SCRIPTS` setting in `server/conf/settings.py`
+
+```python
+GLOBAL_SCRIPTS = {
+    "event_calendar_script": {
+        "typeclass": "base_systems.events_calendar.events.EventCalendar",
+        "desc": "Track and manage community events.",
+				# The interval is optional and defines how often old events will be cleaned up.
+				"interval": 36000
+    }
+}
+````
+
+The event calendar comes with an optional clean-up mechanism. If you set a repeating interval on the calendar global script, it will regularly delete any events that have already ended. If you would rather keep old events or remove them manually, leave the interval setting out.
+
+You will also need to add the events cmdset to your game. It can be added to `CharacterCmdSet`, `AccountCmdSet`, or both.
+
+Example:
+```python
+    # add this import line
+    from evennia.contrib.base_systems.events_calendar.commands import EventsCmdSet
+    
+    class AccountCmdSet(default_cmds.AccountCmdSet):
+    
+        def at_cmdset_creation(self):
+            super().at_cmdset_creation()
+            # ...
+            # add this line to include the cmdset
+            self.add(EventsCmdSet)
+```
+
+## Website Installation
+
+To add an events listing page to your game's website, you will first need to copy the template file `events_template.html` (e.g. from [github](https://github.com/evennia/evennia/blob/main/evennia/contrib/base_systems/events_calendar/events_template.html) ) from the contrib to your website templates folder: `mygame/web/templates/website/`.
+
+Then, import and add the events view to `mygame/web/website/urls.py` - it should look something like this:
+
+```python
+from django.urls import path
+
+from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
+from evennia.contrib.base_systems.events_calendar.events_view import EventListView
+
+# add patterns here
+urlpatterns = [
+    # this is the new path for the events page
+    path("events/", EventListView.as_view(), name="events")
+]
+
+# read by Django
+urlpatterns = urlpatterns + evennia_website_urlpatterns
+```
+
+That will make a list of your scheduled events available at e.g. `localhost:4001/events`
+
+In order to make the new Events page available from the menu bar, you also need to copy `_menu.html` (e.g. from [github](https://github.com/evennia/evennia/blob/main/evennia/web/templates/website/_menu.html) to your `web/templates/website/` folder, then add a new menu item.
+
+Example:
+```html
+            <!-- game views -->
+            <li><a class="nav-link" href="{% url 'characters' %}">Characters</a></li>
+            <li><a class="nav-link" href="{% url 'channels' %}">Channels</a></li>
+            <li><a class="nav-link" href="{% url 'help' %}">Help</a></li>
+            <!-- the new Events link -->
+            <li><a class="nav-link" href="{% url 'events' %}">Events</a></li>
+            <!-- end game views -->
+```
+
+**This contrib does not provide the ability to add, modify, or delete events from the website.**
+
+## Usage
+
+The primary method for adding, creating and viewing events is the `events` command in-game, but the contrib also has several optional settings to customize its behavior.
+
+### Creating new events.
+
+New events are created through the `events/new` command, which will begin an EvMenu that allows you to define the information for your event.
+
+If you enter the command with arguments, e.g. `events/new My Event`, it will set that as the name of your event. If not, it will prompt you for an event name before continuing with the menu.
+
+The contrib supports setting the name, description, start time, end time, and view permissions of events with the menu, along with anonymous mode and auto-announce for staff. View permissions can only be limited to your own permission level and lower.
+
+### Viewing events
+
+The main way to view events is with the `events` command.
+
+Entering `events` on its own will show a list of all current and upcoming commands. `events/current` will show only currently active events, while `events/future` will show only upcoming events. `events/mine` will show a similar list, but only events that you are set as the creator for.
+
+You can also use the `view` switch to see more detail of an event. `events/view my event` will show the detail view of all events matching that name. `view` can be combined with any of the list switches to show the full detail view instead of the list view. e.g. `events/view/current` or `events/view/mine`.
+
+Additionally, if you have the website view installed, you can view a list of current and upcoming lists at `yourgame.com/events`. This list can't be filtered further, but it does respect view permissions.
+
+### Deleting events
+
+Existing events can be deleted with the `events/delete` command.
+
+Entering the command with arguments, e.g. `events/delete my event`, the events calendar will filter to matching events that you're allowed to delete. Otherwise, it will show a complete list of all events that you can delete.
+
+### Settings
+
+By default, only players with `Admin` permission or above can create or delete any events. You can modify that with the following settings:
+
+```python
+# Set the permission required to create new events
+EVENTS_PERMS_ADD = "Admin"
+# Set the permission required to delete events created by *anyone*
+EVENTS_PERMS_DELETE_ANY = "Admin"
+# What permission is required to create "staff" events - anonymous events that 
+# can be automatically announced to all players when they begin.
+EVENTS_PERMS_STAFF = "Admin"
+```
+
+> Anyone can always view and delete their own events.
+
+Creating and deleting new events are managed with a custom `EvMenu` - `menus.py` in the contrib. You can replace these menus with your own, allowing you to add, remove, or otherwise modify any of the information that can be added to a single Event.
+
+> When using your own menus, the event creation menu MUST have "menunode_begin_add_menu" and "menunode_add_info" defined, and event deletion menu MUST have "menunode_begin_delete_menu" defined.
+
+```python
+# The menu module used when creating a new event
+EVENTS_CREATE_MENU = "mygame.world.event_create_menu"
+# The menu module used for deleting an event
+EVENTS_DELETE_MENU = "mygame.world.event_delete_menu"
+```
+
+The `Event` class and `EventCalendar` global script are designed to be flexible and support any extra metadata you might want to add to your events - for example, Category, or Location - without changing their code, so you can pass any additional keyword arguments when creating an Event in your custom menus.

--- a/evennia/contrib/base_systems/events_calendar/__init__.py
+++ b/evennia/contrib/base_systems/events_calendar/__init__.py
@@ -1,0 +1,1 @@
+from .events_calendar import EventCalendar

--- a/evennia/contrib/base_systems/events_calendar/commands.py
+++ b/evennia/contrib/base_systems/events_calendar/commands.py
@@ -1,0 +1,201 @@
+"""
+Events Command
+
+Adds a command for managing events through the EventCalendar script.
+"""
+
+from django.conf import settings
+from evennia import CmdSet, GLOBAL_SCRIPTS, utils
+from evennia.utils import evmenu, iter_to_str
+from evennia.commands.default.muxcommand import MuxCommand
+
+_ADD_EVENT_PERMS = getattr(settings, "EVENTS_PERMS_ADD", "Admin")
+_DELETE_EVENT_PERMS = getattr(settings, "EVENTS_PERMS_DELETE_ANY", "Admin")
+
+
+_CREATE_MENU = getattr(
+    settings, "EVENTS_CREATE_MENU", "evennia.contrib.base_systems.events_calendar.menus"
+)
+_DELETE_MENU = getattr(
+    settings, "EVENTS_DELETE_MENU", "evennia.contrib.base_systems.events_calendar.menus"
+)
+
+
+class CmdEvents(MuxCommand):
+    """
+    view and manage community events
+
+    Usage:
+        events
+        events/[current/future/mine]
+        events/[new/delete] [event name]
+        events/rsvp event name
+
+    Examples:
+        events
+        events/mine
+        events/new My First Event
+        events/view Another Event
+
+    Switches:
+        current - List any events currently active
+        future  - List upcoming events
+        mine    - List all events you've created
+        view    - View full details for an event. Can be combined with list switches or
+                  used with an event name.
+        rsvp    - Sign up to be alerted when the event begins, or again to remove yourself.
+        new     - Open the new event menu, optionally providing a name.
+        delete  - Open the event deletion menu, optionally providing a name.
+    """
+
+    key = "events"
+    aliases = ("event",)
+
+    switch_options = (
+        "current",
+        "future",
+        "mine",
+        "new",
+        "add",
+        "create",
+        "remove",
+        "delete",
+        "view",
+        "rsvp",
+        "del",
+    )
+
+    def func(self):
+        if not (calendar := GLOBAL_SCRIPTS.get("event_calendar_script")):
+            self.msg("No event calendar was found.")
+            return
+
+        def _cleanup_info(caller, evmenu):
+            del caller.ndb._event_info
+
+        if any(w in self.switches for w in ("new", "create", "add")):
+            if not self.caller.check_permstring(_ADD_EVENT_PERMS):
+                self.msg("You do not have permission to add new events.")
+                return
+            if self.args:
+                name = self.args.strip()
+                self.caller.ndb._event_info = {"name": name}
+                startnode = "menunode_add_info"
+            else:
+                startnode = "menunode_begin_add_menu"
+            evmenu.EvMenu(
+                self.caller,
+                _CREATE_MENU,
+                startnode=startnode,
+                cmd_on_exit=_cleanup_info,
+            )
+            return
+
+        if any(w in self.switches for w in ("remove", "delete", "del")):
+            search_term = self.args.strip()
+            if not self.caller.check_permstring(_DELETE_EVENT_PERMS):
+                # can only delete your own events
+                if search_results := calendar.search_event(
+                    search_term, viewer=self.caller, creator=self.caller
+                ):
+                    self.caller.ndb._event_info = {"opts": search_results}
+                else:
+                    self.msg("You have no events to delete.")
+                    return
+            elif search_term:
+                # filter list by search term
+                if search_results := calendar.search_event(search_term, viewer=self.caller):
+                    self.caller.ndb._event_info = {"opts": search_results}
+                else:
+                    self.msg(f"No matching events for {search_term} were found.")
+                    return
+            self.msg(self.caller.ndb._event_info)
+            evmenu.EvMenu(
+                self.caller,
+                _DELETE_MENU,
+                startnode="menunode_begin_delete_menu",
+                cmd_on_exit=_cleanup_info,
+            )
+            return
+
+        if not (switches := self.switches):
+            switches = ("current", "future")
+
+        if "rsvp" in switches:
+            if not self.args:
+                self.msg("You must specify which event you want to RSVP")
+                return
+            search_term = self.args.strip()
+            if search_results := calendar.search_event(
+                search_term, viewer=self.caller, status="scheduled"
+            ):
+                if len(search_results) > 1:
+                    # do proper multimatch here
+                    self.msg("More than one match.")
+                    return
+                event = search_results[0]
+                if self.caller in event.notify:
+                    event.notify.remove(self.caller)
+                    self.msg(f"You will no longer be notified when |w{event}|n begins.")
+                else:
+                    event.notify.append(self.caller)
+                    self.msg(
+                        f"You have RSVPed for |w{event}|n and will be notified when it begins."
+                    )
+            else:
+                self.msg(f"No matching events for {search_term} were found.")
+            return
+
+        short_view = "view" not in switches
+        if len(switches) == 1:
+            if "view" in switches:
+                if not self.args:
+                    self.msg("View which event?")
+                    return
+                search_term = self.args.strip()
+                if not (search_results := calendar.search_event(search_term, viewer=self.caller)):
+                    self.msg("No matching events were found.")
+                    return
+                self.msg(calendar.format_events(search_results))
+                return
+            if "mine" in switches:
+                if events := calendar.search_event(creator=self.caller):
+                    self.msg("|wMy Events|n")
+                    self.msg(calendar.format_events(events, short=short_view))
+                else:
+                    self.msg("You have no events.")
+                return
+
+        results = []
+
+        if "current" in switches:
+            if events := calendar.current_events(
+                viewer=self.caller,
+                creator=self.caller if "mine" in switches else None,
+                short=short_view,
+            ):
+                results.append(events)
+
+        if "future" in switches:
+            if events := calendar.future_events(
+                viewer=self.caller,
+                creator=self.caller if "mine" in switches else None,
+                short=short_view,
+            ):
+                results.append(events)
+
+        if not results:
+            self.msg(f"There are no matching events.")
+
+        else:
+            self.msg("|wEvents|n")
+            self.msg("\n".join(results).strip())
+
+
+class EventsCmdSet(CmdSet):
+    key = "Events CmdSet"
+
+    def at_cmdset_creation(self):
+        super().at_cmdset_creation()
+
+        self.add(CmdEvents)

--- a/evennia/contrib/base_systems/events_calendar/events_calendar.py
+++ b/evennia/contrib/base_systems/events_calendar/events_calendar.py
@@ -1,0 +1,367 @@
+"""
+Events Calendar
+
+Contribution by InspectorCaracal (2023)
+
+A system for viewing and managing community events for your game.
+
+## Installation
+
+The main components of the events system are the `Event` class and the `EventCalendar`
+global script. You'll need to create the `EventCalendar` global script for any of the
+provided commands to work.
+
+The recommended method is to add it to the `GLOBAL_SCRIPTS` setting in `server/conf/settings.py`
+
+    GLOBAL_SCRIPTS = {
+        "event_calendar_script": {
+            "typeclass": "base_systems.events_calendar.events.EventCalendar",
+            "desc": "Track and manage community events."
+        }
+    }
+
+The event calendar comes with an optional clean-up mechanism. If you set a repeating interval
+on the calendar global script, it will regularly delete any events that have already ended.
+
+You will also need to add the cmdset to your game. It can be added to `CharacterCmdSet`,
+`AccountCmdSet`, or both.
+
+Example:
+
+    # ...
+    from evennia.contrib.base_systems.events_calendar.commands import EventCmdSet
+    
+    class AccountCmdSet(default_cmds.AccountCmdSet):
+    
+        def at_cmdset_creation(self):
+            super().at_cmdset_creation()
+            # ...
+            self.add(EventCmdSet)
+
+"""
+from zoneinfo import ZoneInfo
+from datetime import datetime
+from django.conf import settings
+from evennia import DefaultScript, create_script
+from evennia.utils import dbserialize, class_from_module, inherits_from, is_iter, make_iter
+from evennia.server.sessionhandler import SESSIONS
+
+_BASE_SCRIPT_TYPECLASS = class_from_module(settings.BASE_SCRIPT_TYPECLASS, DefaultScript)
+
+_TIME_ZONE = ZoneInfo(settings.TIME_ZONE) if settings.USE_TZ else None
+
+_DEFAULT_VIEW_TEMPLATE = """\
+|c{name}|n{creator}
+Starts: {start}|g{active}|n
+Ends:   {end}
+{desc}
+"""
+_SHORT_VIEW_TEMPLATE = "|w{name}|n{creator}, starts {start}|g{active}|n"
+_DEFAULT_TIME_FORMAT = "%d %b %Y, %H:%M %Z"
+
+
+class AnnounceEvent(DefaultScript):
+    def at_repeat(self):
+        if not (event := self.db.event):
+            return
+
+        # announce to all if applicable
+        if event.announce:
+            message = f"|w{event.name}|n has begun!"
+            SESSIONS.announce_all(message)
+
+        # notify all RSVP'd
+        elif notify_list := event.notify:
+            message = f"Your RSVP'd event |w{event.name}|n has started."
+            for rsvp in notify_list:
+                rsvp.msg(message)
+
+    def at_stop(self):
+        self.delete()
+
+
+class EventError(Exception):
+    """
+    Error from an Event
+    """
+
+
+class Event:
+    """
+    A class containing information about a single Event.
+    """
+
+    view_perm = None
+    script = None
+    announce = False
+
+    def __init__(self, name, desc, start_time, end_time, creator=None, **kwargs):
+        """
+        Initialize the event class.
+
+        Args:
+            name (str):  The name of the event.
+            desc (str):  The description for the event.
+            start_time (datetime):  What time the event will begin.
+            end_time (datetime):  What time the event will end.
+
+        Keyword args:
+            creator (Object or Account):  An optional event-creator to attach to the event.
+        """
+        if start_time > end_time:
+            # an event can't go backwards in time!
+            raise EventError("Start time cannot be later than the end time.")
+        self.name = name
+        self.desc = desc
+        self.start_time = start_time
+        self.end_time = end_time
+        self.creator = creator
+        self.notify = []
+        # add optional arbitrary data
+        for key, val in kwargs.items():
+            # don't override methods
+            if not (attr := hasattr(self, key)) or not callable(attr):
+                setattr(self, key, val)
+
+    def __str__(self):
+        return "{name}{creator} {start}-{end}".format(
+            name=self.name,
+            creator=f" (by {self.creator})" if self.creator else "",
+            start=self.start_time.strftime("%d %b"),
+            end=self.end_time.strftime("%d %b"),
+        )
+
+    def __lt__(self, other):
+        return self.start_time < other.start_time
+
+    def __serialize_dbobjs__(self):
+        # serialize all attributes in case there are custom ones with db objects
+        for attr, val in vars(self).items():
+            if inherits_from(val, "evennia.typeclasses.models.TypedObject"):
+                setattr(self, attr, dbserialize.dbserialize(val))
+
+    def __deserialize_dbobjs__(self):
+        # deserialize all attributes in case there are custom ones with db objects
+        for attr, val in vars(self).items():
+            if type(val) is bytes:
+                setattr(self, attr, dbserialize.dbunserialize(val))
+
+    @property
+    def status(self):
+        """
+        Returns a string representing the chronological status of the event.
+        """
+        now = datetime.now(tz=_TIME_ZONE)
+        if self.start_time > now:
+            return "scheduled"
+        elif self.start_time < now < self.end_time:
+            return "active"
+        else:
+            return "completed"
+
+    def can_view(self, viewer):
+        # for situations like the website, which checks all your character perms
+        if is_iter(viewer):
+            return any(self.can_view(v) for v in viewer)
+
+        if not viewer:
+            # "no viewer" means get a full list
+            return True
+
+        if viewer == self.creator:
+            # you can always view your own events
+            return True
+
+        if not self.view_perm:
+            # if no perm is specified, assume no restrictions
+            return True
+
+        if not hasattr(viewer, "check_permstring"):
+            # this viewer has no permissions but permissions are required
+            return False
+
+        return viewer.check_permstring(self.view_perm)
+
+    def view(self, **kwargs):
+        """
+        Formats the data for view.
+        """
+        if not (template_str := kwargs.get("template")):
+            template_str = _DEFAULT_VIEW_TEMPLATE
+        if not (time_format := kwargs.get("ftime")):
+            time_format = _DEFAULT_TIME_FORMAT
+
+        view_str = template_str.format(
+            name=self.name,
+            desc=self.desc,
+            creator=f" (by {self.creator.name})" if self.creator else "",
+            start=self.start_time.strftime(time_format).strip(),
+            end=self.end_time.strftime(time_format).strip(),
+            active=" (happening now!)" if self.status == "active" else "",
+        )
+        return view_str
+
+
+class EventCalendar(_BASE_SCRIPT_TYPECLASS):
+    """
+    A script typeclass intended to be used as a global script, for tracking current and upcoming events.
+    """
+
+    key = "event_calendar_script"
+
+    def at_repeat(self):
+        # clear out events that have already completed
+        self.clean_up()
+
+    def _sort_events(self):
+        if not (all_events := self.db.all_events):
+            return
+        all_events = all_events.deserialize()
+        all_events.sort()
+        self.db.all_events = all_events
+
+    def current_events(self, as_data=False, **kwargs):
+        """
+        Returns a list of all currently active events
+        """
+        return self.list_events(as_data=as_data, status="active", **kwargs)
+
+    def future_events(self, as_data=False, **kwargs):
+        """
+        Returns a list of all future events
+        """
+        return self.list_events(as_data=as_data, status="scheduled", **kwargs)
+
+    def list_events(
+        self, viewer=None, as_data=False, status=None, include_expired=True, short=False, **kwargs
+    ):
+        """
+        Returns an optionally-filtered list of events
+        """
+        if not (all_events := self.db.all_events):
+            return []
+        # optional custom view template
+        if short:
+            view_template = str(self.db.short_view or _SHORT_VIEW_TEMPLATE)
+        else:
+            view_template = str(self.db.view_template or _DEFAULT_VIEW_TEMPLATE)
+        # optional custom time format
+        ftime = str(self.db.ftime or "")
+        event_list = []
+        for event in all_events:
+            if not event:
+                continue
+
+            # check optional filters
+            if not event.can_view(viewer):
+                continue
+            if status and event.status != status:
+                continue
+            if not include_expired and event.status == "completed":
+                continue
+
+            # append the right form of the event
+            if as_data:
+                event_list.append(event)
+            else:
+                event_list.append(event.view(template=view_template, ftime=ftime, **kwargs))
+
+        if as_data:
+            return event_list
+        else:
+            return "\n".join(event_list) or ""
+
+    def format_events(self, events, short=False, **kwargs):
+        """
+        Format a list of Event objects using the scripts formatting templates.
+        """
+        events = make_iter(events)
+        # optional custom view template
+        if short:
+            view_template = str(self.db.short_view or _SHORT_VIEW_TEMPLATE)
+        else:
+            view_template = str(self.db.view_template or _DEFAULT_VIEW_TEMPLATE)
+        # optional custom time format
+        ftime = str(self.db.ftime or "")
+        event_list = [event.view(template=view_template, ftime=ftime, **kwargs) for event in events]
+        return "\n".join(event_list) or ""
+
+    def clean_up(self):
+        """
+        Remove all past events
+        """
+        if not (all_events := self.db.all_events):
+            return
+        all_events = all_events.deserialize()
+        to_remove = []
+        for event in all_events:
+            if event.status == "completed":
+                to_remove.append(event)
+        for event in to_remove:
+            all_events.remove(event)
+        self.db.all_events = all_events
+
+    def add_event(self, event):
+        """
+        Add a new event to the calendar
+        """
+        if not event.script:
+            from evennia.utils import logger
+
+            logger.log_msg(event.start_time.tzinfo)
+            tdelta = event.start_time - datetime.now(tz=_TIME_ZONE)
+            seconds_until = int(tdelta.total_seconds())
+            if seconds_until > 0:
+                # only create an announcement script if the event will start in the future
+                new_script = create_script(
+                    typeclass="evennia.contrib.base_systems.events_calendar.events_calendar.AnnounceEvent",
+                    start_delay=True,
+                    interval=seconds_until,
+                    repeats=1,
+                    persistent=True,
+                    desc=f"announce start of {event}",
+                )
+                new_script.db.event = event
+                event.script = new_script.key
+        if not (events_list := self.db.all_events):
+            self.db.all_events = [event]
+            return True
+        elif event not in events_list:
+            events_list.append(event)
+            self._sort_events()
+            return True
+
+    def delete_event(self, event):
+        """
+        Delete an existing event from the calendar.
+        """
+        if event in self.db.all_events:
+            if scheduled := getattr(event, "script"):
+                if script := DefaultScript.objects.search_script(scheduled):
+                    script.delete()
+            self.db.all_events.remove(event)
+            return True
+
+    def search_event(self, search_data="", viewer=None, creator=None, **kwargs):
+        """
+        Find matching events.
+        """
+        search_data = search_data.lower().strip()
+
+        def _check_creator(ecreator):
+            # make sure that both account and character creators are identified
+            if not creator:
+                return True
+            if creator == ecreator:
+                return True
+            elif account := getattr(creator, "account", None):
+                return account == ecreator
+
+        return [
+            event
+            for event in self.attributes.get("all_events", [])
+            if search_data in str(event).lower()
+            and event.can_view(viewer)
+            and _check_creator(event.creator)
+            and all(val == getattr(event, key, None) for key, val in kwargs.items())
+        ]

--- a/evennia/contrib/base_systems/events_calendar/events_template.html
+++ b/evennia/contrib/base_systems/events_calendar/events_template.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block titleblock %}
+{{ view.page_title }}
+{% endblock %}
+
+{% block content %}
+
+{% load addclass %}
+<div class="row">
+  <div class="col">
+    <div class="card">
+      <div class="card-body">
+        <h1 class="card-title">{{ view.page_title }}</h1>
+        <hr />
+
+        {% for object in object_list %}
+        <div class="event-item">
+          <h3 class="card-header">
+            {{ object.name }} {% if object.creator %}(by {{ object.creator }}){% endif %}
+          </h3>
+          {% if object.status == "active" %}
+            <p class="lead">Happening Now!</p>
+          {% else %}
+            <span style="font-weight:bold">Starts:</span> {{ object.start_time|date:"j M Y, H:i e" }}<br/>
+          {% endif %}
+          <span style="font-weight:bold">Ends:</span> {{ object.end_time|date:"j M Y, H:i e" }}
+          <div class="card-body">
+            <p>{{ object.desc }}</p>
+          </div>
+        </div>
+        {% endfor %}
+          
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/evennia/contrib/base_systems/events_calendar/events_view.py
+++ b/evennia/contrib/base_systems/events_calendar/events_view.py
@@ -1,0 +1,27 @@
+"""
+The main index page, including the game stats
+
+"""
+
+from django.views.generic import ListView
+
+from evennia import GLOBAL_SCRIPTS
+
+
+class EventListView(ListView):
+    # Tell the view what HTML template to use for the page
+    template_name = "website/events_template.html"
+
+    paginate_by = 10
+
+    # -- Evennia constructs --
+    page_title = "Events List"
+
+    def get_queryset(self):
+        if not (calendar := GLOBAL_SCRIPTS.get("event_calendar_script")):
+            return []
+
+        viewer = self.request.user
+        if not str(viewer) == "AnonymousUser":
+            viewer = viewer.db._playable_characters + [viewer]
+        return calendar.list_events(as_data=True, viewer=viewer, include_expired=False)

--- a/evennia/contrib/base_systems/events_calendar/menus.py
+++ b/evennia/contrib/base_systems/events_calendar/menus.py
@@ -1,0 +1,237 @@
+from zoneinfo import ZoneInfo
+from datetime import datetime
+from django.conf import settings
+import dateutil.parser as dateparser
+from evennia import GLOBAL_SCRIPTS
+from evennia.utils import dedent, evmenu
+
+from .events_calendar import Event
+
+_EVENTS_ADMIN_PERM = getattr(settings, "EVENTS_PERMS_STAFF", "Admin")
+
+_TIME_ZONE = ZoneInfo(settings.TIME_ZONE) if settings.USE_TZ else None
+
+_DEFAULT_TIME_FORMAT = "%d %b %Y, %H:%M %Z"
+# Add Event menu
+
+_PERM_LIST = settings.PERMISSION_HIERARCHY
+
+
+def menunode_begin_add_menu(caller):
+    caller.ndb._event_info = {}
+    text = "What would you like to call this event?"
+    options = {"key": "_default", "goto": (_set_event_info, {"to_set": "name"})}
+
+    return text, options
+
+
+def menunode_add_info(caller, raw_string, **kwargs):
+    if not (time_format := GLOBAL_SCRIPTS.event_calendar_script.db.ftime):
+        time_format = _DEFAULT_TIME_FORMAT
+    event_info = caller.ndb._event_info
+    err = ""
+    start_time = event_info.get("start_time")
+    end_time = event_info.get("end_time")
+    if start_time and end_time and start_time > end_time:
+        err = "|rYour event cannot end before it starts!|n\n\n"
+    text = dedent(
+        """\
+        You are adding a new event: |w{name}|n
+        Start time: {start}
+        End time:   {end}
+        {desc}
+  
+        {err}Choose an option to set (or |wq|n to cancel):
+    """
+    ).format(
+        name=caller.ndb._event_info["name"],
+        start=start_time.strftime(time_format) if start_time else "N/A",
+        end=end_time.strftime(time_format) if end_time else "N/A",
+        desc=event_info.get("desc", "(no description)"),
+        err=err,
+    )
+
+    options = [
+        {"desc": "Name", "goto": ("menunode_enter_info", {"to_set": "name"})},
+        {"desc": "Description", "goto": ("menunode_enter_info", {"to_set": "desc"})},
+        {"desc": "Starting time", "goto": ("menunode_pick_date", {"to_set": "start"})},
+        {"desc": "Ending time", "goto": ("menunode_pick_date", {"to_set": "end"})},
+    ]
+    if caller.check_permstring(_EVENTS_ADMIN_PERM):
+        if event_info.get("anonymous"):
+            options.append({"desc": "Set to player event", "goto": _toggle_anonymous})
+            if event_info.get("announce"):
+                options.append({"desc": "Turn off auto-announcement", "goto": _toggle_announce})
+            else:
+                options.append({"desc": "Auto-announce event starting", "goto": _toggle_announce})
+        else:
+            options.append({"desc": "Set to anonymous/staff event", "goto": _toggle_anonymous})
+    options.append({"desc": "Set view permission", "goto": "menunode_set_permission"})
+
+    if start_time and end_time and not err:
+        options.append({"desc": "Confirm and create", "goto": "menunode_confirm_add"})
+    return text, options
+
+
+def menunode_enter_info(caller, raw_string, to_set, **kwargs):
+    if to_set == "name":
+        word = "name"
+    elif to_set == "desc":
+        word = "description"
+
+    text = f"Enter your event's {word}:"
+
+    option = {"key": "_default", "goto": (_set_event_info, {"to_set": to_set})}
+
+    return text, option
+
+
+def menunode_pick_date(caller, raw_string, to_set, **kwargs):
+    if not (time_format := GLOBAL_SCRIPTS.event_calendar_script.db.ftime):
+        time_format = _DEFAULT_TIME_FORMAT
+    event_info = caller.ndb._event_info
+    if scheduled := event_info.get(f"{to_set}_time"):
+        schedule_str = scheduled.strftime(time_format)
+    else:
+        schedule_str = "N/A"
+
+    text = dedent(
+        f"""
+  Your event |w{event_info['name']}|n is scheduled to {to_set} at:
+  
+  {schedule_str}
+  
+  Enter a new date, or leave blank to keep this time:
+  """
+    )
+    if err := kwargs.get("error"):
+        text = err + "\n\n" + text
+
+    option = {"key": "_default", "goto": (_set_event_date, {"to_set": to_set})}
+
+    return text, option
+
+
+def menunode_set_permission(caller, raw_string, **kwargs):
+    current = caller.ndb._event_info.get("view_perm") or "anyone"
+
+    text = f"Your event is currently restricted to: {current}.\n\nChoose a permission level below to restrict the event to players of that level or higher:"
+    options = []
+
+    for perm in _PERM_LIST:
+        if caller.permissions.check(perm):
+            options.append({"desc": perm, "goto": (_set_permission, {"perm": perm})})
+
+    return text, options
+
+
+def _set_event_info(caller, raw_string, to_set, **kwargs):
+    info = raw_string.strip()
+    caller.ndb._event_info[to_set] = info
+    return "menunode_add_info"
+
+
+def _set_event_date(caller, raw_string, to_set, **kwargs):
+    try:
+        date_obj = dateparser.parse(
+            raw_string.strip(),
+            default=datetime.now(tz=_TIME_ZONE),
+            fuzzy=True,
+            ignoretz=not _TIME_ZONE,
+        )
+    except ValueError:
+        return ("menunode_pick_date", {"to_set": to_set, "error": "Invalid date."})
+
+    caller.ndb._event_info[f"{to_set}_time"] = date_obj
+    return "menunode_add_info"
+
+
+def _set_permission(caller, raw_string, perm, **kwargs):
+    caller.ndb._event_info["view_perm"] = perm
+    return "menunode_add_info"
+
+
+def _toggle_anonymous(caller, raw_string, **kwargs):
+    anon = caller.ndb._event_info.get("anonymous")
+    caller.ndb._event_info["anonymous"] = not anon
+    if anon:
+        # it was anonymous and no longer is; non-anon events can't be announced
+        caller.ndb._event_info["announce"] = False
+
+    return "menunode_add_info"
+
+
+def _toggle_announce(caller, raw_string, **kwargs):
+    caller.ndb._event_info["announce"] = not caller.ndb._event_info.get("announce")
+    return "menunode_add_info"
+
+
+def menunode_confirm_add(caller, raw_string, **kwargs):
+    event_info = dict(caller.ndb._event_info)
+    event_info["desc"] = event_info.get("desc", "(no description)")
+    if not event_info.pop("anonymous", None):
+        event_info["creator"] = caller
+    event = Event(**event_info)
+
+    text = dedent(
+        """
+  Your event:
+  
+  {event}{announce}
+  """
+    ).format(
+        event=event.view(),
+        announce="\n(Event will be auto-announced when it starts.)" if event.announce else "",
+    )
+
+    options = (
+        {"key": "Create", "goto": ("menunode_add_end", {"event": event})},
+        {"key": ("Back", "b"), "goto": "menunode_add_info"},
+    )
+
+    return text, options
+
+
+def menunode_add_end(caller, raw_string, event, **kwargs):
+    GLOBAL_SCRIPTS.event_calendar_script.add_event(event)
+    text = "Your event has been added!"
+    return text
+
+
+# Delete Event menu
+
+
+def _list_events(caller):
+    events = caller.ndb._event_info or {}
+    if not (options := events.get("opts")):
+        options = GLOBAL_SCRIPTS.event_calendar_script.list_events(as_data=True)
+    return options
+
+
+@evmenu.list_node(_list_events, select="menunode_confirm_delete", pagesize=10)
+def menunode_begin_delete_menu(caller, raw_string, **kwargs):
+    text = "Which event do you want to delete?\n\n(press |wq|n to cancel)"
+    return text, []
+
+
+def menunode_confirm_delete(caller, raw_string, selection, **kwargs):
+    text = dedent(
+        """
+    {event}
+    
+    Delete this event?
+  """
+    ).format(event=selection.view())
+
+    options = (
+        {"key": "Delete", "goto": ("menunode_delete_event", {"event": selection})},
+        {"key": ("Back", "b"), "goto": "menunode_begin_delete_menu"},
+    )
+
+    return text, options
+
+
+def menunode_delete_event(caller, raw_string, event, **kwargs):
+    text = f"Event {event} has been deleted."
+    GLOBAL_SCRIPTS.event_calendar_script.delete_event(event)
+    return text

--- a/evennia/contrib/base_systems/events_calendar/tests.py
+++ b/evennia/contrib/base_systems/events_calendar/tests.py
@@ -1,0 +1,190 @@
+from zoneinfo import ZoneInfo
+from datetime import datetime, timedelta
+from mock import patch
+from parameterized import parameterized
+
+from evennia import create_script, GLOBAL_SCRIPTS
+from evennia.utils.test_resources import BaseEvenniaTest, BaseEvenniaCommandTest  # noqa
+from . import events_calendar
+from .commands import CmdEvents
+
+_test_time = datetime(2020, 6, 7, 8, tzinfo=ZoneInfo("UTC"))
+
+
+@patch.object(events, "datetime", wraps=datetime)
+# @patch.object(events_calendar.time, "time", test_time)
+class TestEventCalendar(BaseEvenniaTest):
+    # TODO: redo this to mock the current time
+    def setUp(self):
+        super().setUp()
+        now = _test_time
+        start = now + timedelta(days=-1)
+        end = now + timedelta(days=1)
+        self.calendar = create_script(events_calendar.EventCalendar, key="event_calendar_script")
+        self.event1 = events_calendar.Event(
+            "test event", "This is an event running now.", start, end, creator=self.char1
+        )
+        start = now + timedelta(weeks=1)
+        end = now + timedelta(weeks=1, days=2)
+        self.event2 = events_calendar.Event("test event 2", "This is a future event.", start, end)
+        start = now + timedelta(weeks=-1)
+        end = now + timedelta(weeks=-1, days=2)
+        self.event3 = events_calendar.Event("test event 3", "This is a past event.", start, end)
+
+    def tearDown(self):
+        super().tearDown()
+        self.calendar.delete()
+
+    def test_add_event(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.assertTrue(self.calendar.add_event(self.event1))
+        self.assertEqual(len(self.calendar.list_events(as_data=True)), 1)
+        # cannot add an event twice
+        self.assertFalse(self.calendar.add_event(self.event1))
+        self.assertEqual(len(self.calendar.list_events(as_data=True)), 1)
+
+    def test_list_events(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.calendar.add_event(self.event2)
+        self.assertEqual(len(self.calendar.list_events(as_data=True)), 1)
+        self.assertEqual(self.event2, self.calendar.list_events(as_data=True)[0])
+        self.assertTrue(self.calendar.list_events().startswith("|ctest event 2|n"))
+        self.calendar.add_event(self.event1)
+        self.assertEqual(len(self.calendar.list_events(as_data=True)), 2)
+        # newly added event should be first, since it's sooner
+        self.assertEqual(self.event1, self.calendar.list_events(as_data=True)[0])
+        self.assertEqual(self.event2, self.calendar.list_events(as_data=True)[1])
+
+    def test_current_list(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.calendar.add_event(self.event1)
+        self.calendar.add_event(self.event2)
+        # event 1 is currently active so should be in this list
+        self.assertIn(self.event1, self.calendar.current_events(as_data=True))
+        # event 2 is in the future so should NOT be in this list
+        self.assertNotIn(self.event2, self.calendar.current_events(as_data=True))
+
+    def test_future_list(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.calendar.add_event(self.event1)
+        self.calendar.add_event(self.event2)
+        # event 1 is currently active so should NOT be in this list
+        self.assertNotIn(self.event1, self.calendar.future_events(as_data=True))
+        # event 2 is in the future so should be in this list
+        self.assertIn(self.event2, self.calendar.future_events(as_data=True))
+
+    def test_clean_up(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.calendar.add_event(self.event1)
+        self.calendar.add_event(self.event3)
+        self.assertIn(self.event3, self.calendar.list_events(as_data=True))
+        self.calendar.clean_up()
+        # event 3 is in the past and so should have been removed
+        self.assertNotIn(self.event3, self.calendar.list_events(as_data=True))
+
+    def test_delete_event(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        self.calendar.add_event(self.event1)
+        self.calendar.add_event(self.event2)
+        self.assertIn(self.event2, self.calendar.list_events(as_data=True))
+        self.calendar.delete_event(self.event2)
+        self.assertNotIn(self.event2, self.calendar.list_events(as_data=True))
+
+
+@patch.object(events, "datetime", wraps=datetime)
+class TestEventCommand(BaseEvenniaCommandTest):
+    def setUp(self):
+        super().setUp()
+        now = _test_time
+        start = now + timedelta(days=-1)
+        end = now + timedelta(days=1)
+        self.calendar = create_script(events_calendar.EventCalendar, key="event_calendar_script")
+        self.calendar.add_event(
+            events_calendar.Event(
+                "test event", "This is an event running now.", start, end, creator=self.char1
+            )
+        )
+        start = now + timedelta(weeks=1)
+        end = now + timedelta(weeks=1, days=2)
+        self.calendar.add_event(
+            events_calendar.Event(
+                "test event 2", "This is a future event.", start, end, creator=self.char2
+            )
+        )
+        self.calendar.add_event(
+            events_calendar.Event(
+                "staff event test", "This is an admin-level event.", start, end, view_perm="admin"
+            )
+        )
+        start = now + timedelta(weeks=-1)
+        end = now + timedelta(weeks=-1, days=2)
+        self.calendar.add_event(
+            events_calendar.Event("test event 3", "This is a past event.", start, end)
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        self.calendar.delete()
+
+    def test_event_list(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        header = "Events|"
+        event_1 = """\
+test event (by Char)
+Starts: 06 Jun 2020, 08:00 UTC (happening now!)
+Ends:   08 Jun 2020, 08:00 UTC
+This is an event running now.
+"""
+
+        event_2 = """\
+test event 2 (by Char2)
+Starts: 14 Jun 2020, 08:00 UTC
+Ends:   16 Jun 2020, 08:00 UTC
+This is a future event.
+"""
+
+        short_list = """\
+test event (by Char), starts 06 Jun 2020, 08:00 UTC (happening now!)
+test event 2 (by Char2), starts 14 Jun 2020, 08:00 UTC
+staff event test, starts 14 Jun 2020, 08:00 UTC
+"""
+
+        self.call(CmdEvents(), "", header + short_list)
+        self.call(
+            CmdEvents(), "/current", header + "test event (by Char), starts 06 Jun 2020, 08:00 UTC"
+        )
+        self.call(
+            CmdEvents(),
+            "/future",
+            header + "test event 2 (by Char2), starts 14 Jun 2020, 08:00 UTC",
+        )
+
+        self.call(CmdEvents(), "/view event 2", event_2)
+        self.call(CmdEvents(), "/view/current", header + event_1)
+        self.call(CmdEvents(), "/view/future", header + event_2)
+
+    def test_event_perms(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        # default caller, char1, has developer perms
+        event_list = self.call(CmdEvents(), "", "Events")
+        self.assertIn("staff event test", event_list)
+        # char2 does not, and should not see the staff event
+        event_list = self.call(CmdEvents(), "", "Events", caller=self.char2)
+        self.assertNotIn("staff event test", event_list)
+
+    def test_view_mine(self, mock_datetime):
+        mock_datetime.now.return_value = _test_time
+        # event 1 was by Char
+        self.call(
+            CmdEvents(),
+            "/mine",
+            "My Events|test event (by Char), starts 06 Jun 2020, 08:00 UTC",
+            caller=self.char1,
+        )
+        # event 2 was by Char2
+        self.call(
+            CmdEvents(),
+            "/mine",
+            "My Events|test event 2 (by Char2), starts 14 Jun 2020, 08:00 UTC",
+            caller=self.char2,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ extra = [
 
   # Git contrib
   "gitpython >= 3.1.27",
+
+  # events calendar contrib
+  "python-dateutil >= 2.8.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This contrib includes several tools for organizing in-game events with a game's community.

- A Global Script to store and manage game community events
- An in-game command for adding, deleting, and viewing scheduled events
- An optional additional web view so the scheduled events list can be available on the website
- The ability to "RSVP" to events, which then sends you a notification when the event starts
- The option for staff-level events to have an automatic event-start announcement
- Several optional settings to set permissions levels and customize event creation

#### Motivation for adding to Evennia
The idea has been floating around the Discord for a while, but someone was wishing for it again recently and I felt, well, motivated.

#### Additional Notes
I use `python-dateutils` in this, so I added the dependency to the pyproject.toml file in the extras section.