### PR TITLE
Point to default settings on documentation site instead of evennia install

### DIFF
--- a/evennia/game_template/server/conf/settings.py
+++ b/evennia/game_template/server/conf/settings.py
@@ -4,7 +4,7 @@ Evennia settings file.
 The available options are found in the default settings file found
 here:
 
-{settings_default}
+https://www.evennia.com/docs/latest/Setup/Settings-Default.html
 
 Remember:
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the auto-generated `settings.py` docstring so it has a link to the Default Settings page of the documentation site.

The current settings file is generated with a line pointing to the location of the actual parent settings file on the computer you created the gamedir on. Since the recommended install method now is `pip` and it's discouraged to go digging around in the core library files, and since we have such a nice documentation website, that approach seems obsolete.