### PR TITLE
[Components] Refactor Component registering with cherry-picked additions

### DIFF
--- a/evennia/contrib/base_systems/components/README.md
+++ b/evennia/contrib/base_systems/components/README.md
@@ -30,12 +30,20 @@ class Character(ComponentHolderMixin, DefaultCharacter):
 # ...
 ```
 
-Components need to inherit the Component class directly and require a name.
+Components need to inherit the Component class and require a unique name.
+Components may inherit from other components but must specify another name.
+You can assign the same 'slot' to both components to have alternative implementations.
 ```python
 from evennia.contrib.base_systems.components import Component
 
+
 class Health(Component):
     name = "health"
+
+    
+class ItemHealth(Health):
+    name = "item_health"
+    slot = "health"
 ```
 
 Components may define DBFields or NDBFields at the class level.
@@ -103,7 +111,10 @@ character.components.add(vampirism)
 
 ...
 
-vampirism_from_elsewhere = character.components.get("vampirism")
+vampirism = character.components.get("vampirism")
+
+# Alternatively
+vampirism = character.cmp.vampirism
 ```
 
 Keep in mind that all components must be imported to be visible in the listing.
@@ -127,6 +138,14 @@ from typeclasses.components.health import Health
 from typeclasses.components import health
 ```
 Both of the above examples will work.
+
+## Known Issues
+
+Assigning mutable default values such as a list to a DBField will share it across instances.
+To avoid this, you must set autocreate=True on the field, like this.
+```python
+health = DBField(default=[], autocreate=True)
+```
 
 ## Full Example
 ```python

--- a/evennia/contrib/base_systems/components/__init__.py
+++ b/evennia/contrib/base_systems/components/__init__.py
@@ -7,23 +7,16 @@ This helps writing isolated code and reusing it over multiple objects.
 
 See the docs for more information.
 """
-
+from evennia.contrib.base_systems.components import exceptions
+from evennia.contrib.base_systems.components.listing import COMPONENT_LISTING, get_component_class
 from evennia.contrib.base_systems.components.component import Component
-from evennia.contrib.base_systems.components.dbfield import DBField, NDBField, TagField
+from evennia.contrib.base_systems.components.dbfield import (
+    DBField,
+    NDBField,
+    TagField
+)
+
 from evennia.contrib.base_systems.components.holder import (
     ComponentHolderMixin,
     ComponentProperty,
 )
-
-
-def get_component_class(component_name):
-    subclasses = Component.__subclasses__()
-    component_class = next((sc for sc in subclasses if sc.name == component_name), None)
-    if component_class is None:
-        message = (
-            f"Component named {component_name} has not been found. "
-            f"Make sure it has been imported before being used."
-        )
-        raise Exception(message)
-
-    return component_class

--- a/evennia/contrib/base_systems/components/component.py
+++ b/evennia/contrib/base_systems/components/component.py
@@ -106,8 +106,11 @@ class Component(metaclass=BaseComponent):
             Component: The loaded instance of the component
 
         """
+        inst = cls(host)
+        if inst.cmd_set:
+            host.cmdset.add(inst.cmd_set)
 
-        return cls(host)
+        return inst
 
     def at_added(self, host):
         """

--- a/evennia/contrib/base_systems/components/component.py
+++ b/evennia/contrib/base_systems/components/component.py
@@ -173,3 +173,7 @@ class Component(metaclass=BaseComponent):
     @classmethod
     def get_fields(cls):
         return tuple(cls._fields.values())
+
+    @classmethod
+    def get_component_slot(cls):
+        return cls.slot or cls.name

--- a/evennia/contrib/base_systems/components/component.py
+++ b/evennia/contrib/base_systems/components/component.py
@@ -50,8 +50,6 @@ class Component(metaclass=BaseComponent):
     name = ""
     slot = None
 
-    cmd_set: CmdSet = None
-
     _fields = {}
 
     def __init__(self, host=None):
@@ -115,11 +113,7 @@ class Component(metaclass=BaseComponent):
             Component: The loaded instance of the component
 
         """
-        inst = cls(host)
-        if inst.cmd_set:
-            host.cmdset.add(inst.cmd_set)
-
-        return inst
+        return cls(host)
 
     def at_added(self, host):
         """
@@ -131,9 +125,6 @@ class Component(metaclass=BaseComponent):
         """
         if self.host and self.host != host:
             raise exceptions.InvalidComponentError("Components must not register twice!")
-
-        if self.cmd_set:
-            self.host.cmdset.add(self.cmd_set)
 
         self.host = host
 
@@ -147,9 +138,6 @@ class Component(metaclass=BaseComponent):
         """
         if host != self.host:
             raise ValueError("Component attempted to remove from the wrong host.")
-
-        if self.cmd_set:
-            self.host.cmdset.remove(self.cmd_set)
 
         self.host = None
 

--- a/evennia/contrib/base_systems/components/component.py
+++ b/evennia/contrib/base_systems/components/component.py
@@ -9,8 +9,17 @@ from evennia.contrib.base_systems.components import COMPONENT_LISTING, exception
 
 
 class BaseComponent(type):
+    """
+    This is the metaclass for components,
+    responsible for registering components to the listing.
+    """
     @classmethod
     def __new__(cls, *args):
+        """
+        Every class that uses this metaclass will be registered
+        as a component in the Component Listing using its name.
+        All of them require a unique name.
+        """
         new_type = super().__new__(*args)
         if new_type.__base__ == object:
             return new_type

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -32,12 +32,12 @@ class DBField(AttributeProperty):
         self._key = f"{owner.slot or owner.name}::{name}"
         owner.add_field(name, self)
 
-    def at_added(self, instance):
+    def at_added(self, component):
         if self._autocreate:
-            self.__set__(instance, self._default)
+            self.__get__(component, type(component))
 
-    def at_removed(self, instance):
-        self.__delete__(instance)
+    def at_removed(self, component):
+        self.__delete__(component)
 
 
 class NDBField(NAttributeProperty):

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -123,9 +123,9 @@ class TagField:
         """
         instance.host.tags.clear(category=self._category_key)
 
-    def at_added(self, instance):
+    def at_added(self, component):
         if self._default:
-            self.__set__(instance, self._default)
+            self.__set__(component, self._default)
 
