### PR TITLE
Fixing Replace Legacy Time of Day Markup

### DIFF
--- a/evennia/contrib/grid/extended_room/extended_room.py
+++ b/evennia/contrib/grid/extended_room/extended_room.py
@@ -47,6 +47,7 @@ from collections import deque
 
 from django.conf import settings
 from django.db.models import Q
+
 from evennia import (
     CmdSet,
     DefaultRoom,
@@ -432,16 +433,16 @@ class ExtendedRoom(DefaultRoom):
 
         """
         desc = desc or ""
-        time_of_day = self.get_time_of_day()
+        current_time_of_day = self.get_time_of_day()
 
         # regexes for in-desc replacements (gets cached)
         if not hasattr(self, "legacy_timeofday_regex_map"):
             timeslots = deque()
-            for time_of_day in self.times_of_day:
+            for tod in self.times_of_day:
                 timeslots.append(
                     (
-                        time_of_day,
-                        re.compile(rf"<{time_of_day}>(.*?)</{time_of_day}>", re.IGNORECASE),
+                        tod,
+                        re.compile(rf"<{tod}>(.*?)</{tod}>", re.IGNORECASE),
                     )
                 )
 
@@ -453,11 +454,10 @@ class ExtendedRoom(DefaultRoom):
                 timeslots.rotate(-1)
 
         # do the replacement
-        regextuple = self.legacy_timeofday_regex_map[time_of_day]
-        desc = regextuple[0].sub(r"\1", desc)
-        desc = regextuple[1].sub("", desc)
-        desc = regextuple[2].sub("", desc)
-        return regextuple[3].sub("", desc)
+        regextuple = self.legacy_timeofday_regex_map[current_time_of_day]
+        for regex in regextuple:
+            desc = regex.sub(r"\1" if regex == regextuple[0] else "", desc)
+        return desc
 
     def get_display_desc(self, looker, **kwargs):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
1. Renamed the loop variable in the for loop to tod to avoid shadowing the current_time_of_day.
2. Used a loop for applying the regex substitutions to make the code more concise and easier to maintain. This change fixed the main issue, ensuring that current_time_of_day retains the correct value from self.get_time_of_day() throughout the function.
3. Ensured that the current_time_of_day is correctly used for the regex lookup.

#### Motivation for adding to Evennia
Prior implementation did not correctly update room description on first instance of call, only on subsequent iterations. With this change, entering/looking at a room now displays the proper description instead of one that is potentially incorrect.

#### Other info (issues closed, discussion etc)
Resolves #3340 
