### PR TITLE
Add an option for custom style overrides to the webclient

### DIFF
--- a/evennia/web/templates/webclient/base.html
+++ b/evennia/web/templates/webclient/base.html
@@ -19,6 +19,12 @@ JQuery available.
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
     <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/webclient.css" %}>
 
+    {% comment %}
+    Allows for loading custom styles without overriding the base site stylesheet
+    {% endcomment %}
+    <!-- Custom CSS -->
+    <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/custom.css" %}>
+
     <link rel="icon" type="image/x-icon" href="/static/website/images/evennia_logo.png" />
 
     <!-- Import JQuery and warn if there is a problem -->


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The core website provides a blank `custom.css` file you can replace to add style overrides into without having to copy the whole core stylesheet into your repo.

This PR just adds the same mechanism to the webclient page, for the same purpose.

#### Motivation for adding to Evennia
Requested feature on Discord