### PR TITLE
fixed a couple of spelling errors and missing py commands

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Making-A-Sittable-Object.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Making-A-Sittable-Object.md
@@ -2,7 +2,7 @@
 
 In this lesson we will make use of what we have learned to create a new game object: a chair you can sit on. 
 
-Out goals are:
+Our goals are:
 
 - We want a new 'sittable' object, a `Chair` in particular.
 - We want to be able to use a command to sit in the chair.
@@ -185,7 +185,7 @@ class Sittable(DefaultObject):
             stander.msg(f"You stand up from {self.key}")
 ```
 
-- **Line 15**: We grab the `adjective` Attribute. Using `seld.db.adjective or "on"` here means that if the Attribute is not set (is `None`/falsy) the default "on" string will be assumed.
+- **Line 15**: We grab the `adjective` Attribute. Using `self.db.adjective or "on"` here means that if the Attribute is not set (is `None`/falsy) the default "on" string will be assumed.
 - **Lines 22 and 43**: We use this adjective to modify the return text we see.  
 
 `reload`  the server. An advantage of using Attributes like this is that they can be modified on the fly, in-game. Let's look at a builder could use this by normal building commands (no need for `py`): 
@@ -210,6 +210,7 @@ What if we want some more dramatic flair when you sit down in certain chairs?
 You can make this happen by tweaking your `Sittable` class having the return messages be replaceable by `Attributes` that you can set on the object you create. You want something like this: 
 
 ```
+> py
 > chair = evennia.create_object("typeclasses.sittables.Sittable", key="pallet")
 > chair.do_sit(me)
 You sit down on pallet.

--- a/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-More-on-Commands.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-More-on-Commands.md
@@ -146,7 +146,7 @@ What we didn't mention  before is that by default those commands are _also avail
 
 To show how this could work, let's put our 'hit' Command on our simple `sword` object from the previous section.
 
-    > self.search("sword").cmdset.add("commands.mycommands.MyCmdSet", persistent=True)
+    > py self.search("sword").cmdset.add("commands.mycommands.MyCmdSet", persistent=True)
 
 We find the sword (it's still in our inventory so `self.search` should be able to find it), then
 add `MyCmdSet` to it. This actually adds both `hit` and `echo` to the sword, which is fine.
@@ -172,7 +172,7 @@ Woah, that didn't go as planned. Evennia actually found _two_ `hit` commands and
 
 In this case we don't need both command-sets, so let's just keep the one on the sword:
 
-    > self.cmdset.remove("commands.mycommands.MyCmdSet")
+    > py self.cmdset.remove("commands.mycommands.MyCmdSet")
     > hit
     Who do you want to hit?
 
@@ -197,7 +197,7 @@ The `hit` command is only available if you hold _or_ are in the same room as the
 Evennia Locks are defined as a mini-language defined in `lockstrings`. The lockstring is on a form `<situation>:<lockfuncs>`, where `situation` determines when this lock applies and the `lockfuncs` (there can be more than one) are run to determine if the lock-check passes or not depending on circumstance.
 ```
 
-Let's get a little ahead of ourselves and make it so you have to _hold_ the sword for the `hit` command to be available. This involves a [Lock](../../../Components/Locks.md). We've cover locks in more detail later, just know that they are useful for limiting the kind of things you can do with an object, including limiting just when you can call commands on it.
+Let's get a little ahead of ourselves and make it so you have to _hold_ the sword for the `hit` command to be available. This involves a [Lock](../../../Components/Locks.md). We'll cover locks in more detail later, just know that they are useful for limiting the kind of things you can do with an object, including limiting just when you can call commands on it.
 
     > py self.search("sword").locks.add("call:holds()")
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Fixed a couple of spelling errors
- Missing the `py` prefix command before a couple of commands
- Added the `py` command to enter so the next commands will work fine.

#### Motivation for adding to Evennia
Going through the docs again. :smile: 

#### Other info (issues closed, discussion etc)
