### PR TITLE
Broken links in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,16 @@
 
 There are many ways you can contribute to Evennia development:
 
- - You can help a lot by being active in the community. You can spread
+- You can help a lot by being active in the community. You can spread
    the word - by writing, talking, blogging etc about Evennia. Let
    others know text-based gaming is still a thing!
- - You can help by reporting any issues/bugs you find, and tell us of your
+- You can help by reporting any issues/bugs you find, and tell us of your
    feature requests [as an issue on github][issues]. This is also where you
    report typos or errors in the [the Evennia documentation][docs].
- - To help fixing (or expand) our docs, check out [how to contribute to docs][contribute-docs].
- - To contribute to Evennia itself, check out how to [help with code][helping-code].
+- To help fixing (or expand) our docs, check out [how to contribute to docs][contribute-docs].
+- To contribute to Evennia itself, check out how to [help with code][helping-code].
 
 [issues]: https://github.com/evennia/evennia/issues/new/choose
-[docs]: https://www.evennia.com/docs/1.0-dev/index.html
-[contribute-docs]: https://www.evennia.com/docs/1.0-dev/Contributing-Docs.html
-[helping-code]: https://www.evennia.com/docs/1.0-dev/Contributing.html#helping-with-code
+[docs]: https://www.evennia.com/docs/latest/index.html
+[contribute-docs]: https://www.evennia.com/docs/latest/Contributing-Docs.html
+[helping-code]: https://www.evennia.com/docs/latest/Contributing.html#helping-with-code


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The doc links pointed to a dev version that didn't seem to exist.
I changed it to `latest`.

I also changed the markdown for the list, so they don't have the unnecessary indents.
Super minor, not sure if this was intentionally. 
If it was intentionally, just let me know in comments and I will revert that.

#### Motivation for adding to Evennia

It's always nice if contributing.md is up to date :)

#### Other info (issues closed, discussion etc)
