### PR TITLE
Fixed stale protocol keys in CmdHelp

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -119,8 +119,8 @@ class CmdHelp(COMMAND_DEFAULT_CLASS):
             usemore = True
 
             if self.session and self.session.protocol_key in (
-                "websocket",
-                "ajax/comet",
+                "webclient/websocket",
+                "webclient/ajax",
             ):
                 try:
                     options = self.account.db._saved_webclient_options


### PR DESCRIPTION
#### Brief overview of PR changes/additions
CmdHelp was using old protocol_key strings for trying to detect if the session was a webclient.

They have been updated.

#### Motivation for adding to Evennia
This feature was broken and needed to be fixed?

#### Other info (issues closed, discussion etc)
