### PR TITLE
Adjusted checks for Object/Account to prevent conflicts.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.db.models import Max, Min, Q
 
+import evennia
 from evennia import InterruptCommand
 from evennia.commands.cmdhandler import get_and_merge_cmdsets
 from evennia.locks.lockhandler import LockException
@@ -2739,7 +2740,7 @@ class CmdExamine(ObjManipCommand):
         all_cmdsets = [(cmdset.key, cmdset) for cmdset in current_cmdset.merged_from]
         # we always at least try to add account- and session sets since these are ignored
         # if we merge on the object level.
-        if hasattr(obj, "has_account") and obj.account:
+        if inherits_from(obj, evennia.DefaultObject) and obj.account:
             # get Attribute-cmdsets if they exist
             all_cmdsets.extend([(cmdset.key, cmdset) for cmdset in obj.account.cmdset.all()])
             if obj.sessions.count():
@@ -2924,7 +2925,7 @@ class CmdExamine(ObjManipCommand):
         objdata["Sessions"] = self.format_sessions(obj)
         objdata["Email"] = self.format_email(obj)
         objdata["Last Login"] = self.format_last_login(obj)
-        if hasattr(obj, "has_account") and obj.has_account:
+        if inherits_from(obj, evennia.DefaultObject) and obj.has_account:
             objdata["Account"] = self.format_account_key(obj.account)
             objdata["  Account Typeclass"] = self.format_account_typeclass(obj.account)
             objdata["  Account Permissions"] = self.format_account_permissions(obj.account)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2739,7 +2739,7 @@ class CmdExamine(ObjManipCommand):
         all_cmdsets = [(cmdset.key, cmdset) for cmdset in current_cmdset.merged_from]
         # we always at least try to add account- and session sets since these are ignored
         # if we merge on the object level.
-        if hasattr(obj, "account") and obj.account:
+        if hasattr(obj, "has_account") and obj.account:
             # get Attribute-cmdsets if they exist
             all_cmdsets.extend([(cmdset.key, cmdset) for cmdset in obj.account.cmdset.all()])
             if obj.sessions.count():

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -723,6 +723,6 @@ class CmdAccess(COMMAND_DEFAULT_CLASS):
 
         string += "\n|wYour access|n:"
         string += f"\nCharacter |c{caller.key}|n: {cperms}"
-        if hasattr(caller, "account"):
+        if hasattr(caller, "has_account"):
             string += f"\nAccount |c{caller.account.key}|n: {pperms}"
         caller.msg(string)

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -5,6 +5,7 @@ import re
 
 from django.conf import settings
 
+import evennia
 from evennia.typeclasses.attributes import NickTemplateInvalid
 from evennia.utils import utils
 
@@ -723,6 +724,6 @@ class CmdAccess(COMMAND_DEFAULT_CLASS):
 
         string += "\n|wYour access|n:"
         string += f"\nCharacter |c{caller.key}|n: {cperms}"
-        if hasattr(caller, "has_account"):
+        if utils.inherits_from(caller, evennia.DefaultObject):
             string += f"\nAccount |c{caller.account.key}|n: {pperms}"
         caller.msg(string)

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -165,7 +165,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
 
         """
         has_sub = self.subscriptions.has(subscriber)
-        if not has_sub and hasattr(subscriber, "account"):
+        if not has_sub and hasattr(subscriber, "has_account"):
             # it's common to send an Object when we
             # by default only allow Accounts to subscribe.
             has_sub = self.subscriptions.has(subscriber.account)

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -8,11 +8,12 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.text import slugify
 
+import evennia
 from evennia.comms.managers import ChannelManager
 from evennia.comms.models import ChannelDB
 from evennia.typeclasses.models import TypeclassBase
 from evennia.utils import create, logger
-from evennia.utils.utils import make_iter
+from evennia.utils.utils import make_iter, inherits_from
 
 
 class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
@@ -165,7 +166,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
 
         """
         has_sub = self.subscriptions.has(subscriber)
-        if not has_sub and hasattr(subscriber, "has_account"):
+        if not has_sub and inherits_from(subscriber, evennia.DefaultObject):
             # it's common to send an Object when we
             # by default only allow Accounts to subscribe.
             has_sub = self.subscriptions.has(subscriber.account)

--- a/evennia/comms/models.py
+++ b/evennia/comms/models.py
@@ -646,8 +646,6 @@ class SubscriptionHandler:
             from django.core.exceptions import ObjectDoesNotExist
 
             try:
