### PR TITLE
Updating Component contrib - allow arbitrarily long subclass chains of Component

### DIFF
--- a/evennia/contrib/base_systems/components/__init__.py
+++ b/evennia/contrib/base_systems/components/__init__.py
@@ -15,9 +15,16 @@ from evennia.contrib.base_systems.components.holder import (
     ComponentProperty,
 )
 
+# Recursively check inheritance chain of the input class.
+def all_component_subclasses(cls):
+    return set(cls.__subclasses__()).union(
+        [s for c in cls.__subclasses__() for s in all_component_subclasses(c)])
+
 
 def get_component_class(component_name):
-    subclasses = Component.__subclasses__()
+    
+    subclasses = all_component_subclasses(Component)
+
     component_class = next((sc for sc in subclasses if sc.name == component_name), None)
     if component_class is None:
         message = (

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -76,10 +76,18 @@ class TagField:
         It is called with the component class and the name of the field.
         """
         self._category_key = f"{owner.name}::{name}"
-        tag_fields = getattr(owner, "_tag_fields", None)
+        
+        # Check __dict__ instead of getattr.  TagField could be on an inherited
+        # class from a parent with their own TagField.  We want to be able to
+        # have unique TagFields on each subclass.  Using getattr would instead
+        # get the parent's TagField in an inheritance situation, which is not
+        # what we want here.
+        tag_fields = owner.__dict__.get("_tag_fields", None)
+
         if tag_fields is None:
             tag_fields = {}
             setattr(owner, "_tag_fields", tag_fields)
+
         tag_fields[name] = self
 
     def __get__(self, instance, owner):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This change allows a subclass of Component to itself be subclassed.  This

would come in handy if a game wanted to make a custom base component
class that contains common functionality and further subclass those into
more specific components.  The base component class would inherit from
Component, and the subclasses would inherit from that base component
class.  Unfortunately this wasn't possible since get_component_class
(used internally by the component contrib) only considered one layer of
subclasses of Component and not a possible inheritance chain.

This change fixes that, and allows you to subclass Component subclasses.
Example is the following:
```
class MyGameBaseComponent(Component):
  # common definitions, data, etc

class MyGameComponentA(MyGameBaseComponent):
  # specific functionality for MyGameComponentA

class MyGameComponentA_inherit(MyGameBaseComponentA):
  # specific functionality for MyGameComponentA_inherit
```
Etc...

#### Motivation for adding to Evennia

In my personal project I want a base Component class with some common stuff for my game, and wanted to derive all Components from that Base class.  This is similar to creating a game-specific BaseObject class which in turn you can subclass different Object types

#### Other info (issues closed, discussion etc)
