### PR TITLE
Fix Django ID cache not being flushed in EvenniaTestCase

### DIFF
--- a/docs/source/Coding/Unit-Testing.md
+++ b/docs/source/Coding/Unit-Testing.md
@@ -106,7 +106,7 @@ To test this, run
 
 to run the entire test module
 
-    evennia test --settings setings.py world.tests
+    evennia test --settings settings.py world.tests
 
 or a specific class:
 

--- a/evennia/utils/test_resources.py
+++ b/evennia/utils/test_resources.py
@@ -558,9 +558,19 @@ class EvenniaTestCase(TestCase):
     """
     For use with gamedir settings; Just like the normal test case, only for naming consistency.
 
+    Notes:
+
+    -   Inheriting from this class will bypass EvenniaTestMixin, and therefore
+        not setup some default objects. This can result in faster tests.
+
+    -   If you do inherit from this class for your unit tests, and have
+        overridden the tearDown() method, please also call flush_cache(). Not
+        doing so will result in flakey and order-dependent tests due to the
+        Django ID cache not being flushed.
     """
 
-    pass
+    def tearDown(self) -> None:
+        flush_cache()
 
 
 @override_settings(**DEFAULT_SETTINGS)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`EvenniaTest` is quite heavy-handed and creates a lot of objects you may not need per test. This makes tests run slower than necessary.

However, `EvenniaTestCase` is insufficient for testing because it does not automatically clear the Django ID cache on test teardown. This can lead to strange and flakey test failures.

#### Motivation for adding to Evennia

Fixes some unpredictable test failures when inheriting from `EvenniaTestCase`.

#### Other info (issues closed, discussion etc)

None - was just something I noticed in my own project.