### PR TITLE
Lockfuncs are now called with an access_type kwarg in their **kwargs

### DIFF
--- a/evennia/locks/lockhandler.py
+++ b/evennia/locks/lockhandler.py
@@ -572,7 +572,8 @@ class LockHandler:
             evalstring, func_tup, raw_string = self.locks[access_type]
             # execute all lock funcs in the correct order, producing a tuple of True/False results.
             true_false = tuple(
-                bool(tup[0](accessing_obj, self.obj, *tup[1], **tup[2])) for tup in func_tup
+                bool(tup[0](accessing_obj, self.obj, *tup[1], access_type=access_type, **tup[2]))
+                for tup in func_tup
             )
             # the True/False tuple goes into evalstring, which combines them
             # with AND/OR/NOT in order to get the final result.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Enable lockfuncs to be aware of the access_type they are checking for.

#### Motivation for adding to Evennia
Although not helpful in many simple cases, if developing complex permission structures with indirection, a lockfunc knowing what kind of access_type it's checking for can allow for more flexible infrastructure.

#### Other info (issues closed, discussion etc)
Nothing that strikes me.