### PR TITLE
Add Command.cmdset_source

### DIFF
--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -541,6 +541,8 @@ class CmdSet(object, metaclass=_CmdSetMeta):
         system_commands = self.system_commands
 
         for cmd in cmds:
+            # Ensure commands know their source cmdset.
+            cmd.cmdset_source = self
             # add all commands
             if not hasattr(cmd, "obj") or cmd.obj is None:
                 cmd.obj = self.cmdsetobj

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -156,9 +156,10 @@ class Command(metaclass=CommandMeta):
                      you to know which alias was used, for example)
     self.args - everything supplied to the command following the cmdstring
                (this is usually what is parsed in self.parse())
-    self.cmdset - the cmdset from which this command was matched (useful only
+    self.cmdset - the merged cmdset from which this command was matched (useful only
                   seldomly, notably for help-type commands, to create dynamic
                   help entries and lists)
+    self.cmdset_source - the specific cmdset this command was matched from.
     self.obj - the object on which this command is defined. If a default command,
                this is usually the same as caller.
     self.raw_string - the full raw string input, including the command name,


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This simply modifies CmdSet.add() to stamp each newly added command with cmd.cmdset_source = self

So, Commands now know EXACTLY which CmdSet they came from.

#### Motivation for adding to Evennia
This allows a Command to reference properties, methods, state, etc, on their CmdSet, which can be useful in a number of ways.

See, for instance, creating a kind of pseudo-menu which is aware of all of the commands available to the 'menu'.

#### Other info (issues closed, discussion etc)
This is such a tiny - but useful - change, it doesn't appear to cause any issues.