### PR TITLE
Fixing Code Typos in Readme for XYZContrib

### DIFF
--- a/evennia/contrib/grid/xyzgrid/README.md
+++ b/evennia/contrib/grid/xyzgrid/README.md
@@ -269,26 +269,28 @@ LEGEND = {}
 # the '*' are wildcards and allows for giving defaults on this map.
 PROTOTYPES = {
     (0, 0): {
-	"prototype_parent": "xyz_room",
-	"key": "A nice glade",
-        "desc": "Sun shines through the branches above.}
+        "prototype_parent": "xyz_room",
+        "key": "A nice glade",
+        "desc": "Sun shines through the branches above.",
+    },
     (0, 0, 'e'): {
-	"prototype_parent": "xyz_exit",
-	"desc": "A quiet path through the foilage"
-    }
+        "prototype_parent": "xyz_exit",
+        "desc": "A quiet path through the foilage",
+    },
     ('*', '*'): {
-	"prototype_parent": "xyz_room",
-	"key": "In a bright forest",
-	"desc": "There is green all around."
+        "prototype_parent": "xyz_room",
+        "key": "In a bright forest",
+        "desc": "There is green all around.",
     },
     ('*', '*', '*'): {
-	"prototype_parent": "xyz_exit",
-	"desc": "The path leads further into the forest."
+        "prototype_parent": "xyz_exit",
+        "desc": "The path leads further into the forest.",
+    },
 }
 
 # collect all info for this one map
 XYMAP_DATA = {
-    "zcoord": "mymap"  # important!
+    "zcoord": "mymap",  # important!
     "map": MAPSTR,
     "legend": LEGEND,
     "prototypes": PROTOTYPES,
@@ -299,7 +301,6 @@ XYMAP_DATA = {
 XYMAP_DATA_LIST = [
     XYMAP_DATA
 ]
-
 ```
 
 The above map would be added to the grid with


### PR DESCRIPTION
The previous code block contained programmatic errors.