-                if hasattr(obj, "account") and obj.account:
-                    obj = obj.account
                 if not obj.is_connected:
                     continue
             except ObjectDoesNotExist:

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -515,7 +515,7 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
     function will still return True.
     """
     obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
-    account = obj.account if hasattr(obj, "account") else obj
+    account = obj.account if hasattr(obj, "has_account") else obj
     if not account:
         return True
     try:

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -18,6 +18,7 @@ from ast import literal_eval
 
 from django.conf import settings
 
+import evennia
 from evennia.utils import utils
 
 _PERMISSION_HIERARCHY = [pe.lower() for pe in settings.PERMISSION_HIERARCHY]
@@ -515,7 +516,7 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
     function will still return True.
     """
     obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
-    account = obj.account if hasattr(obj, "has_account") else obj
+    account = obj.account if utils.inherits_from(obj, evennia.DefaultObject) else obj
     if not account:
         return True
     try:
@@ -657,7 +658,7 @@ def has_account(accessing_obj, accessed_obj, *args, **kwargs):
     This is a useful lock for traverse-locking Exits to restrain NPC
     mobiles from moving outside their areas.
     """
-    return hasattr(accessing_obj, "has_account") and accessing_obj.has_account
+    return utils.inherits_from(accessing_obj, evennia.DefaultObject) and accessing_obj.has_account
 
 
 def serversetting(accessing_obj, accessed_obj, *args, **kwargs):

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -109,6 +109,7 @@ import re
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+import evennia
 from evennia.utils import logger, utils
 
 __all__ = ("LockHandler", "LockException")
@@ -553,7 +554,7 @@ class LockHandler:
             if not no_superuser_bypass and (
                 (hasattr(accessing_obj, "is_superuser") and accessing_obj.is_superuser)
                 or (
-                    hasattr(accessing_obj, "has_account")
+                    utils.inherits_from(accessing_obj, evennia.DefaultObject)
                     and hasattr(accessing_obj.account, "is_superuser")
                     and accessing_obj.account.is_superuser
                 )
@@ -627,7 +628,7 @@ class LockHandler:
             if no_superuser_bypass and (
                 (hasattr(accessing_obj, "is_superuser") and accessing_obj.is_superuser)
                 or (
-                    hasattr(accessing_obj, "has_account")
+                    utils.inherits_from(accessing_obj, evennia.DefaultObject)
                     and hasattr(accessing_obj.account, "is_superuser")
                     and accessing_obj.account.is_superuser
                 )

--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -553,7 +553,7 @@ class LockHandler:
             if not no_superuser_bypass and (
                 (hasattr(accessing_obj, "is_superuser") and accessing_obj.is_superuser)
                 or (
-                    hasattr(accessing_obj, "account")
+                    hasattr(accessing_obj, "has_account")
                     and hasattr(accessing_obj.account, "is_superuser")
                     and accessing_obj.account.is_superuser
                 )
@@ -627,7 +627,7 @@ class LockHandler:
             if no_superuser_bypass and (
                 (hasattr(accessing_obj, "is_superuser") and accessing_obj.is_superuser)
                 or (
-                    hasattr(accessing_obj, "account")
+                    hasattr(accessing_obj, "has_account")
                     and hasattr(accessing_obj.account, "is_superuser")
                     and accessing_obj.account.is_superuser
                 )

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -35,6 +35,7 @@ from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.utils.text import slugify
 
+import evennia
 from evennia.locks.lockhandler import LockHandler
 from evennia.server.signals import SIGNAL_TYPED_OBJECT_POST_RENAME
 from evennia.typeclasses import managers
@@ -700,7 +701,7 @@ class TypedObject(SharedMemoryModel):
             result (bool): If the permstring is passed or not.
 
         """
