### PR TITLE
Resolving xyzgrid default_cmds error

### DIFF
--- a/evennia/contrib/grid/xyzgrid/commands.py
+++ b/evennia/contrib/grid/xyzgrid/commands.py
@@ -11,8 +11,8 @@ from collections import namedtuple
 
 from django.conf import settings
 
-from evennia import CmdSet, InterruptCommand, default_cmds
-from evennia.commands.default import building
+from evennia import CmdSet, InterruptCommand
+from evennia.commands.default import building, muxcommand
 from evennia.contrib.grid.xyzgrid.xyzgrid import get_xyzgrid
 from evennia.contrib.grid.xyzgrid.xyzroom import XYZRoom
 from evennia.utils import ansi
@@ -87,7 +87,7 @@ class CmdXYZTeleport(building.CmdTeleport):
             raise InterruptCommand
 
     def parse(self):
-        default_cmds.MuxCommand.parse(self)
+        muxcommand.MuxCommand.parse(self)
         self.obj_to_teleport = self.caller
         self.destination = None
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/root/evennia/evenv/lib/python3.10/site
-packages/evennia/commands/cmdhandler.py", line 624, in _run_command
    yield cmd.parse()
  File "/root/evennia/evenv/lib/python3.10/site
-packages/evennia/contrib/grid/xyzgrid/commands.py", line 90, in parse
    default_cmds.MuxCommand.parse(self)
AttributeError: 'NoneType' object has no attribute 'MuxCommand'

An untrapped error occurred.
(Traceback was logged 23-12-27 01:02:39-05).

#### Brief overview of PR changes/additions
Version 3.0.0 produced a bug where default_cmds would be empty upon use. This PR changes the import to directly call for muxcommand instead of using default_cmds.