-    def at_removed(self, instance):
-        self.__delete__(instance)
+    def at_removed(self, component):
+        self.__delete__(component)

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -29,7 +29,7 @@ class DBField(AttributeProperty):
             owner (Component): The component classF on which this is set
             name (str): The name that was used to set the DBField.
         """
-        self._key = f"{owner.slot or owner.name}::{name}"
+        self._key = f"{owner.get_component_slot()}::{name}"
         owner.add_field(name, self)
 
     def at_added(self, component):
@@ -69,7 +69,7 @@ class NDBField(NAttributeProperty):
             owner (Component): The component class on which this is set
             name (str): The name that was used to set the DBField.
         """
-        self._key = f"{owner.slot or owner.name}::{name}"
+        self._key = f"{owner.get_component_slot()}::{name}"
         owner.add_field(name, self)
 
     def at_added(self, component):
@@ -113,7 +113,7 @@ class TagField:
         Called when TagField is first assigned to the class.
         It is called with the component class and the name of the field.
         """
-        self._category_key = f"{owner.slot or owner.name}::{name}"
+        self._category_key = f"{owner.get_component_slot()}::{name}"
         owner.add_field(name, self)
 
     def __get__(self, instance, owner):

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -3,7 +3,12 @@ Components - ChrisLR 2022
 
 This file contains the Descriptors used to set Fields in Components
 """
+import typing
+
 from evennia.typeclasses.attributes import AttributeProperty, NAttributeProperty
+
+if typing.TYPE_CHECKING:
+    from evennia.contrib.base_systems.components import Component
 
 
 class DBField(AttributeProperty):
@@ -13,7 +18,10 @@ class DBField(AttributeProperty):
     It uses AttributeProperty under the hood but prefixes the key with the component name.
     """
 
-    def __set_name__(self, owner, name):
+    def __init__(self, default=None, autocreate=False, **kwargs):
+        super().__init__(default=default, autocreate=autocreate, **kwargs)
+
+    def __set_name__(self, owner: 'Component', name):
         """
         Called when descriptor is first assigned to the class.
 
@@ -21,13 +29,15 @@ class DBField(AttributeProperty):
             owner (object): The component classF on which this is set
             name (str): The name that was used to set the DBField.
         """
-        key = f"{owner.name}::{name}"
-        self._key = key
-        db_fields = getattr(owner, "_db_fields", None)
-        if db_fields is None:
-            db_fields = {}
-            setattr(owner, "_db_fields", db_fields)
-        db_fields[name] = self
+        self._key = f"{owner.slot or owner.name}::{name}"
+        owner.add_field(name, self)
+
+    def at_added(self, instance):
+        if self._autocreate:
+            self.__set__(instance, self._default)
+
+    def at_removed(self, instance):
+        self.__delete__(instance)
 
 
 class NDBField(NAttributeProperty):
@@ -37,7 +47,7 @@ class NDBField(NAttributeProperty):
     It uses NAttributeProperty under the hood but prefixes the key with the component name.
     """
 
-    def __set_name__(self, owner, name):
+    def __set_name__(self, owner: 'Component', name):
         """
         Called when descriptor is first assigned to the class.
 
@@ -45,13 +55,15 @@ class NDBField(NAttributeProperty):
             owner (object): The component class on which this is set
             name (str): The name that was used to set the DBField.
         """
-        key = f"{owner.name}::{name}"
-        self._key = key
-        ndb_fields = getattr(owner, "_ndb_fields", None)
-        if ndb_fields is None:
-            ndb_fields = {}
-            setattr(owner, "_ndb_fields", ndb_fields)
-        ndb_fields[name] = self
+        self._key = f"{owner.slot or owner.name}::{name}"
+        owner.add_field(name, self)
+
+    def at_added(self, instance):
+        if self._autocreate:
+            self.__set__(instance, self._default)
+
+    def at_removed(self, instance):
+        self.__delete__(instance)
 
 
 class TagField:
@@ -70,17 +82,13 @@ class TagField:
         self._default = default
         self._enforce_single = enforce_single
 
-    def __set_name__(self, owner, name):
+    def __set_name__(self, owner: 'Component', name):
         """
         Called when TagField is first assigned to the class.
         It is called with the component class and the name of the field.
         """
-        self._category_key = f"{owner.name}::{name}"
-        tag_fields = getattr(owner, "_tag_fields", None)
-        if tag_fields is None:
-            tag_fields = {}
-            setattr(owner, "_tag_fields", tag_fields)
-        tag_fields[name] = self
+        self._category_key = f"{owner.slot or owner.name}::{name}"
+        owner.add_field(name, self)
 
     def __get__(self, instance, owner):
         """
@@ -114,3 +122,10 @@ class TagField:
         It is called with the component instance.
         """
         instance.host.tags.clear(category=self._category_key)
+
+    def at_added(self, instance):
+        if self._default:
+            self.__set__(instance, self._default)
+
+    def at_removed(self, instance):
+        self.__delete__(instance)

--- a/evennia/contrib/base_systems/components/dbfield.py
+++ b/evennia/contrib/base_systems/components/dbfield.py
@@ -26,17 +26,31 @@ class DBField(AttributeProperty):
         Called when descriptor is first assigned to the class.
 
         Args:
-            owner (object): The component classF on which this is set
+            owner (Component): The component classF on which this is set
             name (str): The name that was used to set the DBField.
         """
         self._key = f"{owner.slot or owner.name}::{name}"
         owner.add_field(name, self)
 
     def at_added(self, component):
+        """
+        Called when the parent component is added to a host.
+
+        Args:
+            component (Component): The component instance being added.
+        """
+
         if self._autocreate:
             self.__get__(component, type(component))
 
     def at_removed(self, component):
+        """
+        Called when the parent component is removed from a host.
+
+        Args:
+            component (Component): The component instance being removed.
+        """
+
         self.__delete__(component)
 
 
@@ -52,18 +66,30 @@ class NDBField(NAttributeProperty):
         Called when descriptor is first assigned to the class.
 
         Args:
-            owner (object): The component class on which this is set
+            owner (Component): The component class on which this is set
             name (str): The name that was used to set the DBField.
         """
         self._key = f"{owner.slot or owner.name}::{name}"
         owner.add_field(name, self)
 
