### PR TITLE
Changed importing of SESSION_HANDLER to avoid circular imports when e…

### DIFF
--- a/evennia/__init__.py
+++ b/evennia/__init__.py
@@ -136,7 +136,7 @@ __version__ = _create_version()
 del _create_version
 
 
-def _init():
+def _init(portal_mode=False):
     """
     This function is called automatically by the launcher only after
     Evennia has fully initialized all its models. It sets up the API
@@ -185,7 +185,6 @@ def _init():
     from .scripts.taskhandler import TASK_HANDLER
     from .scripts.tickerhandler import TICKER_HANDLER
     from .server import signals
-    from .server.sessionhandler import SESSION_HANDLER
     from .typeclasses.attributes import AttributeProperty
     from .typeclasses.tags import TagProperty
     from .utils import ansi, gametime, logger
@@ -219,6 +218,21 @@ def _init():
         search_script,
         search_tag,
     )
+
+    from .utils.utils import class_from_module
+    if portal_mode:
+        # Set up the PortalSessionHandler
+        from evennia.server.portal import portalsessionhandler
+        portal_sess_handler_class = class_from_module(settings.PORTAL_SESSION_HANDLER_CLASS)
+        portalsessionhandler.PORTAL_SESSIONS = portal_sess_handler_class()
+    else:
+        # Create the ServerSesssionHandler
+        from evennia.server import sessionhandler
+        sess_handler_class = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
+        sessionhandler.SESSIONS = sess_handler_class()
+        sessionhandler.SESSION_HANDLER = sessionhandler.SESSIONS
+        SESSION_HANDLER = sessionhandler.SESSIONS
+
 
     # API containers
 

--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -20,6 +20,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
+import evennia
 from evennia.accounts.manager import AccountManager
 from evennia.accounts.models import AccountDB
 from evennia.commands.cmdsethandler import CmdSetHandler
@@ -40,8 +41,6 @@ from evennia.utils.optionhandler import OptionHandler
 from evennia.utils.utils import is_iter, lazy_property, make_iter, to_str, variable_from_module
 
 __all__ = ("DefaultAccount", "DefaultGuest")
-
-_SESSIONS = None
 
 _AT_SEARCH_RESULT = variable_from_module(*settings.SEARCH_AT_RESULT.rsplit(".", 1))
 _MULTISESSION_MODE = settings.MULTISESSION_MODE
@@ -95,13 +94,10 @@ class AccountSessionHandler(object):
                 is given, this is a list with one (or zero) elements.
 
         """
-        global _SESSIONS
-        if not _SESSIONS:
-            from evennia.server.sessionhandler import SESSIONS as _SESSIONS
         if sessid:
-            return make_iter(_SESSIONS.session_from_account(self.account, sessid))
+            return make_iter(evennia.SESSION_HANDLER.session_from_account(self.account, sessid))
         else:
-            return _SESSIONS.sessions_from_account(self.account)
+            return evennia.SESSION_HANDLER.sessions_from_account(self.account)
 
     def all(self):
         """
@@ -284,10 +280,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             reason (str, optional): Eventual reason for the disconnect.
 
         """
-        global _SESSIONS
-        if not _SESSIONS:
-            from evennia.server.sessionhandler import SESSIONS as _SESSIONS
-        _SESSIONS.disconnect(session, reason)
+        evennia.SESSION_HANDLER.disconnect(session, reason)
 
     # puppeting operations
 

--- a/evennia/accounts/tests.py
+++ b/evennia/accounts/tests.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from django.test import override_settings
 from mock import MagicMock, Mock, patch
 
