### PR TITLE
SIGNAL_ACCOUNT_POST_LOGIN_FAIL is now properly used. Added a CUSTOM_S…

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -33,6 +33,7 @@ from evennia.server.signals import (
     SIGNAL_ACCOUNT_POST_CREATE,
     SIGNAL_OBJECT_POST_PUPPET,
     SIGNAL_OBJECT_POST_UNPUPPET,
+    SIGNAL_ACCOUNT_POST_LOGIN_FAIL,
 )
 from evennia.server.throttle import Throttle
 from evennia.typeclasses.attributes import ModelAttributeBackend, NickHandler
@@ -673,6 +674,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             if session:
                 account = AccountDB.objects.get_account_from_name(username)
                 if account:
+                    SIGNAL_ACCOUNT_POST_LOGIN_FAIL.send(sender=account, session=session)
                     account.at_failed_login(session)
 
             return None, errors

--- a/evennia/server/signals.py
+++ b/evennia/server/signals.py
@@ -93,6 +93,11 @@ SIGNAL_CHANNEL_POST_CREATE = Signal()
 SIGNAL_EXIT_TRAVERSED = Signal()
 
 # Used as a generic event emitter. Use to make your own signals easily in one place!
+# To use it, import SIGNALS_CUSTOM and use it like a dictionary of Signal objects.
+# Example:
+# from evennia.utils.signals import SIGNALS_CUSTOM
+# SIGNALS_CUSTOM['my_signal'].connect(my_callback)
+# SIGNALS_CUSTOM['my_signal'].send(sender, **kwargs)
 SIGNALS_CUSTOM: dict[str, Signal] = defaultdict(Signal)
 
 # Django default signals (https://docs.djangoproject.com/en/4.1/topics/signals/)

--- a/evennia/server/signals.py
+++ b/evennia/server/signals.py
@@ -21,6 +21,7 @@ without necessitating a full takeover of hooks that may be in high demand.
 
 """
 from django.dispatch import Signal
+from collections import defaultdict
 
 # The sender is the created Account. This is triggered at the very end of
 # Account.create() after the Account is created. Note that this will *not* fire
@@ -90,6 +91,9 @@ SIGNAL_CHANNEL_POST_CREATE = Signal()
 # The sender is the exit used when traversing, as well as 'traverser', for the one traversing
 # Called just after at_traverse hook.
 SIGNAL_EXIT_TRAVERSED = Signal()
+
+# Used as a generic event emitter. Use to make your own signals easily in one place!
+SIGNALS_CUSTOM: dict[str, Signal] = defaultdict(Signal)
 
 # Django default signals (https://docs.djangoproject.com/en/4.1/topics/signals/)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
the SIGNAL_ACCOUNT_POST_LOGIN_FAIL signal wasn't being called anywhere, so that's been fixed.

A SIGNALS_CUSTOM object has been added to signals.py using a defaultdict to make for an easy event handler.

#### Motivation for adding to Evennia
Although I regret pushing for adding these signals all over the place (the custom variant using the defaultdict is a much more elegant approach), they ought to do what they say they do, so... fixing this oversight.

#### Other info (issues closed, discussion etc)
