### PR TITLE
Fix typo in new default AJAX setting

### DIFF
--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -1182,7 +1182,7 @@ WEBSOCKET_PROTOCOL_CLASS = "evennia.server.portal.webclient.WebSocketClient"
 # resilient to IP address changes.
 
 # The Ajax Client Class is used to manage all AJAX sessions.
-AJAX_CLIENT_CLASS = "evennia.server.portal.webclient.ajax.AjaxWebClient"
+AJAX_CLIENT_CLASS = "evennia.server.portal.webclient_ajax.AjaxWebClient"
 
 # Ajax Protocol Class is used for all AJAX client connections.
 AJAX_PROTOCOL_CLASS = "evennia.server.portal.webclient_ajax.AjaxWebClientSession"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes `webclient.ajax` in the class path to the correct `webclient_ajax`

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Resolves #3362