### PR TITLE
Fixing output of BaseOption.display to always be str

### DIFF
--- a/evennia/utils/optionclasses.py
+++ b/evennia/utils/optionclasses.py
@@ -170,7 +170,7 @@ class BaseOption:
         """
         return validatorfuncs.text(value, option_key=self.key, **kwargs)
 
-    def display(self, **kwargs):
+    def display(self, **kwargs) -> str:
         """
         Renders the Option's value as something pretty to look at.
 
@@ -183,7 +183,7 @@ class BaseOption:
                 timedelta is pretty ugly).
 
         """
-        return self.value
+        return self.value if isinstance(self.value, str) else str(self.value)
 
 
 # Option classes


### PR DESCRIPTION
#### Brief overview of PR changes/additions
ensure that BaseOption.display() always returns a string.

#### Motivation for adding to Evennia
Turns out this wasn't actually minding its own API; sometimes it would return a number or some other value.

Not everything that wants to use it liked that...

#### Other info (issues closed, discussion etc)
