### PR TITLE
Default Commands now use self.msg() instead of self.caller.msg()

### DIFF
--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -510,7 +510,7 @@ Command {self} has no defined `func()` - showing on-command variables:
             % (self.cmdset.key if self.cmdset.key else self.cmdset.__class__)
         )
 
-        self.caller.msg(string)
+        self.msg(string)
 
     def func(self):
         """

--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -192,7 +192,7 @@ class CmdBan(COMMAND_DEFAULT_CLASS):
         if not self.args or (
             self.switches and not any(switch in ("ip", "name") for switch in self.switches)
         ):
-            self.caller.msg(list_bans(self, banlist))
+            self.msg(list_bans(self, banlist))
             return
 
         now = time.ctime()
@@ -219,13 +219,13 @@ class CmdBan(COMMAND_DEFAULT_CLASS):
 
         ret = yield (f"Are you sure you want to {typ}-ban '|w{ban}|n' [Y]/N?")
         if str(ret).lower() in ("no", "n"):
-            self.caller.msg("Aborted.")
+            self.msg("Aborted.")
             return
 
         # save updated banlist
         banlist.append(bantup)
         ServerConfig.objects.conf("server_bans", banlist)
-        self.caller.msg(f"{typ}-ban '|w{ban}|n' was added. Use |wunban|n to reinstate.")
+        self.msg(f"{typ}-ban '|w{ban}|n' was added. Use |wunban|n to reinstate.")
         logger.log_sec(
             f"Banned {typ}: {ban.strip()} (Caller: {self.caller}, IP: {self.session.address})."
         )
@@ -255,19 +255,19 @@ class CmdUnban(COMMAND_DEFAULT_CLASS):
         banlist = ServerConfig.objects.conf("server_bans")
 
         if not self.args:
-            self.caller.msg(list_bans(self, banlist))
+            self.msg(list_bans(self, banlist))
             return
 
         try:
             num = int(self.args)
         except Exception:
-            self.caller.msg("You must supply a valid ban id to clear.")
+            self.msg("You must supply a valid ban id to clear.")
             return
 
         if not banlist:
-            self.caller.msg("There are no bans to clear.")
+            self.msg("There are no bans to clear.")
         elif not (0 < num < len(banlist) + 1):
-            self.caller.msg(f"Ban id |w{self.args}|n was not found.")
+            self.msg(f"Ban id |w{self.args}|n was not found.")
         else:
             # all is ok, ask, then clear ban
             ban = banlist[num - 1]
@@ -275,12 +275,12 @@ class CmdUnban(COMMAND_DEFAULT_CLASS):
 
             ret = yield (f"Are you sure you want to unban {num}: '|w{value}|n' [Y]/N?")
             if str(ret).lower() in ("n", "no"):
-                self.caller.msg("Aborted.")
+                self.msg("Aborted.")
                 return
 
             del banlist[num - 1]
             ServerConfig.objects.conf("server_bans", banlist)
-            self.caller.msg(f"Cleared ban {num}: '{value}'")
+            self.msg(f"Cleared ban {num}: '{value}'")
             logger.log_sec(
                 f"Unbanned: {value.strip()} (Caller: {self.caller}, IP: {self.session.address})."
             )
@@ -559,7 +559,7 @@ class CmdWall(COMMAND_DEFAULT_CLASS):
     def func(self):
         """Implements command"""
         if not self.args:
-            self.caller.msg("Usage: wall <message>")
+            self.msg("Usage: wall <message>")
             return
         message = f'{self.caller.name} shouts "{self.args}"'
         self.msg("Announcing to all connected sessions ...")
@@ -585,13 +585,13 @@ class CmdForce(COMMAND_DEFAULT_CLASS):
     def func(self):
         """Implements the force command"""
         if not self.lhs or not self.rhs:
-            self.caller.msg("You must provide a target and a command string to execute.")
+            self.msg("You must provide a target and a command string to execute.")
             return
         targ = self.caller.search(self.lhs)
         if not targ:
             return
         if not targ.access(self.caller, self.perm_used):
-            self.caller.msg(f"You don't have permission to force {targ} to execute commands.")
+            self.msg(f"You don't have permission to force {targ} to execute commands.")
             return
         targ.execute_cmd(self.rhs)
-        self.caller.msg(f"You have forced {targ} to: {self.rhs}")
+        self.msg(f"You have forced {targ} to: {self.rhs}")

--- a/evennia/commands/default/batchprocess.py
+++ b/evennia/commands/default/batchprocess.py
@@ -398,7 +398,7 @@ class CmdStateAbort(_COMMAND_DEFAULT_CLASS):
     def func(self):
         """Exit back to default."""
         purge_processor(self.caller)
-        self.caller.msg("Exited processor and reset out active cmdset back to the default one.")
+        self.msg("Exited processor and reset out active cmdset back to the default one.")
 
 
 class CmdStateLL(_COMMAND_DEFAULT_CLASS):
@@ -729,7 +729,7 @@ class CmdStateQQ(_COMMAND_DEFAULT_CLASS):
 
     def func(self):
         purge_processor(self.caller)
-        self.caller.msg("Aborted interactive batch mode.")
+        self.msg("Aborted interactive batch mode.")
 
 
 class CmdStateHH(_COMMAND_DEFAULT_CLASS):
@@ -765,7 +765,7 @@ class CmdStateHH(_COMMAND_DEFAULT_CLASS):
               batch-command processing. It immediately shuts down
               the processor and returns us to the default cmdset.
     """
