### PR TITLE
[Components] Fix class components with inherited typeclasses

### DIFF
--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -36,9 +36,11 @@ class ComponentProperty:
         raise Exception("Cannot set a class property")
 
     def __set_name__(self, owner, name):
-        class_components = getattr(owner, "_class_components", None)
+        # Retrieve the class_components set on the direct class only
+        class_components = owner.__dict__.get("_class_components")
         if not class_components:
-            class_components = []
+            # Create a new list, including inherited class components
+            class_components = list(getattr(owner, "_class_components", []))
             setattr(owner, "_class_components", class_components)
 
         class_components.append((self.component_name, self.values))

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -42,12 +42,24 @@ class CharacterWithComponents(ComponentHolderMixin, DefaultCharacter):
     test_b = ComponentProperty("test_b", my_int=3, my_list=[1, 2, 3])
 
 
+class InheritedTCWithComponents(CharacterWithComponents):
+    test_c = ComponentProperty("test_c")
+
+
 class TestComponents(EvenniaTest):
     character_typeclass = CharacterWithComponents
 
     def test_character_has_class_components(self):
         assert self.char1.test_a
         assert self.char1.test_b
+
+    def test_inherited_typeclass_does_not_include_child_class_components(self):
+        char_with_c = create.create_object(
+            InheritedTCWithComponents, key="char_with_c", location=self.room1, home=self.room1
+        )
+        assert self.char1.test_a
+        assert not self.char1.cmp.get('test_c')
+        assert char_with_c.test_c
 
     def test_character_instances_components_properly(self):
         assert isinstance(self.char1.test_a, ComponentTestA)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This prevents a child typeclass to add its own class components to its parent typeclass

#### Motivation for adding to Evennia
Bugfix

#### Other info (issues closed, discussion etc)

Related to ComponentProperties
