### PR TITLE
Fix typo in tutorial

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Rooms.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Rooms.md
@@ -212,7 +212,7 @@ When the `.send_echo` method is called, it will use `random.random()` to check i
 
 Here's how you'd use this room in-game: 
 
-    > dig market:evadventure.EchoingRoom = market,back 
+    > dig market:evadventure.rooms.EchoingRoom = market,back 
     > market 
     > set here/echoes = ["You hear a merchant shouting", "You hear the clatter of coins"]
     > py here.start_echo() 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Corrects `evadventure.EchoingRoom` to `evadventure.rooms.EchoingRoom`

#### Additional info
I'm not sure why github decided that I'd changed the last line as well, they look identical to me