### PR TITLE
Add VS Code config to gitignore

### DIFF
--- a/evennia/game_template/gitignore
+++ b/evennia/game_template/gitignore
@@ -51,3 +51,6 @@ nosetests.xml
 
 # PyCharm config
 .idea
+
+# VSCode config
+.vscode


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a gitignore line in the game template for the standard VS Code config location to go along with the PyCharm one
