### PR TITLE
Bug Fix: Autosub to all channels instead of just first

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -20,6 +20,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
+
 import evennia
 from evennia.accounts.manager import AccountManager
 from evennia.accounts.models import AccountDB
@@ -28,17 +29,16 @@ from evennia.comms.models import ChannelDB
 from evennia.objects.models import ObjectDB
 from evennia.scripts.scripthandler import ScriptHandler
 from evennia.server.models import ServerConfig
-from evennia.server.signals import (
-    SIGNAL_ACCOUNT_POST_CREATE,
-    SIGNAL_OBJECT_POST_PUPPET,
-    SIGNAL_OBJECT_POST_UNPUPPET,
-)
+from evennia.server.signals import (SIGNAL_ACCOUNT_POST_CREATE,
+                                    SIGNAL_OBJECT_POST_PUPPET,
+                                    SIGNAL_OBJECT_POST_UNPUPPET)
 from evennia.server.throttle import Throttle
 from evennia.typeclasses.attributes import ModelAttributeBackend, NickHandler
 from evennia.typeclasses.models import TypeclassBase
 from evennia.utils import class_from_module, create, logger
 from evennia.utils.optionhandler import OptionHandler
-from evennia.utils.utils import is_iter, lazy_property, make_iter, to_str, variable_from_module
+from evennia.utils.utils import (is_iter, lazy_property, make_iter, to_str,
+                                 variable_from_module)
 
 __all__ = ("DefaultAccount", "DefaultGuest")
 
@@ -855,11 +855,12 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                 account.db.creator_ip = ip
 
             # join the new account to the public channel
-            pchannel = ChannelDB.objects.get_channel(settings.DEFAULT_CHANNELS[0]["key"])
-            if not pchannel or not pchannel.connect(account):
-                string = "New account '{account.key}' could not connect to public channel!"
-                errors.append(string)
-                logger.log_err(string)
+            pchannels = ChannelDB.objects.get_all_channels()
+            for pchannel in pchannels:
+                if pchannel.access(account, "listen") and not pchannel.connect(account):
+                    string = f"New account '{account.key}' could not connect to {pchannel.key} channel!"
+                    errors.append(string)
+                    logger.log_err(string)
 
             if account and _AUTO_CREATE_CHARACTER_WITH_ACCOUNT:
                 # Auto-create a character to go with this account


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR resolves issue #3239. Original account implementation did not auto-sub accounts to default channels, only the very first one.

#### Motivation for adding to Evennia
Documentation and intuition would lead one to believe that all characters automatically sub to the channels listed in DEFAULT_CHANNELS

#### Other info (issues closed, discussion etc)
Imports were not changed. Linter made those changes.