### PR TITLE
Streamlined cmdhandler to support more extension.

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -274,9 +274,9 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
 
     # Determines which order command sets begin to be assembled from.
     # Accounts are usually second.
-    cmd_order = 50
-    cmd_order_error = 0
-    cmd_type = "account"
+    cmdset_provider_order = 50
+    cmdset_provider_error_order = 0
+    cmdset_provider_type = "account"
 
     objects = AccountManager()
 
@@ -315,17 +315,16 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
     def characters(self):
         return CharactersHandler(self)
 
-    def get_command_objects(self) -> dict[str, "CommandObject"]:
+    def get_cmdset_providers(self) -> dict[str, "CmdSetProvider"]:
         """
-        Overrideable method which returns a dictionary of all the kinds of CommandObjects
-        linked to this Account.
+        Overrideable method which returns a dictionary of every kind of object which
+        has a cmdsethandler linked to this Account, and should participate in cmdset
+        merging.
 
-        In all normal cases, that's just the account itself.
-
-        The cmdhandler uses this to determine available cmdsets when executing a command.
+        Accounts have no way of being aware of anything besides themselves, unfortunately.
 
         Returns:
-            dict[str, CommandObject]: The CommandObjects linked to this Account.
+            dict[str, CmdSetProvider]: The CmdSetProviders linked to this Object.
         """
         return {"account": self}
 

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -10,7 +10,7 @@ from django.db.models import Max, Min, Q
 
 import evennia
 from evennia import InterruptCommand
-from evennia.commands.cmdhandler import get_and_merge_cmdsets
+from evennia.commands.cmdhandler import get_and_merge_cmdsets, generate_command_objects
 from evennia.locks.lockhandler import LockException
 from evennia.objects.models import ObjectDB
 from evennia.prototypes import menus as olc_menus
@@ -3122,8 +3122,16 @@ class CmdExamine(ObjManipCommand):
                 def _get_cmdset_callback(current_cmdset):
                     self.msg(self.format_output(obj, current_cmdset).strip())
 
+                (
+                    command_objects,
+                    command_objects_list,
+                    command_objects_list_error,
+                    caller,
+                    error_to,
+                ) = generate_command_objects(obj, session=session)
+
                 get_and_merge_cmdsets(
-                    obj, session, account, objct, mergemode, self.raw_string
+                    obj, command_objects_list, mergemode, self.raw_string, error_to
                 ).addCallback(_get_cmdset_callback)
 
             else:

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -10,7 +10,7 @@ from django.db.models import Max, Min, Q
 
 import evennia
 from evennia import InterruptCommand
-from evennia.commands.cmdhandler import get_and_merge_cmdsets, generate_command_objects
+from evennia.commands.cmdhandler import get_and_merge_cmdsets, generate_cmdset_providers
 from evennia.locks.lockhandler import LockException
 from evennia.objects.models import ObjectDB
 from evennia.prototypes import menus as olc_menus
@@ -3128,7 +3128,7 @@ class CmdExamine(ObjManipCommand):
                     command_objects_list_error,
                     caller,
                     error_to,
-                ) = generate_command_objects(obj, session=session)
+                ) = generate_cmdset_providers(obj, session=session)
 
                 get_and_merge_cmdsets(
                     obj, command_objects_list, mergemode, self.raw_string, error_to

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -1026,7 +1026,7 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
             command_objects_list_error,
             caller,
             error_to,
-        ) = cmdhandler.generate_command_objects(self.session)
+        ) = cmdhandler.generate_cmdset_providers(self.session)
 
         deferred = cmdhandler.get_and_merge_cmdsets(
             self.session, [self.session], "session", "", error_to
@@ -1050,7 +1050,7 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
             command_objects_list_error,
             caller,
             error_to,
-        ) = cmdhandler.generate_command_objects(self.account)
+        ) = cmdhandler.generate_cmdset_providers(self.account)
 
         deferred = cmdhandler.get_and_merge_cmdsets(
             self.account, command_objects_list, "account", "", error_to
@@ -1075,7 +1075,7 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
             command_objects_list_error,
             caller,
             error_to,
-        ) = cmdhandler.generate_command_objects(self.obj1)
+        ) = cmdhandler.generate_cmdset_providers(self.obj1)
 
         deferred = cmdhandler.get_and_merge_cmdsets(
             self.obj1, command_objects_list, "object", "", error_to
@@ -1101,7 +1101,7 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
             command_objects_list_error,
             caller,
             error_to,
-        ) = cmdhandler.generate_command_objects(self.obj1)
+        ) = cmdhandler.generate_cmdset_providers(self.obj1)
         deferred = cmdhandler.get_and_merge_cmdsets(
             self.obj1, command_objects_list, "object", "", error_to
         )
