### PR TITLE
EvMenu Tooltip Functionality

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -911,7 +911,9 @@ class EvMenu:
 
         # validation of the node return values
 
-        # if the nodetext is a list/tuple, the second set is the help text.
+        # if the nodetext is a list/tuple, the second set is the help text. 
+        # helptext can also be a dict, which allows for tooltip command-text (key-value) pairs. 
+
         helptext = ""
         if is_iter(nodetext):
             nodetext, *helptext = nodetext
@@ -1084,6 +1086,8 @@ class EvMenu:
                 self.goto(goto_node, raw_string, **(goto_kwargs or {}))
             elif self.auto_look and cmd in ("look", "l"):
                 self.display_nodetext()
+            elif self.auto_help and isinstance(self.helptext, dict) and cmd in self.helptext:
+                self.display_tooltip(cmd)
             elif self.auto_help and cmd in ("help", "h"):
                 self.display_helptext()
             elif self.auto_quit and cmd in ("quit", "q", "exit"):
@@ -1105,6 +1109,9 @@ class EvMenu:
 
     def display_helptext(self):
         self.msg(self.helptext)
+    
+    def display_tooltip(self, cmd):
+        self.msg(self.helptext.get(cmd))
 
     # formatters - override in a child class
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
PR for feature request [#3244](https://github.com/evennia/evennia/issues/3244). 

#### Motivation for adding to Evennia
The purpose of this change is to optionally provide an EvMenu node with a dictionary that acts as tooltip-like entries for displaying text without having to jump nodes. Discussed in discord chat. 

#### Other info (issues closed, discussion etc)
With this fix, optional dictionary parsing happens in the evmenu `parse_input` function. I initially wrote the feature in the `goto` function (under the `is_iter(nodetext)` check) with a new, separate variable to hold the tooltip dict, but ended up opting for the solution which made the least amount of changes (the `goto` change required a new, duplicate formatter and more nested checks under the `is_iter(nodetext)` check). 

Evmenu tests currently don't seem to cover helptext. Is it needed for this change? 