### PR TITLE
Fixes evennia/evennia#3336 - Dockerfile's ONBUILD command fails at --chown=evennia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY . /usr/src/evennia
 
 # add the game source when rebuilding a new docker image from inside
 # a game dir
-ONBUILD COPY --chown=evennia . /usr/src/game
+ONBUILD COPY . /usr/src/game
 
 # make the game source hierarchy persistent with a named volume.
 # mount on-disk game location here when using the container


### PR DESCRIPTION
Addressing evennia/evennia#3336

Taking the assumption that the user creation was commented out for a reason and following suit by fixing this to work without it.