### PR TITLE
Adding client-side flags for supporting TRUECOLOR and extending MTTS...

### DIFF
--- a/evennia/server/portal/ssh.py
+++ b/evennia/server/portal/ssh.py
@@ -127,6 +127,10 @@ class SshProtocol(Manhole, _BASE_SESSION_CLASS):
         self.width = width
         self.height = height
 
+        # Set color defaults
+        for color in ("ANSI", "XTERM256", "TRUECOLOR"):
+            self.protocol_flags[color] = True
+
         # initialize the session
         client_address = self.getClientAddress()
         client_address = client_address.host if client_address else None

--- a/evennia/server/portal/ttype.py
+++ b/evennia/server/portal/ttype.py
@@ -19,6 +19,10 @@ SEND = bytes([1])  # b"\x01"
 
 # terminal capabilities and their codes
 MTTS = [
+    (2048, "SSL"),
+    (1024, "MSLP"),
+    (512, "MNES"),
+    (256, "TRUECOLOR"),
     (128, "PROXY"),
     (64, "SCREENREADER"),
     (32, "OSC_COLOR_PALETTE"),

--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -131,6 +131,9 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
         self.protocol_flags["CLIENTNAME"] = f"Evennia Webclient (websocket{browserstr})"
         self.protocol_flags["UTF-8"] = True
         self.protocol_flags["OOB"] = True
+        self.protocol_flags["TRUECOLOR"] = True
+        self.protocol_flags["XTERM256"] = True
+        self.protocol_flags["ANSI"] = True
 
         # watch for dead links
         self.transport.setTcpKeepAlive(1)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

A few minor changes to the portal-side protocols so that they can detect TRUECOLOR support for the few clients that do support it, as well as the rest of the expanded MTTS options.

#### Motivation for adding to Evennia
Now the protocol_flags are more standardized for color detecting routines, and the Telnet protocol gathers more information from the client. We might not be USING that information just yet, but we're gathering it now.

#### Other info (issues closed, discussion etc)
It is assumed that the WebClient and SSH both support ANSI, XTERM256, and TRUECOLOR.
I am not sure if this is actually true, but it seems like a reasonable assumption.

Not that it will matter in the short term, since ANSIString isn't capable of generating truecolor codes (yet.)
