### PR TITLE
Fix traceback on printing `CounterTrait`

### DIFF
--- a/evennia/contrib/rpg/traits/traits.py
+++ b/evennia/contrib/rpg/traits/traits.py
@@ -1282,6 +1282,12 @@ class CounterTrait(Trait):
             trait_data["last_update"] = None
         return trait_data
 
+    def __str__(self):
+        status = "{current:4} / {base:4}".format(current=self.current, base=self.base)
+        return "{name:12} {status} ({mod:+3}) (* {mult:.2f})".format(
+            name=self.name, status=status, mod=self.mod, mult=self.mult
+        )
+
     # Helpers
 
     def _within_boundaries(self, value):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The base `Trait` string conversion references a data value which the `CounterTrait` doesn't have, causing a traceback when printing a counter trait. This adds a `__str__` method to `CounterTrait` to correct that.

#### Motivation for adding to Evennia
Bug fixing