-    def at_added(self, instance):
-        if self._autocreate:
-            self.__set__(instance, self._default)
+    def at_added(self, component):
+        """
+        Called when the parent component is added to a host.
 
-    def at_removed(self, instance):
-        self.__delete__(instance)
+        Args:
+            component (Component): The component instance being added.
+        """
+        if self._autocreate:
+            self.__set__(component, self._default)
+
+    def at_removed(self, component):
+        """
+        Called when the parent component is removed from a host.
+
+        Args:
+            component (Component): The component instance being removed.
+        """
+        self.__delete__(component)
 
 
 class TagField:
@@ -124,8 +150,20 @@ class TagField:
         instance.host.tags.clear(category=self._category_key)
 
     def at_added(self, component):
+        """
+        Called when the parent component is added to a host.
+
+        Args:
+            component (Component): The component instance being added.
+        """
         if self._default:
             self.__set__(component, self._default)
 
     def at_removed(self, component):
+        """
+        Called when the parent component is removed from a host.
+
+        Args:
+            component (Component): The component instance being removed.
+        """
         self.__delete__(component)

--- a/evennia/contrib/base_systems/components/exceptions.py
+++ b/evennia/contrib/base_systems/components/exceptions.py
@@ -1,0 +1,10 @@
+class InvalidComponentError(ValueError):
+    pass
+
+
+class ComponentDoesNotExist(ValueError):
+    pass
+
+
+class ComponentIsNotRegistered(ValueError):
+    pass

--- a/evennia/contrib/base_systems/components/exceptions.py
+++ b/evennia/contrib/base_systems/components/exceptions.py
@@ -8,7 +8,3 @@ class ComponentDoesNotExist(ValueError):
 
 class ComponentIsNotRegistered(ValueError):
     pass
-
-
-class ComponentSlotRegisteredTwice(ValueError):
-    pass

--- a/evennia/contrib/base_systems/components/exceptions.py
+++ b/evennia/contrib/base_systems/components/exceptions.py
@@ -8,3 +8,7 @@ class ComponentDoesNotExist(ValueError):
 
 class ComponentIsNotRegistered(ValueError):
     pass
+
+
+class ComponentSlotRegisteredTwice(ValueError):
+    pass

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -77,7 +77,7 @@ class ComponentHandler:
         self.host.tags.add(component_name, category="components")
         self._set_component(component)
         for field in component.get_fields():
-            field.at_added(self.host)
+            field.at_added(component)
 
         component.at_added(self.host)
 
@@ -115,7 +115,7 @@ class ComponentHandler:
             raise exceptions.ComponentIsNotRegistered(message)
 
         for field in component.get_fields():
-            field.at_removed(self.host)
+            field.at_removed(component)
 
         component.at_removed(self.host)
         if component.cmd_set:

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -283,9 +283,16 @@ class ComponentHolderMixin:
 
         for base_type in base_type_iterator():
             base_class_components = getattr(base_type, "_class_components", ())
-            class_components.update({cmp[0]: cmp[1] for cmp in base_class_components})
+            for cmp_name, cmp_values in base_class_components:
+                cmp_class = get_component_class(cmp_name)
+                cmp_slot = cmp_class.get_component_slot()
+                class_components[cmp_slot] = (cmp_name, cmp_values)
 
+        # TODO Is this necessary?
         instance_components = getattr(self, "_class_components", ())
-        class_components.update({cmp[0]: cmp[1] for cmp in instance_components})
+        for cmp_name, cmp_values in instance_components:
+            cmp_class = get_component_class(cmp_name)
+            cmp_slot = cmp_class.get_component_slot()
+            class_components[cmp_slot] = (cmp_name, cmp_values)
 
-        return tuple(class_components.items())
+        return tuple(class_components.values())

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -5,7 +5,7 @@ This file contains the classes that allow a typeclass to use components.
 """
 
 from evennia.contrib.base_systems import components
-from evennia.contrib.base_systems.components import signals, exceptions
+from evennia.contrib.base_systems.components import signals, exceptions, get_component_class
 
 
 class ComponentProperty:
@@ -27,9 +27,16 @@ class ComponentProperty:
         """
         self.name = name
         self.values = kwargs
+        self.component_class = None
+        self.slot_name = None
 
     def __get__(self, instance, owner):
-        component = instance.components.get(self.name)
+        if not self.component_class:
+            component_class = get_component_class(self.name)
+            self.component_class = component_class
+            self.slot_name = component_class.slot or component_class.name
+
+        component = instance.components.get(self.slot_name)
         return component
 
     def __set__(self, instance, value):

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -5,7 +5,7 @@ This file contains the classes that allow a typeclass to use components.
 """
 
 from evennia.contrib.base_systems import components
-from evennia.contrib.base_systems.components import signals
+from evennia.contrib.base_systems.components import signals, exceptions
 
 
 class ComponentProperty:
@@ -17,19 +17,19 @@ class ComponentProperty:
     Defaults can be overridden for this typeclass by passing kwargs
     """
 
-    def __init__(self, component_name, **kwargs):
+    def __init__(self, name, **kwargs):
         """
         Initializes the descriptor
 
         Args:
-            component_name (str): The name of the component
+            name (str): The name of the component
             **kwargs (any): Key=Values overriding default values of the component
         """
-        self.component_name = component_name
+        self.name = name
         self.values = kwargs
 
     def __get__(self, instance, owner):
-        component = instance.components.get(self.component_name)
+        component = instance.components.get(self.name)
         return component
 
     def __set__(self, instance, value):
@@ -37,13 +37,11 @@ class ComponentProperty:
 
     def __set_name__(self, owner, name):
         # Retrieve the class_components set on the direct class only
-        class_components = owner.__dict__.get("_class_components")
+        class_components = owner.__dict__.get("_class_components", [])
         if not class_components:
-            # Create a new list, including inherited class components
-            class_components = list(getattr(owner, "_class_components", []))
             setattr(owner, "_class_components", class_components)
 
-        class_components.append((self.component_name, self.values))
+        class_components.append((self.name, self.values))
 
 
 class ComponentHandler:
@@ -57,7 +55,7 @@ class ComponentHandler:
         self.host = host
         self._loaded_components = {}
 
-    def add(self, component):
+    def add(self, component: components.Component):
         """
         Method to add a Component to a host.
         It caches the loaded component and appends its name to the host's component name list.
@@ -67,16 +65,19 @@ class ComponentHandler:
             component (object): The 'loaded' component instance to add.
 
         """
