### PR TITLE
Only start GLOBAL_SCRIPTS in Server mode

### DIFF
--- a/evennia/__init__.py
+++ b/evennia/__init__.py
@@ -227,7 +227,6 @@ def _init(portal_mode=False):
     else:
         # Create the ServerSesssionHandler
         from evennia.server import sessionhandler
-
         sess_handler_class = class_from_module(settings.SERVER_SESSION_HANDLER_CLASS)
         sessionhandler.SESSIONS = sess_handler_class()
         sessionhandler.SESSION_HANDLER = sessionhandler.SESSIONS
@@ -378,7 +377,8 @@ def _init(portal_mode=False):
 
     # delayed starts - important so as to not back-access evennia before it has
     # finished initializing
-    GLOBAL_SCRIPTS.start()
+    if not portal_mode:
+        GLOBAL_SCRIPTS.start()
 
 
 def set_trace(term_size=(140, 80), debugger="auto"):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Scripts are only supposed to run in server mode however after recent changes, they start up in both server and portal.

#### Motivation for adding to Evennia
It's supposed to work like this.

#### Other info (issues closed, discussion etc)
Changes introduced in PR https://github.com/evennia/evennia/pull/3187