@@ -1127,7 +1127,7 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
             command_objects_list_error,
             caller,
             error_to,
-        ) = cmdhandler.generate_command_objects(self.obj1, session=None)
+        ) = cmdhandler.generate_cmdset_providers(self.obj1, session=None)
 
         deferred = cmdhandler.get_and_merge_cmdsets(
             self.obj1, command_objects_list, "object", "", error_to

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -1020,8 +1020,16 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         a = self.cmdset_a
         a.no_channels = True
         self.set_cmdsets(self.session, a)
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_command_objects(self.session)
+
         deferred = cmdhandler.get_and_merge_cmdsets(
-            self.session, self.session, None, None, "session", ""
+            self.session, [self.session], "session", "", error_to
         )
 
         def _callback(cmdset):
@@ -1036,8 +1044,16 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         a = self.cmdset_a
         a.no_channels = True
         self.set_cmdsets(self.account, a)
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_command_objects(self.account)
+
         deferred = cmdhandler.get_and_merge_cmdsets(
-            self.account, None, self.account, None, "account", ""
+            self.account, command_objects_list, "account", "", error_to
         )
         # get_and_merge_cmdsets converts  to lower-case internally.
 
@@ -1053,7 +1069,17 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
 
     def test_from_object(self):
         self.set_cmdsets(self.obj1, self.cmdset_a)
-        deferred = cmdhandler.get_and_merge_cmdsets(self.obj1, None, None, self.obj1, "object", "")
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_command_objects(self.obj1)
+
+        deferred = cmdhandler.get_and_merge_cmdsets(
+            self.obj1, command_objects_list, "object", "", error_to
+        )
         # get_and_merge_cmdsets converts  to lower-case internally.
 
         def _callback(cmdset):
@@ -1069,8 +1095,16 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         a.no_exits = True
         a.no_channels = True
         self.set_cmdsets(self.obj1, a, b, c, d)
-
-        deferred = cmdhandler.get_and_merge_cmdsets(self.obj1, None, None, self.obj1, "object", "")
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_command_objects(self.obj1)
+        deferred = cmdhandler.get_and_merge_cmdsets(
+            self.obj1, command_objects_list, "object", "", error_to
+        )
 
         def _callback(cmdset):
             self.assertTrue(cmdset.no_exits)
@@ -1087,7 +1121,17 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         b.duplicates = True
         d.duplicates = True
         self.set_cmdsets(self.obj1, a, b, c, d)
-        deferred = cmdhandler.get_and_merge_cmdsets(self.obj1, None, None, self.obj1, "object", "")
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_command_objects(self.obj1, session=None)
+
+        deferred = cmdhandler.get_and_merge_cmdsets(
+            self.obj1, command_objects_list, "object", "", error_to
+        )
 
         def _callback(cmdset):
             self.assertEqual(len(cmdset.commands), 9)

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -206,9 +206,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     # Determines which order command sets begin to be assembled from.
     # Objects are usually third.
-    cmd_order = 100
-    cmd_order_error = 100
-    cmd_type = "object"
+    cmdset_provider_order = 100
+    cmdset_provider_error_order = 100
+    cmdset_provider_type = "object"
 
     # Used for sorting / filtering in inventories / room contents.
     _content_types = ("object",)
@@ -262,18 +262,16 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         return self.sessions.count()
 
-    def get_command_objects(self) -> dict[str, "CommandObject"]:
+    def get_cmdset_providers(self) -> dict[str, "CmdSetProvider"]:
         """
-        Overrideable method which returns a dictionary of all the kinds of CommandObjects
-        linked to this Object.
+        Overrideable method which returns a dictionary of every kind of object which
+        has a cmdsethandler linked to this Object, and should participate in cmdset
+        merging.
 
-        In all normal cases, that's the Object itself, and maybe an Account if the Object
-        is being puppeted.
-
-        The cmdhandler uses this to determine available cmdsets when executing a command.
+        Objects might be aware of an Account. Otherwise, just themselves, by default.
 
         Returns:
-            dict[str, CommandObject]: The CommandObjects linked to this Object.
+            dict[str, CmdSetProvider]: The CmdSetProviders linked to this Object.
         """
         out = {"object": self}
         if self.account:

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -204,6 +204,12 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     """
 
+    # Determines which order command sets begin to be assembled from.
+    # Objects are usually third.
+    cmd_order = 100
+    cmd_order_error = 100
+    cmd_type = "object"
+
     # Used for sorting / filtering in inventories / room contents.
     _content_types = ("object",)
 
@@ -255,6 +261,24 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         """
         return self.sessions.count()
+
+    def get_command_objects(self) -> dict[str, "CommandObject"]:
+        """
+        Overrideable method which returns a dictionary of all the kinds of CommandObjects
+        linked to this Object.
+
+        In all normal cases, that's the Object itself, and maybe an Account if the Object
+        is being puppeted.
+
+        The cmdhandler uses this to determine available cmdsets when executing a command.
+
+        Returns:
+            dict[str, CommandObject]: The CommandObjects linked to this Object.
+        """
+        out = {"object": self}
+        if self.account:
+            out["account"] = self.account
+        return out
 
     @property
     def is_superuser(self):
@@ -1601,11 +1625,27 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         have no cmdsets.
 
         Keyword Args:
-            caller (Session, Object or Account): The caller requesting
-                this cmdset.
+            caller (obj): The object requesting the cmdsets.
+            current (cmdset): The current merged cmdset.
+            force_init (bool): If `True`, force a re-build of the cmdset. (seems unused)
+            **kwargs: Arbitrary input for overloads.
 
         """
         pass
+
+    def get_cmdsets(self, caller, current, **kwargs):
+        """
+        Called by the CommandHandler to get a list of cmdsets to merge.
+
+        Args:
+            caller (obj): The object requesting the cmdsets.
+            current (cmdset): The current merged cmdset.
+            **kwargs: Arbitrary input for overloads.
+
+        Returns:
+            tuple: A tuple of (current, cmdsets), which is probably self.cmdset.current and self.cmdset.cmdset_stack
+        """
+        return self.cmdset.current, list(self.cmdset.cmdset_stack)
 
     def at_pre_puppet(self, account, session=None, **kwargs):
         """

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -48,9 +48,9 @@ class ServerSession(_BASE_SESSION_CLASS):
 
     # Determines which order command sets begin to be assembled from.
     # Sessions are usually first.
-    cmd_order = 0
-    cmd_order_error = 50
-    cmd_type = "session"
+    cmdset_provider_order = 0
+    cmdset_provider_error_order = 50
+    cmdset_provider_type = "session"
 
     def __init__(self):
         """
@@ -70,24 +70,23 @@ class ServerSession(_BASE_SESSION_CLASS):
 
     cmdset_storage = property(__cmdset_storage_get, __cmdset_storage_set)
 
-    def get_command_objects(self) -> dict[str, "CommandObject"]:
+    def get_cmdset_providers(self) -> dict[str, "CmdSetProvider"]:
         """
-        Overrideable method which returns a dictionary of all the kinds of CommandObjects
-        linked to this ServerSession.
+        Overrideable method which returns a dictionary of every kind of object which
+        has a cmdsethandler linked to this ServerSession, and should participate in cmdset
+        merging.
 
         In all normal cases, that's the Session itself, and possibly an account and puppeted
          object.
 
-        The cmdhandler uses this to determine available cmdsets when executing a command.
-
         Returns:
-            dict[str, CommandObject]: The CommandObjects linked to this Object.
+            dict[str, CmdSetProvider]: The CmdSetProviders linked to this Object.
         """
         out = {"session": self}
         if self.account:
             out["account"] = self.account
         if self.puppet:
-            out["puppet"] = self.puppet
+            out["object"] = self.puppet
         return out
 
     @property

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -46,6 +46,12 @@ class ServerSession(_BASE_SESSION_CLASS):
 
     """
 
+    # Determines which order command sets begin to be assembled from.
+    # Sessions are usually first.
+    cmd_order = 0
+    cmd_order_error = 50
+    cmd_type = "session"
+
     def __init__(self):
         """
         Initiate to avoid AttributeErrors down the line
@@ -63,6 +69,26 @@ class ServerSession(_BASE_SESSION_CLASS):
         self.cmdset_storage_string = ",".join(str(val).strip() for val in make_iter(value))
 
     cmdset_storage = property(__cmdset_storage_get, __cmdset_storage_set)
+
+    def get_command_objects(self) -> dict[str, "CommandObject"]:
+        """
+        Overrideable method which returns a dictionary of all the kinds of CommandObjects
+        linked to this ServerSession.
+
+        In all normal cases, that's the Session itself, and possibly an account and puppeted
+         object.
+
+        The cmdhandler uses this to determine available cmdsets when executing a command.
+
+        Returns:
+            dict[str, CommandObject]: The CommandObjects linked to this Object.
+        """
+        out = {"session": self}
+        if self.account:
+            out["account"] = self.account
+        if self.puppet:
+            out["puppet"] = self.puppet
+        return out
 
     @property
     def id(self):
@@ -376,11 +402,34 @@ class ServerSession(_BASE_SESSION_CLASS):
 
     def at_cmdset_get(self, **kwargs):
         """
-        A dummy hook all objects with cmdsets need to have
+        Called just before cmdsets on this object are requested by the
+        command handler. If changes need to be done on the fly to the
+        cmdset before passing them on to the cmdhandler, this is the
+        place to do it. This is called also if the object currently
+        have no cmdsets.
+
+        Keyword Args:
+            caller (obj): The object requesting the cmdsets.
+            current (cmdset): The current merged cmdset.
+            force_init (bool): If `True`, force a re-build of the cmdset. (seems unused)
+            **kwargs: Arbitrary input for overloads.
 
         """
-
         pass
+
+    def get_cmdsets(self, caller, current, **kwargs):
+        """
+        Called by the CommandHandler to get a list of cmdsets to merge.
+
+        Args:
+            caller (obj): The object requesting the cmdsets.
+            current (cmdset): The current merged cmdset.
+            **kwargs: Arbitrary input for overloads.
+
+        Returns:
+            tuple: A tuple of (current, cmdsets), which is probably self.cmdset.current and self.cmdset.cmdset_stack
+        """
+        return self.cmdset.current, list(self.cmdset.cmdset_stack)
 
     # Mock db/ndb properties for allowing easy storage on the session
     # (note that no databse is involved at all here. session.db.attr =


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Reworked some of the cmdhandler guts to grow more agnostic of the KINDS of objects it can be executing commands from, without breaking existing conventions.

#### Motivation for adding to Evennia
The current cmdhandler code is very messy and not very pythonic; it's also difficult to extend in ways that challenge the internal architecture of Evennia itself. These alterations are a major step in divorcing the process of merging cmdsets from the triad of (session, account, object). It is now possible to add MORE "command-providing objects".

#### Other info (issues closed, discussion etc)
evennia.commands.default.tests.TestCmdTasks.test_new_task_waiting_input keeps failing and I have no idea why.