### PR TITLE
Remove obsolete Windows install note

### DIFF
--- a/docs/source/Setup/Installation.md
+++ b/docs/source/Setup/Installation.md
@@ -14,7 +14,6 @@ Installing Evennia doesn't make anything visible online. Apart from installation
 ```
 - Evennia requires [Python](https://www.python.org/downloads/) 3.10 or 3.11 (recommended). Any OS that supports Python should work.
 	- _Windows_: In the installer, make sure you select `add python to path`.  If you have multiple versions of Python installed, use `py` command instead of `python` to have Windows automatically use the latest.
-	- _Windows:_ If you want to use Python 3.11, you must also install the [Windows SDK](https://aka.ms/vs/16/release/vs_buildtools.exe). Run the linked installer. Click the `Individual Components` tab at the top, then search and checkbox the latest `Windows 10 SDK` (also for older/newer Windows versions). Then click `Install`. If you have trouble, use Python 3.10 for now (2022).
 - Don't install Evennia as administrator or superuser. 
 - If you run into trouble, see [installation troubleshooting](./Installation-Troubleshooting.md).
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`twisted-iocpsupport` now has an updated pip package supporting python 3.11, so the build tools are no longer necessary. As such, I've removed the note about the SDK requirement.