### PR TITLE
Add a unique ID to each webclient instance

### DIFF
--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -68,7 +68,7 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
 
         """
         try:
-            # client will connect with wsurl?csessid&browserid
+            # client will connect with wsurl?csessid&page_id&browserid
             webarg = self.http_request_uri.split("?", 1)[1]
         except IndexError:
             # this may happen for custom webclients not caring for the
@@ -86,7 +86,7 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
         if len(cargs) == 1:
             self.browserstr = str(cargs[0])
         elif len(cargs) == 2:
-            self.cuid = str(cargs[0])
+            self.page_id = str(cargs[0])
             self.browserstr = str(cargs[1])
 
         if self.csessid:

--- a/evennia/server/portal/webclient.py
+++ b/evennia/server/portal/webclient.py
@@ -82,9 +82,12 @@ class WebSocketClient(WebSocketServerProtocol, _BASE_SESSION_CLASS):
             logger.log_trace(str(self))
             return None
 
-        self.csessid, *browserstr = webarg.split("&", 1)
-        if browserstr:
-            self.browserstr = str(browserstr[0])
+        self.csessid, *cargs = webarg.split("&", 2)
+        if len(cargs) == 1:
+            self.browserstr = str(cargs[0])
+        elif len(cargs) == 2:
+            self.cuid = str(cargs[0])
+            self.browserstr = str(cargs[1])
 
         if self.csessid:
             return _CLIENT_SESSIONS(session_key=self.csessid)

--- a/evennia/server/portal/webclient_ajax.py
+++ b/evennia/server/portal/webclient_ajax.py
@@ -336,11 +336,6 @@ class AjaxWebClient(resource.Resource):
             del self.requests[csessid]
         if csessid in self.databuffer:
             del self.databuffer[csessid]
-        if csessid in self.requests:
-            self.requests[csessid].finish()
-            del self.requests[csessid]
-        if csessid in self.databuffer:
-            del self.databuffer[csessid]
 
     def mode_init(self, request):
         """
@@ -437,7 +432,6 @@ class AjaxWebClient(resource.Resource):
         self.last_alive[csessid] = (time.time(), False)
 
         dataentries = self.databuffer.get(csessid)
-        dataentries = self.databuffer.get(csessid)
         if dataentries:
             # we have data that could not be sent earlier (because client was not
             # ready to receive it). Return this buffered data immediately
@@ -445,10 +439,6 @@ class AjaxWebClient(resource.Resource):
         else:
             # we have no data to send. End the old request and start
             # a new long-polling one
-            request.notifyFinish().addErrback(self._responseFailed, csessid, request)
-            if csessid in self.requests:
-                self.requests[csessid].finish()  # Clear any stale request.
-            self.requests[csessid] = request
             request.notifyFinish().addErrback(self._responseFailed, csessid, request)
             if csessid in self.requests:
                 self.requests[csessid].finish()  # Clear any stale request.
@@ -467,10 +457,8 @@ class AjaxWebClient(resource.Resource):
         csessid = self.get_client_sessid(request) + self.get_client_page_id(request)
         try:
             sess = self.sessionhandler.sessions_from_csessid(csessid)[0]
-            sess = self.sessionhandler.sessions_from_csessid(csessid)[0]
             sess.sessionhandler.disconnect(sess)
         except IndexError:
-            self.client_disconnect(csessid)
             self.client_disconnect(csessid)
         return b'""'
 

--- a/evennia/web/static/webclient/js/evennia.js
+++ b/evennia/web/static/webclient/js/evennia.js
@@ -220,6 +220,7 @@ An "emitter" object must have a function
         var websocket = null;
         var wsurl = window.wsurl;
         var csessid = window.csessid;
+        var cuid = window.cuid;
 
         var connect = function() {
             if (websocket && websocket.readyState != websocket.CLOSED) {
@@ -227,7 +228,7 @@ An "emitter" object must have a function
                 return;
             }
             // Important - we pass csessid tacked on the url
-            websocket = new WebSocket(wsurl + '?' + csessid + '&' + browser);
+            websocket = new WebSocket(wsurl + '?' + csessid + '&' + cuid + '&' + browser);
 
             // Handle Websocket open event
             websocket.onopen = function (event) {
@@ -304,13 +305,14 @@ An "emitter" object must have a function
         var stop_polling = false;
         var is_closing = false;
         var csessid = window.csessid;
+        var cuid = window.cuid;
 
         // initialize connection, send csessid
         var init = function() {
             $.ajax({type: "POST", url: "/webclientdata",
                     async: true, cache: false, timeout: 50000,
                     datatype: "json",
-                    data: {mode: "init", csessid: csessid, browserstr: browser},
+                    data: {mode: "init", csessid: csessid, cuid: cuid, browserstr: browser},
 
                     success: function(data) {
                         open = true;
@@ -336,7 +338,7 @@ An "emitter" object must have a function
                    async: true, cache: false, timeout: 30000,
                    dataType: "json",
                    data: {mode: inmode == null ? 'input' : inmode,
-                          data: JSON.stringify(data), 'csessid': csessid},
+                          data: JSON.stringify(data), 'csessid': csessid, 'cuid': cuid},
                    success: function(req, stat, err) {
                        stop_polling = false;
                    },
@@ -356,7 +358,7 @@ An "emitter" object must have a function
             $.ajax({type: "POST", url: "/webclientdata",
                     async: true, cache: false, timeout: 60000,
                     dataType: "json",
-                    data: {mode: 'receive', 'csessid': csessid},
+                    data: {mode: 'receive', 'csessid': csessid, 'cuid': cuid},
                     success: function(data) {
                         // log("ajax data received:", data);
                         if (data[0] === "ajax_keepalive") {
@@ -411,7 +413,7 @@ An "emitter" object must have a function
                 cache: false,
                 timeout: 50000,
                 dataType: "json",
-                data: {mode: 'close', 'csessid': csessid},
+                data: {mode: 'close', 'csessid': csessid, 'cuid': cuid},
 
                 success: function(data){
                     is_closing = false;

--- a/evennia/web/templates/webclient/base.html
+++ b/evennia/web/templates/webclient/base.html
@@ -40,6 +40,15 @@ JQuery available.
       })
     </script>
 
+    <!-- Generate a low-quality UID to uniquely identify client tabs -->
+    <script language="javascript" type="text/javascript">
+        function generateUID() {
+            return Math.random().toString(36).substring(2, 15) +
+                Math.random().toString(36).substring(2, 15);
+        }
+        var cuid = generateUID();
+    </script>
+
     <!-- Set up Websocket url and load the evennia.js library-->
     <script language="javascript" type="text/javascript">
         {% if websocket_enabled %}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Generates a low-security unique ID on loading a new webclient page, so that multiple pages associated with a single browser session properly count as their own play sessions.

#### Other info (issues closed, discussion etc)
Resolves #3327

Quick note: while there is a more cryptographically sound UUID generator available in modern browsers via the `crypto` library, its usage is restricted to secure contexts. Since Evennia doesn't require running a server with HTTPS and individual tabs on a single browser don't actually need to be guaranteed unique on a large scale, I opted for a quicker and more widely functional generator function.