### PR TITLE
Reset portal's `server_restart_mode` on server start

### DIFF
--- a/evennia/server/portal/amp_server.py
+++ b/evennia/server/portal/amp_server.py
@@ -197,6 +197,8 @@ class AMPServerProtocol(amp.AMPMultiConnectionProtocol):
         if process and not _is_windows():
             # avoid zombie-process on Unix/BSD
             process.wait()
+        # unset the reset-mode flag on the portal
+        self.factory.portal.server_restart_mode = None
         return
 
     def wait_for_disconnect(self, callback, *args, **kwargs):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, AMP sets an attribute of `server_restart_mode` on the portal to the restart mode when the server is being stopped - however, it never resets it on reconnect.

This just sets it to `None` on server connect regardless of mode.

#### Motivation for adding to Evennia
Making that flag actually potentially useful. 👍 