+        component_name = component.name
+        self.db_names.append(component_name)
+        self.host.tags.add(component_name, category="components")
         self._set_component(component)
-        self.db_names.append(component.name)
-        self._add_component_tags(component)
+        for field in component.get_fields():
+            field.at_added(self.host)
+
         component.at_added(self.host)
-        self.host.signals.add_object_listeners_and_responders(component)
 
     def add_default(self, name):
         """
         Method to add a Component initialized to default values on a host.
-        It will retrieve the proper component and instanciate it with 'default_create'.
+        It will retrieve the proper component and instantiate it with 'default_create'.
         It will cache this new component and add it to its list.
         It will also call the component's 'at_added' method, passing its host.
 
@@ -84,33 +85,11 @@ class ComponentHandler:
             name (str): The name of the component class to add.
 
         """
-        component = components.get_component_class(name)
-        if not component:
-            raise ComponentDoesNotExist(f"Component {name} does not exist.")
+        component_class = components.get_component_class(name)
+        component_instance = component_class.default_create(self.host)
+        self.add(component_instance)
 
-        new_component = component.default_create(self.host)
-        self._set_component(new_component)
-        self.db_names.append(name)
-        self._add_component_tags(new_component)
-        new_component.at_added(self.host)
-        self.host.signals.add_object_listeners_and_responders(new_component)
-
-    def _add_component_tags(self, component):
-        """
-        Private method that adds the Tags set on a Component via TagFields
-        It will also add the name of the component so objects can be filtered
-        by the components the implement.
-
-        Args:
-            component (object): The component instance that is added.
-        """
-        self.host.tags.add(component.name, category="components")
-        for tag_field_name in component.tag_field_names:
-            default_tag = type(component).__dict__[tag_field_name]._default
-            if default_tag:
-                setattr(component, tag_field_name, default_tag)
-
-    def remove(self, component):
+    def remove(self, component: components.Component):
         """
         Method to remove a component instance from a host.
         It removes the component from the cache and listing.
@@ -120,18 +99,26 @@ class ComponentHandler:
             component (object): The component instance to remove.
 
         """
-        component_name = component.name
-        if component_name in self._loaded_components:
-            self._remove_component_tags(component)
-            component.at_removed(self.host)
-            self.db_names.remove(component_name)
-            self.host.signals.remove_object_listeners_and_responders(component)
-            del self._loaded_components[component_name]
-        else:
+        name = component.name
+        slot_name = component.slot or name
+        if not self.has(slot_name):
             message = (
-                f"Cannot remove {component_name} from {self.host.name} as it is not registered."
+                f"Cannot remove {name} from {self.host.name} as it is not registered."
             )
-            raise ComponentIsNotRegistered(message)
+            raise exceptions.ComponentIsNotRegistered(message)
+
+        for field in component.get_fields():
+            field.at_removed(self.host)
+
+        component.at_removed(self.host)
+        if component.cmd_set:
+            self.host.cmdset.remove(component.cmd_set)
+
+        self.host.tags.remove(component.name, category="components")
+        self.host.signals.remove_object_listeners_and_responders(component)
+
+        self.db_names.remove(name)
+        del self._loaded_components[slot_name]
 
     def remove_by_name(self, name):
         """
@@ -140,49 +127,25 @@ class ComponentHandler:
         It will call the component's 'at_removed' method.
 
         Args:
-            name (str): The name of the component to remove.
+            name (str): The name of the component to remove or its slot.
 
         """
         instance = self.get(name)
         if not instance:
             message = f"Cannot remove {name} from {self.host.name} as it is not registered."
-            raise ComponentIsNotRegistered(message)
+            raise exceptions.ComponentIsNotRegistered(message)
 
-        self._remove_component_tags(instance)
-        instance.at_removed(self.host)
-        self.host.signals.remove_object_listeners_and_responders(instance)
-        self.db_names.remove(name)
+        self.remove(instance)
 
-        del self._loaded_components[name]
-
-    def _remove_component_tags(self, component):
-        """
-        Private method that will remove the Tags set on a Component via TagFields
-        It will also remove the component name tag.
-
-        Args:
-            component (object): The component instance that is removed.
-        """
-        self.host.tags.remove(component.name, category="components")
-        for tag_field_name in component.tag_field_names:
-            delattr(component, tag_field_name)
-
-    def get(self, name):
-        """
-        Method to retrieve a cached Component instance by its name.
-
-        Args:
-            name (str): The name of the component to retrieve.
-
-        """
+    def get(self, name: str) -> components.Component | None:
         return self._loaded_components.get(name)
 
-    def has(self, name):
+    def has(self, name: str) -> bool:
         """
         Method to check if a component is registered and ready.
 
         Args:
-            name (str): The name of the component.
+            name (str): The name of the component or the slot.
 
         """
         return name in self._loaded_components
@@ -203,26 +166,35 @@ class ComponentHandler:
             if component:
                 component_instance = component.load(self.host)
                 self._set_component(component_instance)
-                self.host.signals.add_object_listeners_and_responders(component_instance)
             else:
                 message = (
                     f"Could not initialize runtime component {component_name} of {self.host.name}"
                 )
-                raise ComponentDoesNotExist(message)
+                raise exceptions.ComponentDoesNotExist(message)
 
     def _set_component(self, component):
-        self._loaded_components[component.name] = component
+        """
+        Sets the loaded component in this instance.
+        """
+        slot_name = component.slot or component.name
+        self._loaded_components[slot_name] = component
+        self.host.signals.add_object_listeners_and_responders(component)
 
     @property
     def db_names(self):
         """
-        Property shortcut to retrieve the registered component names
+        Property shortcut to retrieve the registered component keys
 
         Returns:
             component_names (iterable): The name of each component that is registered
 
         """
-        return self.host.attributes.get("component_names")
+        names = self.host.attributes.get("component_names")
+        if names is None:
+            self.host.db.component_names = []
+            names = self.host.db.component_names
+
+        return names
 
     def __getattr__(self, name):
         return self.get(name)
@@ -236,7 +208,6 @@ class ComponentHolderMixin:
     All registered components are initialized on the typeclass.
     They will be of None value if not present in the class components or runtime components.
     """
-
     def at_init(self):
         """
         Method that initializes the ComponentHandler.
