### PR TITLE
fix _get_cmdset return type

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -410,7 +410,7 @@ def get_and_merge_cmdsets(
             try:
                 returnValue(obj.get_cmdsets(caller=caller, current=current))
             except AttributeError:
-                returnValue(((None, None, None), []))
+                returnValue((CmdSet(), []))
 
         local_obj_cmdsets = []
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The recent refactor of the cmdhandler changed the expected return types to be handled when merging cmdsets, but missed changing the error-case fallback to match, causing additional errors when encountered.

#### Motivation for adding to Evennia
Bug fixing