### PR TITLE
Fix issue with helper func _on_monitor_change

### DIFF
--- a/evennia/server/inputfuncs.py
+++ b/evennia/server/inputfuncs.py
@@ -417,12 +417,27 @@ def _on_monitor_change(**kwargs):
     name = kwargs["name"]
     session = kwargs["session"]
     outputfunc_name = kwargs["outputfunc_name"]
+    category = None
+
+    # Attributes stored in the MonitorHandler with categories are
+    # stored as fieldname "db_value[category_name]", but we need to
+    # separate [category_name] because the actual attribute is stored on
+    # the object as "db_value" with a separate "category" field.
+    if hasattr(obj, "db_category") and obj.db_category != None:
+        category = obj.db_category
+        fieldname = fieldname.replace("[{}]".format(obj.db_category), '')
 
     # the session may be None if the char quits and someone
     # else then edits the object
 
     if session:
-        callsign = {outputfunc_name: {"name": name, "value": _GA(obj, fieldname)}}
+        callsign = {
+            outputfunc_name: {
+                "name": name,
+                **({"category": category} if category is not None else {}),
+                "value": _GA(obj, fieldname)
+                }
+            }
         session.msg(**callsign)
 
 


### PR DESCRIPTION
This changes causes _on_monitor_change to first separate out the category from the attribute field name in order to properly reference the attribute on the object.  This fixes errors such as:

  File "C:\Users\Scyfris\Projects\norn\evennia\evennia\scripts\monitorhandler.py", line 118, in at_update
    callback(obj=obj, fieldname=fieldname, **kwargs)
  File "C:\Users\Scyfris\Projects\norn\evennia\evennia\server\inputfuncs.py", line 425, in _on_monitor_change
    callsign = {outputfunc_name: {"name": name, "value": _GA(obj, fieldname)}}
AttributeError: 'Attribute' object has no attribute 'db_value[base]'

#### Brief overview of PR changes/additions

This is a follow-up fix for closed issue #3307 that I found after some fixes.

#### Motivation for adding to Evennia

This is used in a custom client requiring to access attributes with categories.

#### Other info (issues closed, discussion etc)

Relates to closed issue #3307