@@ -261,27 +232,15 @@ class ComponentHolderMixin:
         components that were set on the typeclass using ComponentProperty.
         """
         super().basetype_setup()
-        component_names = []
         setattr(self, "_component_handler", ComponentHandler(self))
         setattr(self, "_signal_handler", signals.SignalsHandler(self))
-        class_components = getattr(self, "_class_components", ())
+        class_components = self._get_class_components()
         for component_name, values in class_components:
             component_class = components.get_component_class(component_name)
             component = component_class.create(self, **values)
-            component_names.append(component_name)
-            self.components._loaded_components[component_name] = component
-            self.signals.add_object_listeners_and_responders(component)
+            self.components.add(component)
 
-        self.db.component_names = component_names
         self.signals.trigger("at_basetype_setup")
-
-    def basetype_posthook_setup(self):
-        """
-        Method that add component related tags that were set using ComponentProperty.
-        """
-        super().basetype_posthook_setup()
-        for component in self.components._loaded_components.values():
-            self.components._add_component_tags(component)
 
     @property
     def components(self) -> ComponentHandler:
@@ -305,10 +264,21 @@ class ComponentHolderMixin:
     def signals(self) -> signals.SignalsHandler:
         return getattr(self, "_signal_handler", None)
 
+    def _get_class_components(self):
+        class_components = {}
 
-class ComponentDoesNotExist(Exception):
-    pass
+        def base_type_iterator():
+            base_stack = [type(self)]
+            while base_stack:
+                _base_type = base_stack.pop()
+                yield _base_type
+                base_stack.extend(_base_type.__bases__)
 
+        for base_type in base_type_iterator():
+            base_class_components = getattr(base_type, "_class_components", ())
+            class_components.update({cmp[0]: cmp[1] for cmp in base_class_components})
 
-class ComponentIsNotRegistered(Exception):
-    pass
+        instance_components = getattr(self, "_class_components", ())
+        class_components.update({cmp[0]: cmp[1] for cmp in instance_components})
+
+        return tuple(class_components.items())

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -118,8 +118,6 @@ class ComponentHandler:
             field.at_removed(component)
 
         component.at_removed(self.host)
-        if component.cmd_set:
-            self.host.cmdset.remove(component.cmd_set)
 
         self.host.tags.remove(component.name, category="components")
         self.host.signals.remove_object_listeners_and_responders(component)

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -286,7 +286,6 @@ class ComponentHolderMixin:
                 cmp_slot = cmp_class.get_component_slot()
                 class_components[cmp_slot] = (cmp_name, cmp_values)
 
-        # TODO Is this necessary?
         instance_components = getattr(self, "_class_components", ())
         for cmp_name, cmp_values in instance_components:
             cmp_class = get_component_class(cmp_name)

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -34,7 +34,7 @@ class ComponentProperty:
         if not self.component_class:
             component_class = get_component_class(self.name)
             self.component_class = component_class
-            self.slot_name = component_class.slot or component_class.name
+            self.slot_name = component_class.get_component_slot()
 
         component = instance.components.get(self.slot_name)
         return component
@@ -107,7 +107,7 @@ class ComponentHandler:
 
         """
         name = component.name