+import evennia
 from evennia.accounts.accounts import (
     AccountSessionHandler,
     DefaultAccount,
@@ -37,22 +38,20 @@ class TestAccountSessionHandler(TestCase):
         self.assertEqual(self.handler.get(), [])
         self.assertEqual(self.handler.get(100), [])
 
-        import evennia.server.sessionhandler
-
         s1 = MagicMock()
         s1.logged_in = True
         s1.uid = self.account.uid
-        evennia.server.sessionhandler.SESSIONS[s1.uid] = s1
+        evennia.SESSION_HANDLER[s1.uid] = s1
 
         s2 = MagicMock()
         s2.logged_in = True
         s2.uid = self.account.uid + 1
-        evennia.server.sessionhandler.SESSIONS[s2.uid] = s2
+        evennia.SESSION_HANDLER[s2.uid] = s2
 
         s3 = MagicMock()
         s3.logged_in = False
         s3.uid = self.account.uid + 2
-        evennia.server.sessionhandler.SESSIONS[s3.uid] = s3
+        evennia.SESSION_HANDLER[s3.uid] = s3
 
         self.assertEqual([s.uid for s in self.handler.get()], [s1.uid])
         self.assertEqual([s.uid for s in [self.handler.get(self.account.uid)]], [s1.uid])
@@ -251,8 +250,6 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_already_puppeting(self):
         "Check puppet_object method called, already puppeting this"
 
-        import evennia.server.sessionhandler
-
         account = create.create_account(
             f"TestAccount{randint(0, 999999)}",
             email="test@test.com",
@@ -260,7 +257,7 @@ class TestDefaultAccount(TestCase):
             typeclass=DefaultAccount,
         )
         self.s1.uid = account.uid
-        evennia.server.sessionhandler.SESSIONS[self.s1.uid] = self.s1
+        evennia.SESSION_HANDLER[self.s1.uid] = self.s1
 
         self.s1.logged_in = True
         self.s1.data_out = Mock(return_value=None)
@@ -276,8 +273,6 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_no_permission(self):
         "Check puppet_object method called, no permission"
 
-        import evennia.server.sessionhandler
-
         account = create.create_account(
             f"TestAccount{randint(0, 999999)}",
             email="test@test.com",
@@ -285,7 +280,7 @@ class TestDefaultAccount(TestCase):
             typeclass=DefaultAccount,
         )
         self.s1.uid = account.uid
-        evennia.server.sessionhandler.SESSIONS[self.s1.uid] = self.s1
+        evennia.SESSION_HANDLER[self.s1.uid] = self.s1
 
         self.s1.data_out = MagicMock()
         obj = Mock()
@@ -302,8 +297,6 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_joining_other_session(self):
         "Check puppet_object method called, joining other session"
 
-        import evennia.server.sessionhandler
-
         account = create.create_account(
             f"TestAccount{randint(0, 999999)}",
             email="test@test.com",
@@ -311,7 +304,7 @@ class TestDefaultAccount(TestCase):
             typeclass=DefaultAccount,
         )
         self.s1.uid = account.uid
-        evennia.server.sessionhandler.SESSIONS[self.s1.uid] = self.s1
+        evennia.SESSION_HANDLER[self.s1.uid] = self.s1
 
         self.s1.puppet = None
         self.s1.logged_in = True
@@ -332,8 +325,6 @@ class TestDefaultAccount(TestCase):
     def test_puppet_object_already_puppeted(self):
         "Check puppet_object method called, already puppeted"
 
-        import evennia.server.sessionhandler
-
         account = create.create_account(
             f"TestAccount{randint(0, 999999)}",
             email="test@test.com",
@@ -342,7 +333,7 @@ class TestDefaultAccount(TestCase):
         )
         self.account = account
         self.s1.uid = account.uid
-        evennia.server.sessionhandler.SESSIONS[self.s1.uid] = self.s1
+        evennia.SESSION_HANDLER[self.s1.uid] = self.s1
 
         self.s1.puppet = None
         self.s1.logged_in = True
@@ -410,7 +401,7 @@ class TestDefaultAccountEv(BaseEvenniaTest):
 
         # test no sessions
         with patch(
-            "evennia.accounts.accounts._SESSIONS.sessions_from_account", return_value=[]
+            "evennia.SESSION_HANDLER.sessions_from_account", return_value=[]
         ) as mock_sessh:
             idle = self.account.idle_time
             self.assertEqual(idle, None)
@@ -423,7 +414,7 @@ class TestDefaultAccountEv(BaseEvenniaTest):
 
         # test no sessions
         with patch(
-            "evennia.accounts.accounts._SESSIONS.sessions_from_account", return_value=[]
+            "evennia.SESSION_HANDLER.sessions_from_account", return_value=[]
         ) as mock_sessh:
             idle = self.account.connection_time
             self.assertEqual(idle, None)

--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -22,7 +22,7 @@ import time
 from codecs import lookup as codecs_lookup
 
 from django.conf import settings
-from evennia.server.sessionhandler import SESSIONS
+import evennia
 from evennia.utils import create, logger, search, utils
 
 COMMAND_DEFAULT_CLASS = utils.class_from_module(settings.COMMAND_DEFAULT_CLASS)
@@ -495,9 +495,8 @@ class CmdWho(COMMAND_DEFAULT_CLASS):
         """
         Get all connected accounts by polling session.
         """
-
         account = self.account
-        session_list = SESSIONS.get_sessions()
+        session_list = evennia.SESSION_HANDLER.get_sessions()
 
         session_list = sorted(session_list, key=lambda o: o.account.key)
 
@@ -508,7 +507,7 @@ class CmdWho(COMMAND_DEFAULT_CLASS):
                 "Admins"
             )
 
