### PR TITLE
Building Command Hook Improvements

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -203,7 +203,7 @@ class ObjManipCommand(COMMAND_DEFAULT_CLASS):
 
         try:
             type_class = (
-                class_from_module(found_typeclass)
+                class_from_module(found_typeclass, settings.TYPECLASS_PATHS)
                 if isinstance(found_typeclass, str)
                 else found_typeclass
             )

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -605,6 +605,9 @@ class CmdCreate(ObjManipCommand):
             # create object (if not a valid typeclass, the default
             # object typeclass will automatically be used)
             lockstring = self.new_obj_lockstring.format(id=caller.id)
+            if (err := caller.can_build_object()):
+                caller.msg(err)
+                return
             obj = create.create_object(
                 typeclass,
                 name,
@@ -616,6 +619,7 @@ class CmdCreate(ObjManipCommand):
             )
             if not obj:
                 continue
+            obj.at_object_constructed(caller)
             if aliases:
                 string = (
                     f"You create a new {obj.typename}: {obj.name} (aliases: {', '.join(aliases)})."
@@ -929,6 +933,9 @@ class CmdDig(ObjManipCommand):
             typeclass = settings.BASE_ROOM_TYPECLASS
 
         # create room
+        if (err := caller.can_build_object()):
+            caller.msg(err)
+            return
         new_room = create.create_object(
             typeclass, room["name"], aliases=room["aliases"], report_to=caller
         )
@@ -937,6 +944,7 @@ class CmdDig(ObjManipCommand):
         alias_string = ""
         if new_room.aliases.all():
             alias_string = " (%s)" % ", ".join(new_room.aliases.all())
+        new_room.at_object_constructed(caller)
         room_string = (
             f"Created room {new_room}({new_room.dbref}){alias_string} of type {typeclass}."
         )
@@ -957,7 +965,9 @@ class CmdDig(ObjManipCommand):
                 typeclass = to_exit["option"]
                 if not typeclass:
                     typeclass = settings.BASE_EXIT_TYPECLASS
-
+                if (err := caller.can_build_object()):
+                    caller.msg(err)
+                    return
                 new_to_exit = create.create_object(
                     typeclass,
                     to_exit["name"],
@@ -974,6 +984,7 @@ class CmdDig(ObjManipCommand):
                     f"\nCreated Exit from {location.name} to {new_room.name}:"
                     f" {new_to_exit}({new_to_exit.dbref}){alias_string}."
                 )
+                new_to_exit.at_object_constructed(caller)
 
         # Create exit back from new room
 
@@ -988,6 +999,9 @@ class CmdDig(ObjManipCommand):
                 typeclass = back_exit["option"]
                 if not typeclass:
                     typeclass = settings.BASE_EXIT_TYPECLASS
+                if (err := caller.can_build_object()):
+                    caller.msg(err)
+                    return
                 new_back_exit = create.create_object(
                     typeclass,
                     back_exit["name"],
@@ -1004,6 +1018,7 @@ class CmdDig(ObjManipCommand):
                     f"\nCreated Exit back from {new_room.name} to {location.name}:"
                     f" {new_back_exit}({new_back_exit.dbref}){alias_string}."
                 )
+                new_back_exit.at_object_constructed(caller)
         caller.msg(f"{room_string}{exit_to_string}{exit_back_string}")
         if new_room and "teleport" in self.switches:
             caller.move_to(new_room, move_type="teleport")
@@ -1477,6 +1492,9 @@ class CmdOpen(ObjManipCommand):
             lockstring = self.new_obj_lockstring.format(id=caller.id)
             if not typeclass:
                 typeclass = settings.BASE_EXIT_TYPECLASS
+            if (err := caller.can_build_object()):
+                caller.msg(err)
+                return
             exit_obj = create.create_object(
                 typeclass,
                 key=exit_name,
@@ -1497,6 +1515,7 @@ class CmdOpen(ObjManipCommand):
                     f"Created new Exit '{exit_name}' from {location.name} to"
                     f" {destination.name}{string}."
                 )
+                exit_obj.at_object_constructed(caller)
             else:
                 string = f"Error: Exit '{exit.name}' not created."
         # emit results

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -725,16 +725,17 @@ class TestAccount(BaseEvenniaCommandTest):
 
 class TestBuilding(BaseEvenniaCommandTest):
     def test_create(self):
-        name = settings.BASE_OBJECT_TYPECLASS.rsplit(".", 1)[1]
+        typeclass = settings.BASE_OBJECT_TYPECLASS
+        name = typeclass.rsplit(".", 1)[1]
         self.call(
             building.CmdCreate(),
-            "/d TestObj1",  # /d switch is abbreviated form of /drop
+            f"/d TestObj1:{typeclass}",  # /d switch is abbreviated form of /drop
             "You create a new %s: TestObj1." % name,
         )
         self.call(building.CmdCreate(), "", "Usage: ")
         self.call(
             building.CmdCreate(),
-            "TestObj1;foo;bar",
+            f"TestObj1;foo;bar:{typeclass}",
             "You create a new %s: TestObj1 (aliases: foo, bar)." % name,
         )
 
@@ -2082,7 +2083,7 @@ class TestBatchProcess(BaseEvenniaCommandTest):
         # cannot test batchcode here, it must run inside the server process
         self.call(
             batchprocess.CmdBatchCommands(),
-            "batchprocessor.example_batch_cmds",
+            "batchprocessor.example_batch_cmds_test",
             "Running Batch-command processor - Automatic mode for"
             " batchprocessor.example_batch_cmds",
         )

--- a/evennia/contrib/tutorials/batchprocessor/example_batch_cmds_test.ev
+++ b/evennia/contrib/tutorials/batchprocessor/example_batch_cmds_test.ev
@@ -1,0 +1,36 @@
+#
+# This is an example batch build file for Evennia.
+#
+# This version is stripped down to work better with the test system.
+# It avoids teleporting the button. For the full version look at the
+# other example_batch_cmds.ev file.
+
+# This creates a red button
+
+create/drop button:red_button.RedButton
+
+# This comment ends input for @create
+# Next command:
+
+set button/desc =
+  This is a large red button. Now and then
+  it flashes in an evil, yet strangely tantalizing way.
+
+  A big sign sits next to it. It says:
+
+
+-----------
+
+ Press me!
+
+-----------
+
+
+  ... It really begs to be pressed, doesn't it? You
+know you want to!
+
+# This ends the @set command. Note that line breaks and extra spaces
+# in the argument are not considered. A completely empty line
+# translates to a \n newline in the command; two empty lines will thus
+# create a new paragraph. (note that few commands support it though, you
+# mainly want to use it for descriptions).

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1598,6 +1598,38 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         pass
 
+    def can_build_object(self):
+        """
+        This hook is called by the build command to determine if
+        self can build a new object. This is called before the
+        object is created. As it receives no arguments, it
+        can only be used to determine if self is allowed to build
+        anything in the current context.
+
+        For instance, a room may want to limit its number of exits,
+        or the builder might have an enforced quota limit for rooms
+        they can add to their custom dungeon.
+
+        Returns:
+            can_build (str or None): If self is allowed to build objects.
+                return a string as the error if there is a problem. If
+                this returns True, the build will abort.
+        """
+        pass
+
+    def at_object_constructed(self, builder):
+        """
+        Called when the object is constructed by a builder.
+        This is used to implement custom logic for building,
+        such as quota tracking systems, auto-tagging of rooms,
+        creation of logical groups of rooms like Zones or
+        dungeons, etc.
+
+        Args:
+            builder (Object): The object that constructed this object.
+        """
+        pass
+
     def at_pre_puppet(self, account, session=None, **kwargs):
         """
         Called just before an Account connects to this object to puppet
@@ -1663,6 +1695,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         """
         pass
+
 
     def at_server_reload(self):
         """

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -222,14 +222,6 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 {exits}{characters}{things}
 {footer}
     """
-
-    default_typeclasses = {
-        "object": settings.BASE_OBJECT_TYPECLASS,
-        "character": settings.BASE_CHARACTER_TYPECLASS,
-        "room": settings.BASE_ROOM_TYPECLASS,
-        "exit": settings.BASE_EXIT_TYPECLASS,
-    }
-
     # on-object properties
 
     @lazy_property
@@ -272,9 +264,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         """
         return (
-                self.db_account
-                and self.db_account.is_superuser
-                and not self.db_account.attributes.get("_quell")
+            self.db_account
+            and self.db_account.is_superuser
+            and not self.db_account.attributes.get("_quell")
         )
 
     def contents_get(self, exclude=None, content_type=None):
@@ -320,22 +312,22 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
     # main methods
 
     def search(
-            self,
-            searchdata,
-            global_search=False,
-            use_nicks=True,
-            typeclass=None,
-            location=None,
-            attribute_name=None,
-            quiet=False,
-            exact=False,
-            candidates=None,
-            use_locks=True,
-            nofound_string=None,
-            multimatch_string=None,
-            use_dbref=None,
-            tags=None,
-            stacked=0,
+        self,
+        searchdata,
+        global_search=False,
+        use_nicks=True,
+        typeclass=None,
+        location=None,
+        attribute_name=None,
+        quiet=False,
+        exact=False,
+        candidates=None,
+        use_locks=True,
+        nofound_string=None,
+        multimatch_string=None,
+        use_dbref=None,
+        tags=None,
+        stacked=0,
     ):
         """
         Returns an Object matching a search string/condition
@@ -439,10 +431,10 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             )
 
         if global_search or (
-                is_string
-                and searchdata.startswith("#")
-                and len(searchdata) > 1
-                and searchdata[1:].isdigit()
+            is_string
+            and searchdata.startswith("#")
+            and len(searchdata) > 1
+            and searchdata[1:].isdigit()
         ):
             # only allow exact matching if searching the entire database
             # or unique #dbrefs