-        slot_name = component.slot or name
+        slot_name = component.get_component_slot()
         if not self.has(slot_name):
             message = (
                 f"Cannot remove {name} from {self.host.name} as it is not registered."
@@ -181,7 +181,7 @@ class ComponentHandler:
         """
         Sets the loaded component in this instance.
         """
-        slot_name = component.slot or component.name
+        slot_name = component.get_component_slot()
         self._loaded_components[slot_name] = component
         self.host.signals.add_object_listeners_and_responders(component)
 

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -42,6 +42,14 @@ class ComponentProperty:
     def __set__(self, instance, value):
         raise Exception("Cannot set a class property")
 
+    def __set_name__(self, owner, name):
+        # Retrieve the class_components set on the direct class only
+        class_components = owner.__dict__.get("_class_components", [])
+        if not class_components:
+            setattr(owner, "_class_components", class_components)
+
+        class_components.append((self.name, self.values))
+
 
 class ComponentHandler:
     """
@@ -262,29 +270,27 @@ class ComponentHolderMixin:
         return getattr(self, "_signal_handler", None)
 
     def _get_class_components(self):
-        self_class = type(self)
-        class_components = getattr(self_class, "_class_components", None)
-        if class_components is not None:
-            return class_components
+        class_components = {}
 
-        class_components_by_slot = {}
-        for att_name in dir(self_class):
-            if att_name.startswith("__"):
-                continue
+        def base_type_iterator():
+            base_stack = [type(self)]
+            while base_stack:
+                _base_type = base_stack.pop()
+                yield _base_type
+                base_stack.extend(_base_type.__bases__)
 
-            att_obj = getattr(self_class, att_name, None)
-            if isinstance(att_obj, ComponentProperty):
-                cmp_name = att_obj.name
+        for base_type in base_type_iterator():
+            base_class_components = getattr(base_type, "_class_components", ())
+            for cmp_name, cmp_values in base_class_components:
                 cmp_class = get_component_class(cmp_name)
                 cmp_slot = cmp_class.get_component_slot()
-                if cmp_slot in class_components_by_slot:
-                    raise exceptions.ComponentSlotRegisteredTwice(
-                        f"Component slot={cmp_slot} is registered twice on class={self_class}"
-                    )
+                class_components[cmp_slot] = (cmp_name, cmp_values)
 
-                class_components_by_slot[cmp_slot] = (cmp_name, att_obj.values)
+        # TODO Is this necessary?
+        instance_components = getattr(self, "_class_components", ())
+        for cmp_name, cmp_values in instance_components:
+            cmp_class = get_component_class(cmp_name)
+            cmp_slot = cmp_class.get_component_slot()
+            class_components[cmp_slot] = (cmp_name, cmp_values)
 
-        class_components = tuple(class_components_by_slot.values())
-        setattr(self_class, "_class_components", class_components)
-
-        return class_components
+        return tuple(class_components.values())

--- a/evennia/contrib/base_systems/components/listing.py
+++ b/evennia/contrib/base_systems/components/listing.py
@@ -4,6 +4,11 @@ COMPONENT_LISTING = {}
 
 
 def get_component_class(name):
+    """
+    Retrieves a component from the listing using a name
+    Args:
+        name (str): The unique name of the component
+    """
     component_class = COMPONENT_LISTING.get(name)
     if component_class is None:
         message = (

--- a/evennia/contrib/base_systems/components/listing.py
+++ b/evennia/contrib/base_systems/components/listing.py
@@ -1,0 +1,15 @@
+from evennia.contrib.base_systems.components import exceptions
+
+COMPONENT_LISTING = {}
+
+
+def get_component_class(name):
+    component_class = COMPONENT_LISTING.get(name)
+    if component_class is None:
+        message = (
+            f"Component with name {name} has not been found. "
+            f"Make sure it has been imported before being used."
+        )
+        raise exceptions.ComponentDoesNotExist(message)
+
+    return component_class

--- a/evennia/contrib/base_systems/components/signals.py
+++ b/evennia/contrib/base_systems/components/signals.py
@@ -179,8 +179,15 @@ class SignalsHandler(object):
         Args:
             obj (object): The instance of an object to connect to this handler.
         """
-        type_host = type(obj)
-        for att_name, att_obj in type_host.__dict__.items():
+        obj_type = type(obj)
+        for att_name in dir(obj_type):
+            if att_name.startswith("__"):
+                continue
+
+            att_obj = getattr(obj_type, att_name, None)
+            if att_obj is None:
+                continue
+
             listener_signal_name = getattr(att_obj, "_listener_signal_name", None)
             if listener_signal_name:
                 callback = getattr(obj, att_name)
@@ -198,8 +205,14 @@ class SignalsHandler(object):
         Args:
             obj (object): The instance of an object to disconnect from this handler.
         """
-        type_host = type(obj)
-        for att_name, att_obj in type_host.__dict__.items():
+        for att_name in dir(obj):
+            if att_name.startswith("__"):
+                continue
+
+            att_obj = getattr(obj, att_name, None)
+            if att_obj is None:
+                continue
+
             listener_signal_name = getattr(att_obj, "_listener_signal_name", None)
             if listener_signal_name:
                 callback = getattr(obj, att_name)

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -68,28 +68,28 @@ class TestComponents(EvenniaTest):
     character_typeclass = CharacterWithComponents
 
     def test_character_has_class_components(self):
-        assert self.char1.test_a
-        assert self.char1.test_b
+        self.assertTrue(self.char1.test_a)
+        self.assertTrue(self.char1.test_b)
 
     def test_inherited_typeclass_does_not_include_child_class_components(self):
         char_with_c = create.create_object(
             InheritedTCWithComponents, key="char_with_c", location=self.room1, home=self.room1
         )
-        assert self.char1.test_a
-        assert not self.char1.cmp.get("test_c")
-        assert char_with_c.test_c
+        self.assertTrue(self.char1.test_a)
+        self.assertFalse(self.char1.cmp.get("test_c"))
+        self.assertTrue(char_with_c.test_c)
 
     def test_character_instances_components_properly(self):
-        assert isinstance(self.char1.test_a, ComponentTestA)
-        assert isinstance(self.char1.test_b, ComponentTestB)
+        self.assertIsInstance(self.char1.test_a, ComponentTestA)
+        self.assertIsInstance(self.char1.test_b, ComponentTestB)
 
     def test_character_assigns_default_value(self):
-        assert self.char1.test_a.my_int == 1
-        assert self.char1.test_a.my_list == []
+        self.assertEquals(self.char1.test_a.my_int, 1)
+        self.assertEquals(self.char1.test_a.my_list, [])
 
     def test_character_assigns_default_provided_values(self):
-        assert self.char1.test_b.my_int == 3
-        assert self.char1.test_b.my_list == [1, 2, 3]
+        self.assertEquals(self.char1.test_b.my_int, 3)
+        self.assertEquals(self.char1.test_b.my_list, [1, 2, 3])
 
     def test_component_inheritance_assigns_proper_values(self):
         self.assertEquals(self.char1.ic_a.my_int, 1)
@@ -103,25 +103,25 @@ class TestComponents(EvenniaTest):
         self.char1.components.add(rct)
         test_c = self.char1.components.get("test_c")
 
-        assert test_c
-        assert test_c.my_int == 6
-        assert test_c.my_dict == {}
+        self.assertTrue(test_c)
+        self.assertEquals(test_c.my_int, 6)
+        self.assertEquals(test_c.my_dict, {})
 
     def test_handler_can_add_default_component(self):
         self.char1.components.add_default("test_c")
         test_c = self.char1.components.get("test_c")
 
-        assert test_c
-        assert test_c.my_int == 6
+        self.assertTrue(test_c)
+        self.assertEquals(test_c.my_int, 6)
 
     def test_handler_has_returns_true_for_any_components(self):
         rct = RuntimeComponentTestC.create(self.char1)
         handler = self.char1.components
         handler.add(rct)
 
-        assert handler.has("test_a")
-        assert handler.has("test_b")
-        assert handler.has("test_c")
+        self.assertTrue(handler.has("test_a"))
+        self.assertTrue(handler.has("test_b"))
+        self.assertTrue(handler.has("test_c"))
 
     def test_can_remove_component(self):
         rct = RuntimeComponentTestC.create(self.char1)
@@ -129,9 +129,9 @@ class TestComponents(EvenniaTest):
         handler.add(rct)
         handler.remove(rct)
 
-        assert handler.has("test_a")
-        assert handler.has("test_b")
-        assert not handler.has("test_c")
+        self.assertTrue(handler.has("test_a"))
+        self.assertTrue(handler.has("test_b"))
+        self.assertFalse(handler.has("test_c"))
 
     def test_can_remove_component_by_name(self):
         rct = RuntimeComponentTestC.create(self.char1)
@@ -139,9 +139,9 @@ class TestComponents(EvenniaTest):
         handler.add(rct)
         handler.remove_by_name("test_c")
 
-        assert handler.has("test_a")
-        assert handler.has("test_b")
-        assert not handler.has("test_c")
+        self.assertTrue(handler.has("test_a"))
+        self.assertTrue(handler.has("test_b"))
+        self.assertFalse(handler.has("test_c"))
 
     def test_cannot_replace_component(self):
         with self.assertRaises(Exception):
@@ -152,76 +152,76 @@ class TestComponents(EvenniaTest):
         handler = self.char1.components
         handler.add(rct)
 
-        assert handler.get("test_c") is rct
+        self.assertIs(handler.get("test_c"), rct)
 
     def test_can_access_component_regular_get(self):
-        assert self.char1.cmp.test_a is self.char1.components.get("test_a")
+        self.assertIs(self.char1.cmp.test_a, self.char1.components.get("test_a"))
 
     def test_returns_none_with_regular_get_when_no_attribute(self):
-        assert self.char1.cmp.does_not_exist is None
+        self.assertIs(self.char1.cmp.does_not_exist, None)
 
     def test_host_has_class_component_tags(self):
-        assert self.char1.tags.has(key="test_a", category="components")
-        assert self.char1.tags.has(key="test_b", category="components")
-        assert self.char1.tags.has(key="initial_value", category="test_b::default_tag")
-        assert self.char1.test_b.default_tag == "initial_value"
-        assert not self.char1.tags.has(key="test_c", category="components")
-        assert not self.char1.tags.has(category="test_b::single_tag")
-        assert not self.char1.tags.has(category="test_b::multiple_tags")
+        self.assertTrue(self.char1.tags.has(key="test_a", category="components"))
+        self.assertTrue(self.char1.tags.has(key="test_b", category="components"))
+        self.assertTrue(self.char1.tags.has(key="initial_value", category="test_b::default_tag"))
+        self.assertTrue(self.char1.test_b.default_tag == "initial_value")
+        self.assertFalse(self.char1.tags.has(key="test_c", category="components"))
+        self.assertFalse(self.char1.tags.has(category="test_b::single_tag"))
+        self.assertFalse(self.char1.tags.has(category="test_b::multiple_tags"))
 
     def test_host_has_added_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)
         self.char1.components.add(rct)
         test_c = self.char1.components.get("test_c")
 
-        assert self.char1.tags.has(key="test_c", category="components")
-        assert self.char1.tags.has(key="added_value", category="test_c::added_tag")
-        assert test_c.added_tag == "added_value"
+        self.assertTrue(self.char1.tags.has(key="test_c", category="components"))
+        self.assertTrue(self.char1.tags.has(key="added_value", category="test_c::added_tag"))
+        self.assertEquals(test_c.added_tag, "added_value")
 
     def test_host_has_added_default_component_tags(self):
         self.char1.components.add_default("test_c")
         test_c = self.char1.components.get("test_c")
 
-        assert self.char1.tags.has(key="test_c", category="components")
-        assert self.char1.tags.has(key="added_value", category="test_c::added_tag")
-        assert test_c.added_tag == "added_value"
+        self.assertTrue(self.char1.tags.has(key="test_c", category="components"))
+        self.assertTrue(self.char1.tags.has(key="added_value", category="test_c::added_tag"))
+        self.assertEquals(test_c.added_tag, "added_value")
 
     def test_host_remove_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)
         handler = self.char1.components
         handler.add(rct)
-        assert self.char1.tags.has(key="test_c", category="components")
+        self.assertTrue(self.char1.tags.has(key="test_c", category="components"))
         handler.remove(rct)
 
-        assert not self.char1.tags.has(key="test_c", category="components")
-        assert not self.char1.tags.has(key="added_value", category="test_c::added_tag")
+        self.assertFalse(self.char1.tags.has(key="test_c", category="components"))
+        self.assertFalse(self.char1.tags.has(key="added_value", category="test_c::added_tag"))
 
     def test_host_remove_by_name_component_tags(self):
         rct = RuntimeComponentTestC.create(self.char1)
         handler = self.char1.components
         handler.add(rct)
-        assert self.char1.tags.has(key="test_c", category="components")
+        self.assertTrue(self.char1.tags.has(key="test_c", category="components"))
         handler.remove_by_name("test_c")
 
-        assert not self.char1.tags.has(key="test_c", category="components")
-        assert not self.char1.tags.has(key="added_value", category="test_c::added_tag")
+        self.assertFalse(self.char1.tags.has(key="test_c", category="components"))
+        self.assertFalse(self.char1.tags.has(key="added_value", category="test_c::added_tag"))
 
     def test_component_tags_only_hold_one_value_when_enforce_single(self):
         test_b = self.char1.components.get("test_b")
         test_b.single_tag = "first_value"
         test_b.single_tag = "second value"
 
-        assert self.char1.tags.has(key="second value", category="test_b::single_tag")
-        assert test_b.single_tag == "second value"
-        assert not self.char1.tags.has(key="first_value", category="test_b::single_tag")
+        self.assertTrue(self.char1.tags.has(key="second value", category="test_b::single_tag"))
+        self.assertEquals(test_b.single_tag, "second value")
+        self.assertFalse(self.char1.tags.has(key="first_value", category="test_b::single_tag"))
 
     def test_component_tags_default_value_is_overridden_when_enforce_single(self):
         test_b = self.char1.components.get("test_b")
         test_b.default_single_tag = "second value"
 
-        assert self.char1.tags.has(key="second value", category="test_b::default_single_tag")
-        assert test_b.default_single_tag == "second value"
-        assert not self.char1.tags.has(key="first_value", category="test_b::default_single_tag")
+        self.assertTrue(self.char1.tags.has(key="second value", category="test_b::default_single_tag"))
+        self.assertTrue(test_b.default_single_tag == "second value")
+        self.assertFalse(self.char1.tags.has(key="first_value", category="test_b::default_single_tag"))
 
     def test_component_tags_support_multiple_values_by_default(self):
         test_b = self.char1.components.get("test_b")
@@ -229,12 +229,12 @@ class TestComponents(EvenniaTest):
         test_b.multiple_tags = "second value"
         test_b.multiple_tags = "third value"
 
-        assert all(
+        self.assertTrue(all(
             val in test_b.multiple_tags for val in ("first value", "second value", "third value")
-        )
-        assert self.char1.tags.has(key="first value", category="test_b::multiple_tags")
-        assert self.char1.tags.has(key="second value", category="test_b::multiple_tags")
-        assert self.char1.tags.has(key="third value", category="test_b::multiple_tags")
+        ))
+        self.assertTrue(self.char1.tags.has(key="first value", category="test_b::multiple_tags"))
+        self.assertTrue(self.char1.tags.has(key="second value", category="test_b::multiple_tags"))
+        self.assertTrue(self.char1.tags.has(key="third value", category="test_b::multiple_tags"))
 
     def test_mutables_are_not_shared_when_autocreate(self):
         self.char1.test_a.my_list.append(1)
@@ -294,14 +294,14 @@ class TestComponentSignals(BaseEvenniaTest):
     def test_host_can_register_as_listener(self):
         self.char1.signals.trigger("my_signal")
 
-        assert self.char1.my_signal_is_called
-        assert not getattr(self.char1, "my_other_signal_is_called", None)
+        self.assertTrue(self.char1.my_signal_is_called)
+        self.assertFalse(getattr(self.char1, "my_other_signal_is_called", None))
 
     def test_host_can_register_as_responder(self):
         responses = self.char1.signals.query("my_response")
 
-        assert 1 in responses
-        assert 2 not in responses
+        self.assertIn(1, responses)
+        self.assertNotIn(2, responses)
 
     def test_component_can_register_as_listener(self):
         char = self.char1
@@ -309,16 +309,16 @@ class TestComponentSignals(BaseEvenniaTest):
         char.signals.trigger("my_signal")
 
         component = char.cmp.test_signal_a
-        assert component.my_signal_is_called
-        assert not getattr(component, "my_other_signal_is_called", None)
+        self.assertTrue(component.my_signal_is_called)
+        self.assertFalse(getattr(component, "my_other_signal_is_called", None))
 
     def test_component_can_register_as_responder(self):
         char = self.char1
         char.components.add(ComponentWithSignal.create(char))
         responses = char.signals.query("my_response")
 
-        assert 1 in responses
-        assert 2 not in responses
+        self.assertIn(1, responses)
+        self.assertNotIn(2, responses)
 
     def test_signals_can_add_listener(self):
         result = []
@@ -329,7 +329,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_listener("my_fake_signal", my_fake_listener)
         self.char1.signals.trigger("my_fake_signal")
 
-        assert result
+        self.assertTrue(result)
 
     def test_signals_can_add_responder(self):
         def my_fake_responder():
@@ -338,7 +338,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_responder("my_fake_response", my_fake_responder)
         responses = self.char1.signals.query("my_fake_response")
 
-        assert 1 in responses
+        self.assertIn(1, responses)
 
     def test_signals_can_remove_listener(self):
         result = []
@@ -350,7 +350,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.remove_listener("my_fake_signal", my_fake_listener)
         self.char1.signals.trigger("my_fake_signal")
 
-        assert not result
+        self.assertFalse(result)
 
     def test_signals_can_remove_responder(self):
         def my_fake_responder():
@@ -360,7 +360,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.remove_responder("my_fake_response", my_fake_responder)
         responses = self.char1.signals.query("my_fake_response")
 
-        assert not responses
+        self.assertFalse(responses)
 
     def test_signals_can_trigger_with_args(self):
         result = []
@@ -371,7 +371,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_listener("my_fake_signal", my_fake_listener)
         self.char1.signals.trigger("my_fake_signal", 1, kwarg1=2)
 
-        assert (1, 2) in result
+        self.assertIn((1, 2), result)
 
     def test_signals_can_query_with_args(self):
         def my_fake_responder(arg1, kwarg1):
@@ -380,7 +380,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_responder("my_fake_response", my_fake_responder)
         responses = self.char1.signals.query("my_fake_response", 1, kwarg1=2)
 
-        assert (1, 2) in responses
+        self.assertIn((1, 2), responses)
 
     def test_signals_trigger_does_not_fail_without_listener(self):
         self.char1.signals.trigger("some_unknown_signal")
@@ -395,7 +395,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_responder("my_fake_response", my_fake_responder)
         responses = self.char1.signals.query("my_fake_response", 1, kwarg1=2)
 
-        assert (1, 2) in responses
+        self.assertIn((1, 2), responses)
 
     def test_signals_can_add_object_listeners_and_responders(self):
         result = []
@@ -408,7 +408,7 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.add_object_listeners_and_responders(FakeObj())
         self.char1.signals.trigger("my_signal")
 
-        assert result
+        self.assertTrue(result)
 
     def test_signals_can_remove_object_listeners_and_responders(self):
         result = []
@@ -423,14 +423,14 @@ class TestComponentSignals(BaseEvenniaTest):
         self.char1.signals.remove_object_listeners_and_responders(obj)
         self.char1.signals.trigger("my_signal")
 
-        assert not result
+        self.assertFalse(result)
 
     def test_component_handler_signals_connected_when_adding_default_component(self):
         char = self.char1
         char.components.add_default("test_signal_a")
         responses = char.signals.query("my_component_response")
 
-        assert 3 in responses
+        self.assertIn(3, responses)
 
     def test_component_handler_signals_disconnected_when_removing_component(self):
         char = self.char1
@@ -439,7 +439,7 @@ class TestComponentSignals(BaseEvenniaTest):
         char.components.remove(comp)
         responses = char.signals.query("my_component_response")
 
-        assert not responses
+        self.assertFalse(responses)
 
     def test_component_handler_signals_disconnected_when_removing_component_by_name(self):
         char = self.char1
@@ -447,4 +447,4 @@ class TestComponentSignals(BaseEvenniaTest):
         char.components.remove_by_name("test_signal_a")
         responses = char.signals.query("my_component_response")
 
-        assert not responses
+        self.assertFalse(responses)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
**WIP**
This refactors Components to remove limitations and add some new functionality

- Registering a component is now done via Metaclass, which allows components to inherit other components
- Components may now specify a slot name, which is used to determine the attribute to access it from.
  This would let us have two components for the same feature, using a different name but the same slot name.
  Example: CharacterHealth, ItemHealth, they would both have a distinct name but use the slot health and both
  would be accessed using object.health or object.cmp.health
- ComponentHolders (Characters/Objects Etc) will also handle a bit better pulling components from inherited classes, 
  such as Mixins
- Components will by default use `__slots__` to be a bit lighter, as they are not intended to store data on themselves.
- DBFields will now auto-create correctly when they are added, but are autocreate=False by default until set, to preserve behavior

#### Motivation for adding to Evennia
A good improvement to Components Contrib

#### Other info (issues closed, discussion etc)