-        naccounts = SESSIONS.account_count()
+        naccounts = evennia.SESSION_HANDLER.account_count()
         if show_session_data:
             # privileged info
             table = self.styled_table(

--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -10,7 +10,8 @@ import time
 from django.conf import settings
 
 from evennia.server.models import ServerConfig
-from evennia.server.sessionhandler import SESSIONS
+
+import evennia
 from evennia.utils import class_from_module, evtable, logger, search
 
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
@@ -68,7 +69,7 @@ class CmdBoot(COMMAND_DEFAULT_CLASS):
 
         if "sid" in self.switches:
             # Boot a particular session id.
-            sessions = SESSIONS.get_sessions(True)
+            sessions = evennia.SESSION_HANDLER.get_sessions(True)
             for sess in sessions:
                 # Find the session with the matching session id.
                 if sess.sessid == int(args):
@@ -85,7 +86,7 @@ class CmdBoot(COMMAND_DEFAULT_CLASS):
                 caller.msg(f"You don't have the permission to boot {pobj.key}.")
                 return
             # we have a bootable object with a connected user
-            matches = SESSIONS.sessions_from_account(pobj)
+            matches = evennia.SESSION_HANDLER.sessions_from_account(pobj)
             for match in matches:
                 boot_list.append(match)
 
@@ -564,7 +565,7 @@ class CmdWall(COMMAND_DEFAULT_CLASS):
             return
         message = f'{self.caller.name} shouts "{self.args}"'
         self.msg("Announcing to all connected sessions ...")
-        SESSIONS.announce_all(message)
+        evennia.SESSION_HANDLER.announce_all(message)
 
 
 class CmdForce(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -16,9 +16,9 @@ import django
 import twisted
 from django.conf import settings
 
+import evennia
 from evennia.accounts.models import AccountDB
 from evennia.scripts.taskhandler import TaskHandlerTask
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import gametime, logger, search, utils
 from evennia.utils.eveditor import EvEditor
 from evennia.utils.evmenu import ask_yes_no
@@ -74,8 +74,8 @@ class CmdReload(COMMAND_DEFAULT_CLASS):
         if self.args:
             reason = "(Reason: %s) " % self.args.rstrip(".")
         if _BROADCAST_SERVER_RESTART_MESSAGES:
-            SESSIONS.announce_all(f" Server restart initiated {reason}...")
-        SESSIONS.portal_restart_server()
+            evennia.SESSION_HANDLER.announce_all(f" Server restart initiated {reason}...")
+        evennia.SESSION_HANDLER.portal_restart_server()
 
 
 class CmdReset(COMMAND_DEFAULT_CLASS):
@@ -108,8 +108,8 @@ class CmdReset(COMMAND_DEFAULT_CLASS):
         """
         Reload the system.
         """
-        SESSIONS.announce_all(" Server resetting/restarting ...")
-        SESSIONS.portal_reset_server()
+        evennia.SESSION_HANDLER.announce_all(" Server resetting/restarting ...")
+        evennia.SESSION_HANDLER.portal_reset_server()
 
 
 class CmdShutdown(COMMAND_DEFAULT_CLASS):
@@ -137,8 +137,8 @@ class CmdShutdown(COMMAND_DEFAULT_CLASS):
         if self.args:
             announcement += "%s\n" % self.args
         logger.log_info(f"Server shutdown by {self.caller.name}.")
-        SESSIONS.announce_all(announcement)
-        SESSIONS.portal_shutdown()
+        evennia.SESSION_HANDLER.announce_all(announcement)
+        evennia.SESSION_HANDLER.portal_shutdown()
 
 
 def _py_load(caller):
@@ -562,7 +562,7 @@ class CmdService(COMMAND_DEFAULT_CLASS):
             return
 
         # get all services
-        service_collection = SESSIONS.server.services
+        service_collection = evennia.SESSION_HANDLER.server.services
 
         if not switches or switches[0] == "list":
             # Just display the list of installed services and their

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, Mock, patch
 from anything import Anything
 from django.conf import settings
 from django.test import override_settings
+import evennia
 from evennia import (
     DefaultCharacter,
     DefaultExit,
@@ -34,7 +35,6 @@ from evennia.commands.default import syscommands, system, unloggedin
 from evennia.commands.default.cmdset_character import CharacterCmdSet
 from evennia.commands.default.muxcommand import MuxCommand
 from evennia.prototypes import prototypes as protlib
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import create, gametime, utils
 from evennia.utils.test_resources import BaseEvenniaCommandTest  # noqa
 from evennia.utils.test_resources import BaseEvenniaTest, EvenniaCommandTest
@@ -2113,7 +2113,7 @@ class TestUnconnectedCommand(BaseEvenniaCommandTest):
             % (
                 settings.SERVERNAME,
                 datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime(),
-                SESSIONS.account_count(),
+                evennia.SESSION_HANDLER.account_count(),
                 utils.get_evennia_version(),
             )
         )

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -8,9 +8,9 @@ from codecs import lookup as codecs_lookup
 
 from django.conf import settings
 
+import evennia
 from evennia.commands.cmdhandler import CMD_LOGINSTART
 from evennia.comms.models import ChannelDB
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import class_from_module, create, gametime, logger, utils
 
 COMMAND_DEFAULT_CLASS = utils.class_from_module(settings.COMMAND_DEFAULT_CLASS)
@@ -462,7 +462,7 @@ class CmdUnconnectedInfo(COMMAND_DEFAULT_CLASS):
             % (
                 settings.SERVERNAME,
                 datetime.datetime.fromtimestamp(gametime.SERVER_START_TIME).ctime(),
-                SESSIONS.account_count(),
+                evennia.SESSION_HANDLER.account_count(),
                 utils.get_evennia_version(),
             )
         )

--- a/evennia/contrib/base_systems/godotwebsocket/webclient.py
+++ b/evennia/contrib/base_systems/godotwebsocket/webclient.py
@@ -12,7 +12,6 @@ from twisted.application import internet
 from evennia import settings
 from evennia.contrib.base_systems.godotwebsocket.text2bbcode import parse_to_bbcode
 from evennia.server.portal import webclient
-from evennia.server.portal.portalsessionhandler import PORTAL_SESSIONS
 from evennia.settings_default import LOCKDOWN_MODE
 
 
@@ -70,6 +69,7 @@ def start_plugin_services(portal):
     factory = GodotWebsocket()
     factory.noisy = False
     factory.protocol = GodotWebSocketClient
+    from evennia.server.portal.portalsessionhandler import PORTAL_SESSIONS
     factory.sessionhandler = PORTAL_SESSIONS
 
     interface = "127.0.0.1" if LOCKDOWN_MODE else settings.GODOT_CLIENT_WEBSOCKET_CLIENT_INTERFACE

--- a/evennia/contrib/utils/auditing/tests.py
+++ b/evennia/contrib/utils/auditing/tests.py
@@ -9,7 +9,7 @@ from anything import Anything
 from django.test import override_settings
 from mock import patch
 
-from evennia.server.sessionhandler import SESSIONS
+import evennia
 from evennia.utils.test_resources import BaseEvenniaTest
 
 from .server import AuditedServerSession
@@ -21,13 +21,13 @@ class AuditingTest(BaseEvenniaTest):
     def setup_session(self):
         """Overrides default one in EvenniaTest"""
         dummysession = AuditedServerSession()
-        dummysession.init_session("telnet", ("localhost", "testmode"), SESSIONS)
+        dummysession.init_session("telnet", ("localhost", "testmode"), evennia.SESSION_HANDLER)
         dummysession.sessid = 1
-        SESSIONS.portal_connect(
+        evennia.SESSION_HANDLER.portal_connect(
             dummysession.get_sync_data()
         )  # note that this creates a new Session!
-        session = SESSIONS.session_from_sessid(1)  # the real session
-        SESSIONS.login(session, self.account, testmode=True)
+        session = evennia.SESSION_HANDLER.session_from_sessid(1)  # the real session
+        evennia.SESSION_HANDLER.login(session, self.account, testmode=True)
         self.session = session
 
     @patch(

--- a/evennia/contrib/utils/fieldfill/fieldfill.py
+++ b/evennia/contrib/utils/fieldfill/fieldfill.py
@@ -138,9 +138,8 @@ Optional:
         object dbrefs). For boolean fields, return '0' or '1' to set
         the field to False or True.
 """
-
+import evennia
 from evennia import Command
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import delay, evmenu, evtable, list_to_string, logger
 
 
@@ -573,7 +572,7 @@ def verify_online_player(caller, value):
             made.
     """
     # Get a list of sessions
-    session_list = SESSIONS.get_sessions()
+    session_list = evennia.SESSION_HANDLER.get_sessions()
     char_list = []
     matched_character = None
 

--- a/evennia/contrib/utils/git_integration/git_integration.py
+++ b/evennia/contrib/utils/git_integration/git_integration.py
@@ -3,9 +3,9 @@ import datetime
 import git
 from django.conf import settings
 
+import evennia
 from evennia import CmdSet, InterruptCommand
 from evennia.commands.default.muxcommand import MuxCommand
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils.utils import list_to_string
 
 
@@ -147,10 +147,10 @@ class GitCommand(MuxCommand):
             caller.msg(self.get_branches())
         elif self.action == "checkout":
             if self.checkout():
-                SESSIONS.portal_restart_server()
+                evennia.SESSION_HANDLER.portal_restart_server()
         elif self.action == "pull":
             if self.pull():
-                SESSIONS.portal_restart_server()
+                evennia.SESSION_HANDLER.portal_restart_server()
         else:
             caller.msg("You can only git status, git branch, git checkout, or git pull.")
             return

--- a/evennia/server/game_index_client/client.py
+++ b/evennia/server/game_index_client/client.py
@@ -16,8 +16,8 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from zope.interface import implementer
 
+import evennia
 from evennia.accounts.models import AccountDB
-from evennia.server.sessionhandler import SESSIONS
 from evennia.utils import get_evennia_version, logger
 
 _EGI_HOST = "http://evennia-game-index.appspot.com"
@@ -98,7 +98,7 @@ class EvenniaGameIndexClient(object):
                 "telnet_port": egi_config.get("telnet_port", ""),
                 "web_client_url": egi_config.get("web_client_url", ""),
                 # Game stats
-                "connected_account_count": SESSIONS.account_count(),
+                "connected_account_count": evennia.SESSION_HANDLER.account_count(),
                 "total_account_count": AccountDB.objects.num_total_accounts() or 0,
                 # System info
                 "evennia_version": get_evennia_version(),

--- a/evennia/server/initial_setup.py
+++ b/evennia/server/initial_setup.py
@@ -12,6 +12,7 @@ import time
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+import evennia
 from evennia.accounts.models import AccountDB
 from evennia.server.models import ServerConfig
 from evennia.utils import create, logger
@@ -180,10 +181,9 @@ def reset_server():
 
     """
     ServerConfig.objects.conf("server_epoch", time.time())
-    from evennia.server.sessionhandler import SESSIONS
 
     logger.log_info("Initial setup complete. Restarting Server once.")
-    SESSIONS.portal_reset_server()
+    evennia.SESSION_HANDLER.portal_reset_server()
 
 
 def handle_setup(last_step=None):

--- a/evennia/server/portal/portal.py
+++ b/evennia/server/portal/portal.py
@@ -24,9 +24,9 @@ from django.db import connection
 
 import evennia
 
-evennia._init()
-
+evennia._init(portal_mode=True)
 from evennia.server.portal.portalsessionhandler import PORTAL_SESSIONS
+
 from evennia.server.webserver import EvenniaReverseProxyResource
 from evennia.utils import logger
 from evennia.utils.utils import (

--- a/evennia/server/portal/portalsessionhandler.py
+++ b/evennia/server/portal/portalsessionhandler.py
@@ -489,5 +489,5 @@ class PortalSessionHandler(SessionHandler):
                         log_trace()
 
 
-_PORTAL_SESSION_HANDLER_CLASS = class_from_module(settings.PORTAL_SESSION_HANDLER_CLASS)
-PORTAL_SESSIONS = _PORTAL_SESSION_HANDLER_CLASS()
+# This will be filled in when the portal boots.
+PORTAL_SESSIONS = None

--- a/evennia/server/server.py
+++ b/evennia/server/server.py
@@ -27,6 +27,8 @@ import evennia
 
 evennia._init()
 
+from evennia.server.sessionhandler import SESSIONS
+
 from django.conf import settings
 from django.db import connection
 from django.db.utils import OperationalError
@@ -35,9 +37,11 @@ from django.utils.translation import gettext as _
 from evennia.accounts.models import AccountDB
 from evennia.scripts.models import ScriptDB
 from evennia.server.models import ServerConfig
-from evennia.server.sessionhandler import SESSIONS
+
 from evennia.utils import logger
 from evennia.utils.utils import get_evennia_version, make_iter, mod_import
+
+
 
 _SA = object.__setattr__
 

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -874,9 +874,6 @@ class ServerSessionHandler(SessionHandler):
                     log_trace()
 
 
-# import class from settings
-_SESSION_HANDLER_CLASS = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
-
-# Instantiate class. These globals are used to provide singleton-like behavior.
-SESSION_HANDLER = _SESSION_HANDLER_CLASS()
-SESSIONS = SESSION_HANDLER  # legacy
+# These are filled in during server boot.
+SESSION_HANDLER = None
+SESSIONS = None  # legacy

--- a/evennia/utils/gametime.py
+++ b/evennia/utils/gametime.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.db.utils import OperationalError
 
+import evennia
 from evennia import DefaultScript
 from evennia.server.models import ServerConfig
 from evennia.utils.create import create_script
@@ -125,9 +126,8 @@ def portal_uptime():
     Returns:
         time (float): The uptime of the portal.
     """
-    from evennia.server.sessionhandler import SESSIONS
 
-    return time.time() - SESSIONS.portal_start_time
+    return time.time() - evennia.SESSION_HANDLER.portal_start_time
 
 
 def game_epoch():

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -34,6 +34,8 @@ from django.core.validators import validate_email as django_validate_email
 from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
+
+import evennia
 from evennia.utils import logger
 from simpleeval import simple_eval
 from twisted.internet import reactor, threads
@@ -1061,14 +1063,13 @@ def server_services():
         services (dict): A dict of available services.
 
     """
-    from evennia.server.sessionhandler import SESSIONS
 
-    if hasattr(SESSIONS, "server") and hasattr(SESSIONS.server, "services"):
-        server = SESSIONS.server.services.namedServices
+    if hasattr(evennia.SESSION_HANDLER, "server") and hasattr(evennia.SESSION_HANDLER.server, "services"):
+        server = evennia.SESSION_HANDLER.server.services.namedServices
     else:
         # This function must be called from inside the evennia process.
         server = {}
-    del SESSIONS
+    del evennia.SESSION_HANDLER
     return server
 
 

--- a/evennia/web/website/views/index.py
+++ b/evennia/web/website/views/index.py
@@ -6,7 +6,7 @@ The main index page, including the game stats
 from django.conf import settings
 from django.views.generic import TemplateView
 
-from evennia import SESSION_HANDLER
+import evennia
 from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from evennia.utils import class_from_module
@@ -25,7 +25,7 @@ def _gamestats():
     nplyrs_conn_recent = len(recent_users) or "none"
     nplyrs = AccountDB.objects.num_total_accounts() or "none"
     nplyrs_reg_recent = len(AccountDB.objects.get_recently_created_accounts()) or "none"
-    nsess = SESSION_HANDLER.account_count()
+    nsess = evennia.SESSION_HANDLER.account_count()
     # nsess = len(AccountDB.objects.get_connected_accounts()) or "no one"
 
     nobjs = ObjectDB.objects.count()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When trying to extend PortalSessionHandler or ServerSessionHandler it's easy to fall afoul of a circular import issue due to them attempting to instantiate when the module loads by pulling straight from settings. That has been changed so now evennia.SESSION_HANDLER is referred to for the active session handler instead of a weird import to a module variable that might be none.

#### Motivation for adding to Evennia
While attempting to create my own PortalSessionHandler, I ran into a circular import issue related to how I was trying to inherit from the same .py module that wants to import the thing I'm inheriting to...

#### Other info (issues closed, discussion etc)
I had to make extensive changes to how things were reaching the session_handler to make this work. I think the result is cleaner and shouldn't be any less performant, though.