### PR TITLE
Added "where" to stop word filter exceptions.

### DIFF
--- a/evennia/help/utils.py
+++ b/evennia/help/utils.py
@@ -19,6 +19,7 @@ _LUNR_STOP_WORD_FILTER_EXCEPTIONS = [
     "get",
     "who",
     "say",
+    "where",
 ] + settings.LUNR_STOP_WORD_FILTER_EXCEPTIONS
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The LUNR list of ignored words included "where", and it is a common MUD command for checking player locations! I added it to the words that the search filter for help files should actually not ignore.

#### Motivation for adding to Evennia

An alpha tester on Song of Avaria noticed that HELP WHERE did not work, and after an hour and a half or so of very confused debugging through all my custom help command methods as well as core, I realized that there was actually no glitch or bug at all. It was a very simple fix to add a word to the stopwordfilter settings, and everything was working exactly as intended after all.

Since "where" is a pretty common MUD command, it would be beneficial to add to core in order to help others avoid this kind of confused diving. Thanks to the player of Illi for noticing and reporting this issue!

#### Other info (issues closed, discussion etc)

Owllex recommended that I open an issue but because it was such a simple thing I figured a quick fix would be more useful.