### PR TITLE
Improve OptionHandler.set()

### DIFF
--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -1056,4 +1056,4 @@ class CmdStyle(COMMAND_DEFAULT_CLASS):
         except ValueError as e:
             self.msg(str(e))
             return
-        self.msg(f"Style {self.lhs} set to {result}")
+        self.msg(f"Style {result.key} set to {result.display()}")

--- a/evennia/utils/optionhandler.py
+++ b/evennia/utils/optionhandler.py
@@ -142,7 +142,7 @@ class OptionHandler:
         op_found = self.options.get(key) or self._load_option(key)
         return op_found if return_obj else op_found.value
 
-    def set(self, key, value, **kwargs):
+    def set(self, key, value, **kwargs) -> "BaseOption":
         """
         Change an individual option.
 
@@ -153,7 +153,8 @@ class OptionHandler:
                 save function and display function and allows to customize either.
 
         Returns:
-            value (any): Value stored in option, after validation.
+            BaseOption: The matched object. Its new value can be accessed with
+                op.value or op.display().
 
         """
         if not key:
@@ -168,7 +169,7 @@ class OptionHandler:
         match = match[0]
         op = self.get(match, return_obj=True)
         op.set(value, **kwargs)
-        return op.value
+        return op
 
     def all(self, return_objs=False):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Simply alters the output type of OptionHandler.set() so that it returns the BaseOption that was matched, allowing access to its methods and properties like .key and .display() by other systems.

#### Motivation for adding to Evennia
I'm implementing a lot of various things which use OptionHandler, and having access to what was .set() will help with output formatting considerably.

#### Other info (issues closed, discussion etc)