-        self.caller.msg(string)
+        self.msg(string)
 
 
 # -------------------------------------------------------------

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -255,7 +255,7 @@ class CmdSetObjAlias(COMMAND_DEFAULT_CLASS):
 
         if not self.lhs:
             string = "Usage: alias <obj> [= [alias[,alias ...]]]"
-            self.caller.msg(string)
+            self.msg(string)
             return
         objname = self.lhs
 
@@ -471,7 +471,7 @@ class CmdCpAttr(ObjManipCommand):
         required and verify an object has an attribute.
         """
         if not obj.attributes.has(attr):
-            self.caller.msg(f"{obj.name} doesn't have an attribute {attr}.")
+            self.msg(f"{obj.name} doesn't have an attribute {attr}.")
             return False
         return True
 
@@ -525,7 +525,7 @@ class CmdCpAttr(ObjManipCommand):
                 return
 
         if (len(from_obj_attrs) != len(set(from_obj_attrs))) and clear:
-            self.caller.msg("|RCannot have duplicate source names when moving!")
+            self.msg("|RCannot have duplicate source names when moving!")
             return
 
         result = []
@@ -594,7 +594,7 @@ class CmdMvAttr(ObjManipCommand):
       mvattr[/switch] <obj>/<attr> = <obj1> [,<obj2>,<obj3>,...]
       mvattr[/switch] <attr> = <obj1>/<attr1> [,<obj2>/<attr2>,<obj3>/<attr3>,...]
       mvattr[/switch] <attr> = <obj1>[,<obj2>,<obj3>,...]"""
-            self.caller.msg(string)
+            self.msg(string)
             return
 
         # simply use cpattr for all the functionality
@@ -734,7 +734,7 @@ class CmdDesc(COMMAND_DEFAULT_CLASS):
             return
 
         if not (obj.access(self.caller, "control") or obj.access(self.caller, "edit")):
-            self.caller.msg(f"You don't have permission to edit the description of {obj.key}.")
+            self.msg(f"You don't have permission to edit the description of {obj.key}.")
             return
 
         self.caller.db.evmenu_target = obj
@@ -881,7 +881,7 @@ class CmdDestroy(COMMAND_DEFAULT_CLASS):
                 obj = caller.search(objname)
 
             if obj is None:
-                self.caller.msg(
+                self.msg(
                     " (Objects to destroy must either be local or specified with a unique #dbref.)"
                 )
             elif obj not in objs:
@@ -1148,7 +1148,7 @@ class CmdTunnel(COMMAND_DEFAULT_CLASS):
                 "Usage: tunnel[/switch] <direction>[:typeclass] [= <roomname>"
                 "[;alias;alias;...][:typeclass]]"
             )
-            self.caller.msg(string)
+            self.msg(string)
             return
 
         # If we get a typeclass, we need to get just the exitname
@@ -1159,7 +1159,7 @@ class CmdTunnel(COMMAND_DEFAULT_CLASS):
                 sorted(self.directions.keys())
             )
             string += "\n(use dig for more freedom)"
-            self.caller.msg(string)
+            self.msg(string)
             return
 
         # retrieve all input and parse it
