### PR TITLE
Fixing Z location in xyzgrid teleport command

### DIFF
--- a/evennia/contrib/grid/xyzgrid/commands.py
+++ b/evennia/contrib/grid/xyzgrid/commands.py
@@ -68,7 +68,7 @@ class CmdXYZTeleport(building.CmdTeleport):
         else:
             # use current location's Z, if it exists
             try:
-                xyz = self.caller.xyz
+                xyz = self.caller.location.xyz
             except AttributeError:
                 self.caller.msg(
                     "Z-coordinate is also required since you are not currently "


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I noticed on the xyzgrid tutorial (https://www.evennia.com/docs/latest/Contribs/Contrib-XYZGrid.html?highlight=xyzgrid#installation) you can teleport using the z-coordinate, such as, "teleport (3,0,the large tree)", but once there on that map, you cannot teleport without the z-coordinate. For example, "teleport (4,1)".

The document says you should be able to teleport within the same map without a z-coordinate.

The error message, btw, is "Z-coordinate is also required since you are not currently in a room with a Z coordinate of its own."

#### Motivation for adding to Evennia

As noted by CatDadKai, the self.caller.xyz was being called, but it should have been self.caller.location.xyz

#### Other info (issues closed, discussion etc)

I did not open an issue for this bug, since it is such a small fix.