@@ -677,13 +669,13 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             func(obj, **kwargs)
 
     def msg_contents(
-            self,
-            text=None,
-            exclude=None,
-            from_obj=None,
-            mapping=None,
-            raise_funcparse_errors=False,
-            **kwargs,
+        self,
+        text=None,
+        exclude=None,
+        from_obj=None,
+        mapping=None,
+        raise_funcparse_errors=False,
+        **kwargs,
     ):
         """
         Emits a message to all objects inside this object.
@@ -796,15 +788,15 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             receiver.msg(text=(outmessage, outkwargs), from_obj=from_obj, **kwargs)
 
     def move_to(
-            self,
-            destination,
-            quiet=False,
-            emit_to_obj=None,
-            use_destination=True,
-            to_none=False,
-            move_hooks=True,
-            move_type="move",
-            **kwargs,
+        self,
+        destination,
+        quiet=False,
+        emit_to_obj=None,
+        use_destination=True,
+        to_none=False,
+        move_hooks=True,
+        move_type="move",
+        **kwargs,
     ):
         """
         Moves this object to a new location.
@@ -895,7 +887,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # check if source location lets us go
             try:
                 if source_location and not source_location.at_pre_object_leave(
-                        self, destination, **kwargs
+                    self, destination, **kwargs
                 ):
                     return False
             except Exception as err:
