### PR TITLE
Update documentation references to `develop`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -245,14 +245,11 @@ The Evennia documentation supports some special reference shortcuts in links:
 #### Github online repository
 
 - `github:` - a shortcut for the full path to the Evennia repository on github. This will refer to
-  the `master` branch by default:
+  the `main` branch by default:
 
         [link to objects.py](github:evennia/objects/objects.py)
 
-    This will remap to https://github.com/evennia/evennia/blob/master/evennia/objects/objects.py.
-- To refer to the `develop` branch, start the url with `develop/`:
-
-        [link to objects.py](github:develop/evennia/objects/objects.py)
+    This will remap to https://github.com/evennia/evennia/blob/main/evennia/objects/objects.py.
 
 #### API
 

--- a/docs/source/Components/Website.md
+++ b/docs/source/Components/Website.md
@@ -51,7 +51,7 @@ As explained on the [Webserver](./Webserver.md) page, the process for getting a 
    the HTML page requires static resources are requested, the browser will
    fetch those separately before displaying it to the user.
 
-If you look at the [evennia/web/](github:develop/evennia/web) directory you'll find the following structure (leaving out stuff not relevant to the website):
+If you look at the [evennia/web/](github:evennia/web) directory you'll find the following structure (leaving out stuff not relevant to the website):
 
 ```
   evennia/web/

--- a/docs/source/Contribs/Contrib-Character-Creator.md
+++ b/docs/source/Contribs/Contrib-Character-Creator.md
@@ -47,7 +47,7 @@ customize that with the setting `MAX_NR_CHARACTERS`.)
 By default, the new `charcreate` command will reference the example menu
 provided by the contrib, so you can test it out before building your own menu.
 You can reference
-[the example menu here](github:develop/evennia/contrib/rpg/character_creator/example_menu.py) for
+[the example menu here](github:evennia/contrib/rpg/character_creator/example_menu.py) for
 ideas on how to build your own.
 
 Once you have your own menu, just add it to your settings to use it. e.g. if your menu is in

--- a/docs/source/Contributing-Docs.md
+++ b/docs/source/Contributing-Docs.md
@@ -148,7 +148,6 @@ These are links to resources outside of the documentation. We also provide some 
 ```
 
 - By using `(github:evennia/objects/objects.py)` as link target, you can point to a place on the Evennia github page (main branch). 
-- Use `(github:develop/evennia/objects/objects.py` to target `develop` branch.
 - Use `(github:issue)` to point to the github issue-creation page.
 
  > Note that if you want to refer to code, it's usually better to [link to the API](#api-links) rather than point to github.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A couple of places in the documentation linked to, or suggested linking to, the `develop` branch. Since that branch is no longer active, I corrected the links to use the default and also updated the documentation guides.