@@ -1245,7 +1245,7 @@ class CmdLink(COMMAND_DEFAULT_CLASS):
                 return
 
             if target == obj:
-                self.caller.msg("Cannot link an object to itself.")
+                self.msg("Cannot link an object to itself.")
                 return
 
             string = ""
@@ -1261,7 +1261,7 @@ class CmdLink(COMMAND_DEFAULT_CLASS):
                         f"To create a two-way link, {obj} and {target} must both have a location"
                     )
                     string += " (i.e. they cannot be rooms, but should be exits)."
-                    self.caller.msg(string)
+                    self.msg(string)
                     return
                 if not target.destination:
                     string += note % (target.name, target.dbref)
@@ -1357,7 +1357,7 @@ class CmdSetHome(CmdLink):
         """implement the command"""
         if not self.args:
             string = "Usage: sethome <obj> [= <home_location>]"
-            self.caller.msg(string)
+            self.msg(string)
             return
 
         obj = self.caller.search(self.lhs, global_search=True)
@@ -1384,7 +1384,7 @@ class CmdSetHome(CmdLink):
                 )
             else:
                 string = f"Home location of {obj} was set to {new_home}({new_home.dbref})."
-        self.caller.msg(string)
+        self.msg(string)
 
 
 class CmdListCmdSets(COMMAND_DEFAULT_CLASS):
@@ -1599,14 +1599,14 @@ class CmdOpen(ObjManipCommand):
         super().parse()
         self.location = self.caller.location
         if not self.args or not self.rhs:
-            self.caller.msg(
+            self.msg(
                 "Usage: open <new exit>[;alias...][:typeclass]"
                 "[,<return exit>[;alias..][:typeclass]]] "
                 "= <destination>"
             )
             raise InterruptCommand
         if not self.location:
-            self.caller.msg("You cannot create an exit from a None-location.")
+            self.msg("You cannot create an exit from a None-location.")
             raise InterruptCommand
         self.destination = self.caller.search(self.rhs, global_search=True)
         if not self.destination:
@@ -1941,7 +1941,7 @@ class CmdSetAttribute(ObjManipCommand):
                     "Continue? [Y]/N?"
                 )
                 if answer.lower() in ("n", "no"):
-                    self.caller.msg("Aborted edit.")
+                    self.msg("Aborted edit.")
                     return
         except AttributeError:
             pass
