### PR TITLE
Added stacking to the Clothing contrib's inventory command.

### DIFF
--- a/evennia/contrib/game_systems/clothing/clothing.py
+++ b/evennia/contrib/game_systems/clothing/clothing.py
@@ -78,7 +78,7 @@ from django.conf import settings
 
 from evennia import DefaultCharacter, DefaultObject, default_cmds
 from evennia.commands.default.muxcommand import MuxCommand
-from evennia.utils import at_search_result, evtable, inherits_from, iter_to_str
+from evennia.utils import at_search_result, evtable, inherits_from, iter_to_str, int2str
 
 # Options start here.
 # Maximum character length of 'wear style' strings, or None for unlimited.
@@ -658,18 +658,19 @@ class CmdInventory(MuxCommand):
         wear_table = evtable.EvTable(border="header")
 
         carried = [obj for obj in items if not obj.db.worn]
-        # Build and populate a dict for tallying items
-        carried_sums = {obj.get_display_name(): 0 for obj in set(carried)}
-        for obj in carried:
-            carried_sums[obj.get_display_name()] += 1
+
+        names_and_descs = [(obj.get_display_name(self.caller), obj.get_display_desc(self.caller))
+                           for obj in set(carried)]
+        carried_sums = {tup: names_and_descs.count(tup) for tup in set(names_and_descs)}
 
         worn = [obj for obj in items if obj.db.worn]
 
         message_list.append("|wYou are carrying:|n")
-        for key, value in carried_sums.items():
+        for (name, desc), count in carried_sums.items():
             carry_table.add_row(
-                f"({value})" if value > 1 else "", key
+                f"{int2str(count)} {name}", desc
             )
+
         if carry_table.nrows == 0:
             carry_table.add_row("Nothing.", "")
         message_list.append(str(carry_table))

--- a/evennia/contrib/game_systems/clothing/clothing.py
+++ b/evennia/contrib/game_systems/clothing/clothing.py
@@ -658,12 +658,17 @@ class CmdInventory(MuxCommand):
         wear_table = evtable.EvTable(border="header")
 
         carried = [obj for obj in items if not obj.db.worn]
+        # Build and populate a dict for tallying items
+        carried_sums = {obj.get_display_name(): 0 for obj in set(carried)}
+        for obj in carried:
+            carried_sums[obj.get_display_name()] += 1
+
         worn = [obj for obj in items if obj.db.worn]
 
         message_list.append("|wYou are carrying:|n")
-        for item in carried:
+        for key, value in carried_sums.items():
             carry_table.add_row(
-                item.get_display_name(self.caller), item.get_display_desc(self.caller)
+                f"({value})" if value > 1 else "", key
             )
         if carry_table.nrows == 0:
             carry_table.add_row("Nothing.", "")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The clothing contrib's inventory command was changed to have the item's name prefaced with (qty) when quantity is greater than 1. The output was also truncated to just the name rather than the name and description. The item's id was dropped as it seemed unnecessary in the list. It is still exposed by "look objectName-itemNumber."

#### Motivation for adding to Evennia
Addresses  #3315

#### Other info (issues closed, discussion etc)
