### PR TITLE
Fix nattributes typo

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1503,7 +1503,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 self.attributes.batch_add(*cdict["attributes"])
             if cdict.get("nattributes"):
                 # this should be a dict of nattrname:value
-                for key, value in cdict["nattributes"]:
+                for key, value in cdict["nattributes"].items():
                     self.nattributes.add(key, value)
 
             del self._createdict


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Missing `.items()` method causes a traceback when attempting to create objects with initial nattributes

#### Motivation for adding to Evennia
Bug fixing