@@ -2618,7 +2618,7 @@ class CmdExamine(ObjManipCommand):
             text (str): The text to send.
 
         """
-        self.caller.msg(text=(text, {"type": "examine"}))
+        self.msg(text=(text, {"type": "examine"}))
 
     def format_key(self, obj):
         return f"{obj.name} ({obj.dbref})"
@@ -3009,11 +3009,11 @@ class CmdExamine(ObjManipCommand):
         else:
             obj = getattr(search, f"search_{objtype}")(obj_name)
             if not obj:
-                self.caller.msg(f"No {objtype} found with key {obj_name}.")
+                self.msg(f"No {objtype} found with key {obj_name}.")
                 obj = None
             elif len(obj) > 1:
                 err = "Multiple {objtype} found with key {obj_name}:\n{matches}"
-                self.caller.msg(
+                self.msg(
                     err.format(
                         obj_name=obj_name, matches=", ".join(f"{ob.key}(#{ob.id})" for ob in obj)
                     )
@@ -3747,7 +3747,7 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
         if self.rhs:
             self.obj_to_teleport = self.caller.search(self.lhs, global_search=True)
             if not self.obj_to_teleport:
-                self.caller.msg("Did not find object to teleport.")
+                self.msg("Did not find object to teleport.")
                 raise InterruptCommand
             self.destination = self.caller.search(self.rhs, global_search=True)
         elif self.lhs:
@@ -3876,7 +3876,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
         """Implement the tag functionality"""
 
         if not self.args:
-            self.caller.msg("Usage: tag[/switches] <obj> [= <tag>[:<category>]]")
+            self.msg("Usage: tag[/switches] <obj> [= <tag>[:<category>]]")
             return
         if "search" in self.switches:
             # search by tag
@@ -3906,7 +3906,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
                     tag,
                     " (category: %s)" % category if category else "",
                 )
-            self.caller.msg(string)
+            self.msg(string)
             return
         if "del" in self.switches:
             # remove one or all tags
@@ -3943,7 +3943,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
                     string = "Cleared all tags from %s: %s" % (obj, ", ".join(sorted(old_tags)))
                 else:
                     string = "No Tags to clear on %s." % obj
-            self.caller.msg(string)
+            self.msg(string)
             return
         # no search/deletion
         if self.rhs:
@@ -3967,7 +3967,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
                 " (category: %s)" % category if category else "",
                 obj,
             )
-            self.caller.msg(string)
+            self.msg(string)
         else:
             # no = found - list tags on object
             # first search locally, then global
@@ -3990,7 +3990,7 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
                 )
             else:
                 string = f"No tags attached to {obj}."
-            self.caller.msg(string)
+            self.msg(string)
 
 
 # helper functions for spawn
@@ -4114,7 +4114,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
         if err:
             # return None on any error
             if not quiet:
-                self.caller.msg(err)
+                self.msg(err)
             return
         return prototype
 
@@ -4153,7 +4153,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
                     )
                 else:
                     string = f"Expected {expect}, got {type(prototype)}."
-                self.caller.msg(string)
+                self.msg(string)
                 return
 
         if expect == dict:
@@ -4161,15 +4161,13 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
             # so don't allow exec.
             # TODO: Exec support is deprecated. Remove completely for 1.0.
             if "exec" in prototype and not self.caller.check_permstring("Developer"):
-                self.caller.msg(
-                    "Spawn aborted: You are not allowed to use the 'exec' prototype key."
-                )
+                self.msg("Spawn aborted: You are not allowed to use the 'exec' prototype key.")
                 return
             try:
                 # we homogenize the prototype first, to be more lenient with free-form
                 protlib.validate_prototype(protlib.homogenize_prototype(prototype))
             except RuntimeError as err:
-                self.caller.msg(str(err))
+                self.msg(str(err))
                 return
         return prototype
 
@@ -4196,9 +4194,9 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
         if prototypes:
             return "\n".join(protlib.prototype_to_str(prot) for prot in prototypes)
         elif query:
-            self.caller.msg(f"No prototype named '{query}' was found.")
+            self.msg(f"No prototype named '{query}' was found.")
         else:
-            self.caller.msg("No prototypes found.")
+            self.msg("No prototypes found.")
 
     def _list_prototypes(self, key=None, tags=None):
         """Display prototypes as a list, optionally limited by key/tags."""
@@ -4501,7 +4499,7 @@ class CmdSpawn(COMMAND_DEFAULT_CLASS):
         # proceed to spawning
         try:
             for obj in spawner.spawn(prototype, caller=self.caller):
-                self.caller.msg("Spawned %s." % obj.get_display_name(self.caller))
+                self.msg("Spawned %s." % obj.get_display_name(self.caller))
                 if not prototype.get("location") and not noloc:
                     # we don't hardcode the location in the prototype (unless the user
                     # did so manually) - that would lead to it having to be 'removed' every

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -312,7 +312,7 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
 
         """
         if not channel.access(self.caller, "send"):
-            self.caller.msg(f"You are not allowed to send messages to channel {channel}")
+            self.msg(f"You are not allowed to send messages to channel {channel}")
             return
 
         # avoid unsafe tokens in message
@@ -1684,21 +1684,21 @@ class CmdIRCStatus(COMMAND_DEFAULT_CLASS):
         chtext = f"IRC bot '{ircbot.db.irc_botname}' on channel {channel} ({network}:{port})"
         if option == "ping":
             # check connection by sending outself a ping through the server.
-            self.caller.msg(f"Pinging through {chtext}.")
+            self.msg(f"Pinging through {chtext}.")
             ircbot.ping(self.caller)
         elif option in ("users", "nicklist", "who"):
             # retrieve user list. The bot must handles the echo since it's
             # an asynchronous call.
-            self.caller.msg(f"Requesting nicklist from {channel} ({network}:{port}).")
+            self.msg(f"Requesting nicklist from {channel} ({network}:{port}).")
             ircbot.get_nicklist(self.caller)
         elif self.caller.locks.check_lockstring(
             self.caller, "dummy:perm(ircstatus) or perm(Developer)"
         ):
             # reboot the client
-            self.caller.msg(f"Forcing a disconnect + reconnect of {chtext}.")
+            self.msg(f"Forcing a disconnect + reconnect of {chtext}.")
             ircbot.reconnect()
         else:
