### PR TITLE
Fix boot/ban function on channel command

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -627,7 +627,7 @@ class CmdChannel(COMMAND_DEFAULT_CLASS):
         # find all of target's nicks linked to this channel and delete them
         for nick in [
             nick
-            for nick in target.nicks.get(category="channel") or []
+            for nick in target.nicks.get(category="channel", return_tuple=True) or []
             if nick.value[3].lower() == channel.key
         ]:
             nick.delete()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The boot_user method uses nicks.get without specifying it wants a tuple, so if there is only one matching nick it tracebacks.
 
#### Motivation for adding to Evennia
bug fixing

#### Other info (issues closed, discussion etc)
traceback from discord:
```
> @chan/ban discord=testius
Are you sure you want to ban user testius from channel(s) discord (make sure name/channels are correct) Y/N?
> y
Error in ask_yes_no. Choice not confirmed (report to admin)
Traceback (most recent call last):
  File "/home/redacted/evennia/evennia/evennia/commands/cmdhandler.py", line 628, in _run_command
    ret = cmd.func()
  File "/home/redacted/evennia/evennia/evennia/utils/evmenu.py", line 1674, in func
    yes_no_question.yes_callable(caller, *args, **kwargs)
  File "/home/redacted/evennia/evennia/evennia/commands/default/comms.py", line 1234, in _ban_user
    success, err = self.ban_user(chan, target, quiet=False, reason=reason)
  File "/home/redacted/evennia/evennia/evennia/commands/default/comms.py", line 662, in ban_user
    self.boot_user(channel, target, quiet=quiet, reason=reason)
  File "/home/redacted/evennia/evennia/evennia/commands/default/comms.py", line 628, in boot_user
    for nick in [
  File "/home/redacted/evennia/evennia/evennia/commands/default/comms.py", line 631, in <listcomp>
    if nick.value[3].lower()  channel.key
AttributeError: 'str' object has no attribute 'value'
An untrapped error occurred.
(Traceback was logged 24-02-13 01:27:03).
```