### PR TITLE
docs(Adding-Commands): :bug: fix for lesson 8.1.2

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Adding-Commands.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Adding-Commands.md
@@ -262,7 +262,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
-        self.add(command.CmdEcho)    # <-----------
+        self.add(CmdEcho())    # <-----------
 
 # ... 
 ```


### PR DESCRIPTION
#### Brief overview of PR changes/additions
if we're already importing `CmdEcho` manually, we should just be able to remove the reference to command in the `self.add` and end it with `()`

#### Motivation for adding to Evennia
existing tutorial code throws runtime error

#### Other info (issues closed, discussion etc)
