### PR TITLE
Fixes BASE_CHARACTER_CLASS to BASE_CHARACTER_TYPECLASS

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Characters.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Characters.md
@@ -293,7 +293,7 @@ the `Character` class in `mygame/typeclasses/characters.py`).
 
 There are thus two ways to weave your new Character class into Evennia: 
 
-1. Change `mygame/server/conf/settings.py` and add `BASE_CHARACTER_CLASS = "evadventure.characters.EvAdventureCharacter"`.
+1. Change `mygame/server/conf/settings.py` and add `BASE_CHARACTER_TYPECLASS = "evadventure.characters.EvAdventureCharacter"`.
 2. Or, change `typeclasses.characters.Character` to inherit from `EvAdventureCharacter`. 
 
 You must always reload the server for changes like this to take effect.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

I noticed that one of the variable names in the documentation wasn't correct. It was `BASE_CHARACTER_CLASS` but should be `BASE_CHARACTER_TYPECLASS`

#### Motivation for adding to Evennia

Cos it's kewl

#### Other info (issues closed, discussion etc)

I searched the codebase for `BASE_CHARACTER_CLASS` and this was the only instance.