@@ -904,7 +896,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # check if destination accepts us
             try:
                 if destination and not destination.at_pre_object_receive(
-                        self, source_location, **kwargs
+                    self, source_location, **kwargs
                 ):
                     return False
             except Exception as err:
@@ -1020,8 +1012,14 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             obj.move_to(home, move_type="teleport")
 
     @classmethod
-    def create(cls, key: str, account: "DefaultAccount" = None, creator: "DefaultObject" = None, method: str = "create",
-               **kwargs):
+    def create(
+        cls,
+        key: str,
+        account: "DefaultAccount" = None,
+        caller: "DefaultObject" = None,
+        method: str = "create",
+        **kwargs,
+    ):
         """
         Creates a basic object with default parameters, unless otherwise
         specified or extended.
@@ -1034,7 +1032,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         Keyword Args:
             account (Account): Account to attribute this object to.
-            creator (DefaultObject): The object which is creating this one.
+            caller (DefaultObject): The object which is creating this one.
             description (str): Brief description for this object.
             ip (str): IP address of creator (for object auditing).
             method (str): The method of creation. Defaults to "create".
@@ -1185,7 +1183,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         return True
 
     def access(
-            self, accessing_obj, access_type="read", default=False, no_superuser_bypass=False, **kwargs
+        self, accessing_obj, access_type="read", default=False, no_superuser_bypass=False, **kwargs
     ):
         """
         Determines if another object has permission to access this object
@@ -1609,43 +1607,6 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         """
         pass
-
-    def get_object_typeclass(self, obj_type: str = "object", typeclass: str = None, method: str = "create", **kwargs) -> tuple[
-        typing.Optional["Builder"], list[str]]:
-        """
-        This hook is called by build commands to determine which typeclass to use for a specific purpose. For instance,
-        when using dig, the system can use this to autodetect which kind of Room typeclass to use based on where the
-        builder is currently located.
-
-        Note: Although intended to be used with typeclasses, as long as this hook returns a class with a create method,
-            which accepts the same API as DefaultObject.create(), build commands and other places should take it.
-
-        Args:
-            obj_type (str, optional): The type of object that is being created. Defaults to "object". Evennia provides
-                "room", "exit", and "character" by default, but this can be extended.
-            typeclass (str, optional): The typeclass that was requested by the player. Defaults to None.
-                Can also be an actual class.
-            method (str, optional): The method that is calling this hook. Defaults to "create". Others are "dig", "open",
-                "tunnel", etc.
-
-        Returns:
-            results_tuple (tuple[Optional[Builder], list[str]]): A tuple containing the typeclass to use and a list of
-                errors. (which might be empty.)
-        """
-
-        found_typeclass = typeclass or self.default_typeclasses.get(obj_type, None)
-        if not found_typeclass:
-            return None, [f"No typeclass found for object type '{obj_type}'."]
-
-        try:
-            type_class = class_from_module(found_typeclass) if isinstance(found_typeclass, str) else found_typeclass
-        except ImportError:
-            return None, [f"Typeclass '{found_typeclass}' could not be imported."]
-
-        if not hasattr(type_class, "create"):
-            return None, [f"Typeclass '{found_typeclass}' is not creatable."]
-
-        return type_class, []
 
     def at_pre_puppet(self, account, session=None, **kwargs):
         """
