### PR TITLE
Fix gendersub contrib's gender sourcing

### DIFF
--- a/evennia/contrib/game_systems/gendersub/gendersub.py
+++ b/evennia/contrib/game_systems/gendersub/gendersub.py
@@ -147,13 +147,17 @@ class GenderCharacter(DefaultCharacter):
             super().msg(from_obj=from_obj, session=session, **kwargs)
             return
 
-        try:
-            if text and isinstance(text, tuple):
-                text = (_RE_GENDER_PRONOUN.sub(self._get_pronoun, text[0]), *text[1:])
-            else:
-                text = _RE_GENDER_PRONOUN.sub(self._get_pronoun, text)
-        except TypeError:
-            pass
-        except Exception as e:
-            logger.log_trace(e)
+        gender_source = from_obj if from_obj else self
+
+        if hasattr(gender_source, "_get_pronoun"):
+            try:
+                if text and isinstance(text, tuple):
+                    text = (_RE_GENDER_PRONOUN.sub(gender_source._get_pronoun, text[0]), *text[1:])
+                else:
+                    text = _RE_GENDER_PRONOUN.sub(gender_source._get_pronoun, text)
+            except TypeError:
+                pass
+            except Exception as e:
+                logger.log_trace(e)
+
         super().msg(text, from_obj=from_obj, session=session, **kwargs)

--- a/evennia/contrib/game_systems/gendersub/tests.py
+++ b/evennia/contrib/game_systems/gendersub/tests.py
@@ -54,3 +54,12 @@ class TestGenderSub(BaseEvenniaCommandTest):
             self.assertIn("Test his gender", mock_msg.call_args.args)
             masc.msg(txt, from_obj=fem)
             self.assertIn("Test her gender", mock_msg.call_args.args)
+
+    def test_ungendered_source(self):
+        char = create_object(gendersub.GenderCharacter, key="Gendered", location=self.room1)
+        txt = "Test |p gender"
+        with patch(
+            "evennia.contrib.game_systems.gendersub.gendersub.DefaultCharacter.msg"
+        ) as mock_msg:
+            char.msg(txt, from_obj=self.char1)
+            self.assertIn("Test their gender", mock_msg.call_args.args)

--- a/evennia/contrib/game_systems/gendersub/tests.py
+++ b/evennia/contrib/game_systems/gendersub/tests.py
@@ -28,5 +28,29 @@ class TestGenderSub(BaseEvenniaCommandTest):
             "evennia.contrib.game_systems.gendersub.gendersub.DefaultCharacter.msg"
         ) as mock_msg:
             char.db.gender = "female"
-            char.msg("Test |p gender")
+            char.msg(txt)
             mock_msg.assert_called_with("Test her gender", from_obj=None, session=None)
+
+    def test_gendering_others(self):
+        """ensure characters see the gender of the sender, not themselves"""
+        fem = create_object(
+            gendersub.GenderCharacter,
+            key="Gendered",
+            location=self.room2,
+            attributes=[("gender", "female")],
+        )
+        masc = create_object(
+            gendersub.GenderCharacter,
+            key="Gendered",
+            location=self.room2,
+            attributes=[("gender", "male")],
+        )
+        txt = "Test |p gender"
+
+        with patch(
+            "evennia.contrib.game_systems.gendersub.gendersub.DefaultCharacter.msg"
+        ) as mock_msg:
+            fem.msg(txt, from_obj=masc)
+            self.assertIn("Test his gender", mock_msg.call_args.args)
+            masc.msg(txt, from_obj=fem)
+            self.assertIn("Test her gender", mock_msg.call_args.args)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes `gendersub.GenderCharacter` to reference `from_obj` when replacing pronouns instead of always using the object being messaged. Also adds a test to catch this issue in the future.

#### Motivation for adding to Evennia
Bug fixing.

#### Other info (issues closed, discussion etc)
Brought to my attention on Discord