### PR TITLE
Fixes incorrect variable name in a doc string

### DIFF
--- a/evennia/game_template/typeclasses/characters.py
+++ b/evennia/game_template/typeclasses/characters.py
@@ -23,12 +23,12 @@ class Character(ObjectParent, DefaultCharacter):
                     (to change things, use at_object_creation() instead).
     at_post_move(source_location) - Launches the "look" command after every move.
     at_post_unpuppet(account) -  when Account disconnects from the Character, we
-                    store the current location in the pre_logout_location Attribute and
+                    store the current location in the prelogout_location Attribute and
                     move it to a None-location so the "unpuppeted" character
                     object does not need to stay on grid. Echoes "Account has disconnected"
                     to the room.
     at_pre_puppet - Just before Account re-connects, retrieves the character's
-                    pre_logout_location Attribute and move it back on the grid.
+                    prelogout_location Attribute and move it back on the grid.
     at_post_puppet - Echoes "AccountName has entered the game" to the room.
 
     """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Simply fixes a mistake in a variable name in a doc string.

Before: `pre_logout_location`

After: `prelogout_location`

This is how the variable is actually used in the code:

```py
# evennia/objects/objects.py

def at_pre_puppet(self, account, session=None, **kwargs):
       ...
    if self.location is None:
        # Make sure character's location is never None before being puppeted.
        # Return to last location (or home, which should always exist)
        location = self.db.prelogout_location if self.db.prelogout_location else self.home
```          
          
#### Motivation for adding to Evennia

> My goals are beyond your understanding.

Nah, just kidding. I got tripped up with this one, and want to fix so that other people don't make the same mistake :)

#### Other info (issues closed, discussion etc)

No