@@ -2128,8 +2089,8 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 obj
                 for obj in obj_list
                 if obj != looker
-                   and obj.access(looker, "view")
-                   and obj.access(looker, "search", default=True)
+                and obj.access(looker, "view")
+                and obj.access(looker, "search", default=True)
             ]
 
         return {
@@ -2386,13 +2347,13 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
     at_before_say = at_pre_say
 
     def at_say(
-            self,
-            message,
-            msg_self=None,
-            msg_location=None,
-            receivers=None,
-            msg_receivers=None,
-            **kwargs,
+        self,
+        message,
+        msg_self=None,
+        msg_location=None,
+        receivers=None,
+        msg_receivers=None,
+        **kwargs,
     ):
         """
         Display the actual say (or whisper) of self.
@@ -2768,6 +2729,7 @@ class DefaultCharacter(DefaultObject):
         if not self.sessions.count():
             # only remove this char from grid if no sessions control it anymore.
             if self.location:
+
                 def message(obj, from_obj):
                     obj.msg(
                         _("{name} has left the game{reason}.").format(
@@ -2829,8 +2791,14 @@ class DefaultRoom(DefaultObject):
     )
 
     @classmethod
-    def create(cls, key: str, account: "DefaultAccount" = None, creator: DefaultObject = None, method: str = "create",
-               **kwargs):
+    def create(
+        cls,
+        key: str,
+        account: "DefaultAccount" = None,
+        caller: DefaultObject = None,
+        method: str = "create",
+        **kwargs,
+    ):
         """
         Creates a basic Room with default parameters, unless otherwise
         specified or extended.
@@ -2844,7 +2812,7 @@ class DefaultRoom(DefaultObject):
             account (DefaultAccount, optional): Account to associate this Room with. If
                 given, it will be given specific control/edit permissions to this
                 object (along with normal Admin perms). If not given, default
-            creator (DefaultObject): The object which is creating this one.
+            caller (DefaultObject): The object which is creating this one.
             description (str): Brief description for this object.
             ip (str): IP address of creator (for object auditing).
             method (str): The method used to create the room. Defaults to "create".
@@ -3038,8 +3006,16 @@ class DefaultExit(DefaultObject):
     # Command hooks
 
     @classmethod
-    def create(cls, key: str, location: DefaultRoom = None, destination: DefaultRoom = None, account: "DefaultAccount" = None, creator: DefaultObject = None,
-               method: str = "create", **kwargs) -> tuple[typing.Optional["DefaultExit"], list[str]]:
+    def create(
+        cls,
+        key: str,
+        location: DefaultRoom = None,
+        destination: DefaultRoom = None,
+        account: "DefaultAccount" = None,
+        caller: DefaultObject = None,
+        method: str = "create",
+        **kwargs,
+    ) -> tuple[typing.Optional["DefaultExit"], list[str]]:
         """
         Creates a basic Exit with default parameters, unless otherwise
         specified or extended.
@@ -3053,7 +3029,7 @@ class DefaultExit(DefaultObject):
 
         Keyword Args:
             account (obj): Account to associate this Exit with.
-            creator (ObjectDB): the Object creating this Object.
+            caller (ObjectDB): the Object creating this Object.
             description (str): Brief description for this object.
             ip (str): IP address of creator (for object auditing).
             destination (Room): The room to which this exit should go.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
All locations in the default building commands which use create_object now call two additional hooks:
builder.can_build_object(), which can generate arbitrary errors if, for some reason, the builder CANNOT currently build that object,

and new_thing.at_object_construction(builder), which is called shortly after the object is created. As it's aware of who made it, it can check them for things like build modes, information about their current location or whatnot, and this can be used for auto-tagging, quota implementation, any number of things.

#### Motivation for adding to Evennia
This will make building complex game grids easier and more powerful through easier implementation of complex building rules and logical grouping of created objects without needing to completely re-implement perfectly working build commands like Dig.

#### Other info (issues closed, discussion etc)
