### PR TITLE
added listener + logic to Webclient Save Layout button -  #2247

### DIFF
--- a/evennia/web/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/static/webclient/js/plugins/goldenlayout.js
@@ -4,8 +4,6 @@
  *
  */
 
-
-
 let goldenlayout = (function () {
 
     var myLayout; // The actively used GoldenLayout API object.
@@ -586,20 +584,18 @@ let goldenlayout = (function () {
         layoutDiv.append(div);
     }
 
-
     // Listener for realtime changes to the layout name input field.
     // If the layout name is "default", the save button is disabled
     // to prevent the perception of overwriting the default layout.
+
     $(document).on("input", "#layoutName", function () {
-        console.log("Input changed to:", $(this).val());
-        if ($(this).val() === "default") {
-            $(".savelayout").prop("disabled", true);
-        } else {
-            $(".savelayout").prop("disabled", false);
+        if ($(this).val() === "default") {              // Disable the save button if the name is "default"
+            $(".savelayout").prop("disabled", true);    // Disabling the save button
+        } else {                                        // Enable the save button if the name is not "default"
+           $(".savelayout").prop("disabled", false);    // Enabling the save button
         }
     });
 
-    //
     var onSaveLayout = function () {
         // get the name from the select box
         var name = $("#layoutName").val();
@@ -640,10 +636,6 @@ let goldenlayout = (function () {
             resetUI( evenniaGoldenLayouts.get(name) );
         }
     }
-
-
-
-
     //
     // Public
     //

--- a/evennia/web/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/static/webclient/js/plugins/goldenlayout.js
@@ -3,6 +3,9 @@
  * Golden Layout plugin
  *
  */
+
+
+
 let goldenlayout = (function () {
 
     var myLayout; // The actively used GoldenLayout API object.
@@ -584,12 +587,33 @@ let goldenlayout = (function () {
     }
 
 
-    //
+    // Listener for realtime changes to the layout name input field.
+    // If the layout name is "default", the save button is disabled
+    // to prevent the perception of overwriting the default layout.
+    $(document).on("input", "#layoutName", function () {
+        console.log("Input changed to:", $(this).val());
+        if ($(this).val() === "default") {
+            $(".savelayout").prop("disabled", true);
+        } else {
+            $(".savelayout").prop("disabled", false);
+        }
+    });
+
     //
     var onSaveLayout = function () {
         // get the name from the select box
         var name = $("#layoutName").val();
         var layouts = $("#goldenlayouts");
+        var saveButton = $(".savelayout"); // Using the class to select the button
+
+        // Enable the save button in case it was disabled before
+        saveButton.prop("disabled", false);
+
+        // Check if name is "default" and disable saving
+        if (name === "default") {
+            saveButton.prop("disabled", true); // Disabling the save button
+            return; // Prevent further execution of the function
+        }
 
         // make sure we have a valid name
         if( name !== "" ) {
@@ -616,6 +640,8 @@ let goldenlayout = (function () {
             resetUI( evenniaGoldenLayouts.get(name) );
         }
     }
+
+
 
 
     //


### PR DESCRIPTION
#2247 

**Brief overview of PR changes/additions**

- Introduced a jQuery listener on the #layoutName input field.
- Automatically disables the "Save" button (class .savelayout) if the input is exactly "default".
- Re-enables the "Save" button for other input values.
- This change ensures that users don't have the perception that they can overwrite the default layout.

**Motivation for adding to Evennia**

- I'm still learning the engine, but excited to contribute to the web site of things!

**Other info (issues closed, discussion etc)**

- This change was inspired by an observed behavior where users would often mistakenly try to save a new layout as "default".
- By disabling the button for this specific input, we add a subtle hint to the user about the importance of this default name and guide them towards choosing a different name.