### PR TITLE
Configurable Django Admin

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -1033,6 +1033,24 @@ MIDDLEWARE = [
     "evennia.web.utils.middleware.SharedLoginMiddleware",
 ]
 
+# A list of Django apps (see INSTALLED_APPS) that will be listed first (if present)
+# in the Django web Admin page.
+DJANGO_ADMIN_APP_ORDER = [
+        "accounts",
+        "objects",
+        "scripts",
+        "comms",
+        "help",
+        "typeclasses",
+        "server",
+        "sites",
+        "flatpages",
+        "auth",
+    ]
+
+# The following apps will be excluded from the Django web Admin page.
+DJANGO_ADMIN_APP_EXCLUDE = list()
+
 ######################################################################
 # Evennia components
 ######################################################################

--- a/evennia/web/utils/adminsite.py
+++ b/evennia/web/utils/adminsite.py
@@ -8,6 +8,7 @@ of that folder for Django to find them).
 
 """
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import apps
 
@@ -30,20 +31,11 @@ class EvenniaAdminSite(admin.AdminSite):
 
     site_header = "Evennia web admin"
 
-    app_order = [
-        "accounts",
-        "objects",
-        "scripts",
-        "comms",
-        "help",
-        "typeclasses",
-        "server",
-        "sites",
-        "flatpages",
-        "auth",
-    ]
-
-    def get_app_list(self, request):
-        app_list = super().get_app_list(request)
+    def get_app_list(self, request, app_label=None):
+        app_list = super().get_app_list(request, app_label=app_label)
         app_mapping = {app["app_label"]: app for app in app_list}
-        return [app_mapping.get(app_label) for app_label in self.app_order]
+        out = [app_mapping.pop(app_label) for app_label in settings.DJANGO_ADMIN_APP_ORDER if app_label in app_mapping]
+        for app in settings.DJANGO_ADMIN_APP_EXCLUDE:
+            app_mapping.pop(app, None)
+        out += app_mapping.values()
+        return out


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, the EvenniaAdminSite's get_all_apps method filters out any app which doesn't exist in its app_order listing.

This replaces that logic to allow settings.py to provide priority ordered listing to a selection of apps, and also to provide a list of apps which can be excluded from the listing.

Now it is possible to use the Django Admin properly for any added models.

#### Motivation for adding to Evennia
The Django Admin is currently filtering out access to models from various Django plugins/libraries like Django Wiki and Django Helpdesk, as well as any models I might create in my projects.

An extendable, more generic approach is far better.

#### Other info (issues closed, discussion etc)
The Django Admin site doesn't nicely categorize the displays of where models come from. I wish it displayed in categories like "Here are Evennia models", "Here are wiki models", "here are helpdesk models"...