-            self.caller.msg("You don't have permission to force-reload the IRC bot.")
+            self.msg("You don't have permission to force-reload the IRC bot.")
 
 
 # RSS connection

--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -377,7 +377,7 @@ class CmdInventory(COMMAND_DEFAULT_CLASS):
                     "{}|n".format(utils.crop(raw_ansi(item.db.desc or ""), width=50) or ""),
                 )
             string = f"|wYou are carrying:\n{table}"
-        self.caller.msg(text=(string, {"type": "inventory"}))
+        self.msg(text=(string, {"type": "inventory"}))
 
 
 class CmdGet(COMMAND_DEFAULT_CLASS):
@@ -555,11 +555,11 @@ class CmdSetDesc(COMMAND_DEFAULT_CLASS):
         """add the description"""
 
         if not self.args:
-            self.caller.msg("You must add a description.")
+            self.msg("You must add a description.")
             return
 
         self.caller.db.desc = self.args.strip()
-        self.caller.msg("You set your description.")
+        self.msg("You set your description.")
 
 
 class CmdSay(COMMAND_DEFAULT_CLASS):
@@ -686,7 +686,7 @@ class CmdPose(COMMAND_DEFAULT_CLASS):
         """Hook function"""
         if not self.args:
             msg = "What do you want to do?"
-            self.caller.msg(msg)
+            self.msg(msg)
         else:
             msg = f"{self.caller.name}{self.args}"
             self.caller.location.msg_contents(text=(msg, {"type": "pose"}), from_obj=self.caller)

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -213,7 +213,7 @@ class MuxCommand(Command):
 Command {self} has no defined `func()` - showing on-command variables: No child func() defined for {self} - available variables:
 {variables}
         """
-        self.caller.msg(string)
+        self.msg(string)
         # a simple test command to show the available properties
         string = "-" * 50
         string += f"\n|w{self.key}|n - Command variables from evennia:\n"
@@ -241,7 +241,7 @@ Command {self} has no defined `func()` - showing on-command variables: No child 
         string += f"rhs, right-hand side of '=' (self.rhs): |w{self.rhs}|n\n"
         string += f"rhs, comma separated (self.rhslist): |w{self.rhslist}|n\n"
         string += "-" * 50
-        self.caller.msg(string)
+        self.msg(string)
 
     def func(self):
         """

--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -698,7 +698,7 @@ class CmdAbout(COMMAND_DEFAULT_CLASS):
             twisted=twisted.version.short(),
             django=django.get_version(),
         )
-        self.caller.msg(string)
+        self.msg(string)
 
 
 class CmdTime(COMMAND_DEFAULT_CLASS):
@@ -740,7 +740,7 @@ class CmdTime(COMMAND_DEFAULT_CLASS):
             "Current time ", datetime.datetime.fromtimestamp(gametime.gametime(absolute=True))
         )
         table2.reformat_column(0, width=30)
-        self.caller.msg(str(table1) + "\n" + str(table2))
+        self.msg(str(table1) + "\n" + str(table2))
 
 
 class CmdServerLoad(COMMAND_DEFAULT_CLASS):
@@ -802,7 +802,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
                 "The Idmapper cache freed |w{idmapper}|n database objects.\n"
                 "The Python garbage collector freed |w{gc}|n Python instances total."
             )
-            self.caller.msg(string.format(idmapper=(prev - now), gc=nflushed))
+            self.msg(string.format(idmapper=(prev - now), gc=nflushed))
             return
 
         # display active processes
@@ -829,7 +829,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
 
                 if "mem" in self.switches:
                     string = "Total computer memory usage: |w%g|n MB (%g%%)"
-                    self.caller.msg(string % (rmem, pmem))
+                    self.msg(string % (rmem, pmem))
                     return
                 # Display table
                 loadtable = self.styled_table("property", "statistic", align="l")
@@ -863,7 +863,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
 
             if "mem" in self.switches:
                 string = "Memory usage: RMEM: |w%g|n MB (%g%%), VMEM (res+swap+cache): |w%g|n MB."
-                self.caller.msg(string % (rmem, pmem, vmem))
+                self.msg(string % (rmem, pmem, vmem))
                 return
 
             loadtable = self.styled_table("property", "statistic", align="l")
@@ -913,7 +913,7 @@ class CmdServerLoad(COMMAND_DEFAULT_CLASS):
         string += "\n|w Entity idmapper cache:|n %i items\n%s" % (total_num, memtable)
 
         # return to caller