-        if hasattr(self, "has_account"):
+        if inherits_from(self, evennia.DefaultObject):
             if (
                 self.account
                 and self.account.is_superuser

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -700,7 +700,7 @@ class TypedObject(SharedMemoryModel):
             result (bool): If the permstring is passed or not.
 
         """
-        if hasattr(self, "account"):
+        if hasattr(self, "has_account"):
             if (
                 self.account
                 and self.account.is_superuser

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -423,7 +423,7 @@ class CmdEvMenuNode(Command):
             if _restore(caller):
                 return
             orig_caller = caller
-            caller = caller.account if hasattr(caller, "account") else None
+            caller = caller.account if hasattr(caller, "has_account") else None
             menu = caller.ndb._evmenu if caller else None
             if not menu:
                 if caller and _restore(caller):
@@ -1497,7 +1497,7 @@ class CmdGetInput(Command):
         caller = self.caller
         try:
             getinput = caller.ndb._getinput
-            if not getinput and hasattr(caller, "account"):
+            if not getinput and (hasattr(caller, "has_account")):
                 getinput = caller.account.ndb._getinput
                 if getinput:
                     caller = caller.account
@@ -1618,7 +1618,7 @@ class CmdYesNoQuestion(Command):
 
     def _clean(self, caller):
         del caller.ndb._yes_no_question
-        if not caller.cmdset.has(YesNoQuestionCmdSet) and hasattr(caller, "account"):
+        if not caller.cmdset.has(YesNoQuestionCmdSet) and hasattr(caller, "has_account"):
             caller.account.cmdset.remove(YesNoQuestionCmdSet)
         else:
             caller.cmdset.remove(YesNoQuestionCmdSet)
@@ -1628,7 +1628,7 @@ class CmdYesNoQuestion(Command):
         caller = self.caller
         try:
             yes_no_question = caller.ndb._yes_no_question
-            if not yes_no_question and hasattr(caller, "account"):
+            if not yes_no_question and hasattr(caller, "has_account"):
                 yes_no_question = caller.account.ndb._yes_no_question
                 caller = caller.account
 

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -277,6 +277,7 @@ from django.conf import settings
 # i18n
 from django.utils.translation import gettext as _
 
+import evennia
 from evennia import CmdSet, Command
 from evennia.commands import cmdhandler
 from evennia.utils import logger
@@ -291,6 +292,7 @@ from evennia.utils.utils import (
     mod_import,
     pad,
     to_str,
+    inherits_from,
 )
 
 # read from protocol NAWS later?
@@ -423,7 +425,7 @@ class CmdEvMenuNode(Command):
             if _restore(caller):
                 return
             orig_caller = caller
-            caller = caller.account if hasattr(caller, "has_account") else None
+            caller = caller.account if inherits_from(caller, evennia.DefaultObject) else None
             menu = caller.ndb._evmenu if caller else None
             if not menu:
                 if caller and _restore(caller):
@@ -1497,7 +1499,7 @@ class CmdGetInput(Command):
         caller = self.caller
         try:
             getinput = caller.ndb._getinput
-            if not getinput and (hasattr(caller, "has_account")):
+            if not getinput and inherits_from(caller, evennia.DefaultObject):
                 getinput = caller.account.ndb._getinput
                 if getinput:
                     caller = caller.account
@@ -1618,7 +1620,9 @@ class CmdYesNoQuestion(Command):
 
     def _clean(self, caller):
         del caller.ndb._yes_no_question
-        if not caller.cmdset.has(YesNoQuestionCmdSet) and hasattr(caller, "has_account"):
+        if not caller.cmdset.has(YesNoQuestionCmdSet) and inherits_from(
+            caller, evennia.DefaultObject
+        ):
             caller.account.cmdset.remove(YesNoQuestionCmdSet)
         else:
             caller.cmdset.remove(YesNoQuestionCmdSet)
@@ -1628,7 +1632,7 @@ class CmdYesNoQuestion(Command):
         caller = self.caller
         try:
             yes_no_question = caller.ndb._yes_no_question
-            if not yes_no_question and hasattr(caller, "has_account"):
+            if not yes_no_question and inherits_from(caller, evennia.DefaultObject):
                 yes_no_question = caller.account.ndb._yes_no_question
                 caller = caller.account
 

--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -78,7 +78,7 @@ class CmdMore(Command):
         Implement the command
         """
         more = self.caller.ndb._more
-        if not more and hasattr(self.caller, "account"):
+        if not more and hasattr(self.caller, "has_account"):
             more = self.caller.account.ndb._more
         if not more:
             self.caller.msg("Error in loading the pager. Contact an admin.")

--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -41,6 +41,7 @@ from django.core.paginator import Paginator
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext as _
 
+import evennia
 from evennia.commands import cmdhandler
 from evennia.commands.cmdset import CmdSet
 from evennia.commands.command import Command
@@ -78,7 +79,7 @@ class CmdMore(Command):
         Implement the command
         """
         more = self.caller.ndb._more
-        if not more and hasattr(self.caller, "has_account"):
+        if not more and inherits_from(self.caller, evennia.DefaultObject):
             more = self.caller.account.ndb._more
         if not more:
             self.caller.msg("Error in loading the pager. Contact an admin.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Tweaked a few uses of hasattr and made a few other minor adjustments where Evennia tries to detect the "account" property to determine if it's looking at an Account or an Object.

I did this by altering hasattr(target, "account") to hasattr(target, "has_account") since DefaultObject has that method and Accounts do not.

#### Motivation for adding to Evennia
Although Evennia itself doesn't strictly need this, one of the projects I'm trying to integrate adds models that establish a OneToOneField to the Django User (settings.AUTH_USER_MODEL, etc). Since this means that Accounts have a .account, it sends Evennia's code off on a wild goose chase and breaks things.

The library in question is Pinax's django-user-accounts, which adds quite an array of features. You might wanna check it out.

#### Other info (issues closed, discussion etc)
Everything appears to be working.