-        self.caller.msg(string)
+        self.msg(string)
 
 
 class CmdTickers(COMMAND_DEFAULT_CLASS):
@@ -938,7 +938,7 @@ class CmdTickers(COMMAND_DEFAULT_CLASS):
 
         all_subs = TICKER_HANDLER.all_display()
         if not all_subs:
-            self.caller.msg("No tickers are currently active.")
+            self.msg("No tickers are currently active.")
             return
         table = self.styled_table("interval (s)", "object", "path/methodname", "idstring", "db")
         for sub in all_subs:
@@ -953,7 +953,7 @@ class CmdTickers(COMMAND_DEFAULT_CLASS):
                 sub[4] or "[Unset]",
                 "*" if sub[5] else "-",
             )
-        self.caller.msg("|wActive tickers|n:\n" + str(table))
+        self.msg("|wActive tickers|n:\n" + str(table))
 
 
 class CmdTasks(COMMAND_DEFAULT_CLASS):

--- a/evennia/commands/default/unloggedin.py
+++ b/evennia/commands/default/unloggedin.py
@@ -292,7 +292,7 @@ class CmdUnconnectedLook(COMMAND_DEFAULT_CLASS):
             connection_screen = utils.random_string_from_module(CONNECTION_SCREEN_MODULE)
             if not connection_screen:
                 connection_screen = "No connection screen found. Please contact an admin."
-        self.caller.msg(connection_screen)
+        self.msg(connection_screen)
 
 
 class CmdUnconnectedHelp(COMMAND_DEFAULT_CLASS):
@@ -334,7 +334,7 @@ You can use the |wlook|n command if you want to see the connect screen again.
 
         if settings.STAFF_CONTACT_EMAIL:
             string += "For support, please contact: %s" % settings.STAFF_CONTACT_EMAIL
-        self.caller.msg(string)
+        self.msg(string)
 
 
 class CmdUnconnectedEncoding(COMMAND_DEFAULT_CLASS):
@@ -418,7 +418,7 @@ class CmdUnconnectedEncoding(COMMAND_DEFAULT_CLASS):
                 sync = True
         if sync:
             self.session.sessionhandler.session_portal_sync(self.session)
-        self.caller.msg(string.strip())
+        self.msg(string.strip())
 
 
 class CmdUnconnectedScreenreader(COMMAND_DEFAULT_CLASS):
@@ -439,7 +439,7 @@ class CmdUnconnectedScreenreader(COMMAND_DEFAULT_CLASS):
         new_setting = not self.session.protocol_flags.get("SCREENREADER", False)
         self.session.protocol_flags["SCREENREADER"] = new_setting
         string = "Screenreader mode turned |w%s|n." % ("on" if new_setting else "off")
-        self.caller.msg(string)
+        self.msg(string)
         self.session.sessionhandler.session_portal_sync(self.session)
 
 
@@ -456,7 +456,7 @@ class CmdUnconnectedInfo(COMMAND_DEFAULT_CLASS):
     locks = "cmd:all()"
 
     def func(self):
-        self.caller.msg(
+        self.msg(
             "## BEGIN INFO 1.1\nName: %s\nUptime: %s\nConnected: %d\nVersion: Evennia %s\n## END"
             " INFO"
             % (


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The Evennia default command has a handy self.msg() which has some unique behavior not found on objects, sessions, and accounts.

Unfortunately, many commands aren't using it, instead going straight for self.caller.msg()

This fixes that, where prudent. The only command I didn't touch is the CmdPy-related things, because that does some special weird stuff I don't want to mess up.

#### Motivation for adding to Evennia
Twofold. First, the Default commands should better conform to their own standards and resources to show off how to write commands.

Second, I have an awesome output-buffering system for Athanor in the works (which we may be able to backport to Evennia later) which bundles up all calls to cmd.msg() for a single operation so that webclients can group up the output of a specific command with the input. So, I need the default commands to be using cmd.msg(), or I need to replace all of them...

Like, if you sent in:
`["text", ["look"], {"results_id": "whatever"}]`
Then you will get a response back that looks something like this:
`["results", [{"look": (["<text>"], {"type": "look"})], {"results_id": "whatever"}]`

#### Other info (issues closed, discussion etc)
There seems to be a weird recursion issue going on with CmdExamine. I'm not sure how to deal with it yet, still investigating.