### PR TITLE
Patches to improve "help" usability

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -480,9 +480,9 @@ class CmdHelp(COMMAND_DEFAULT_CLASS):
             # lunr search fields/boosts
             search_fields = [
                 {"field_name": "key", "boost": 10},
-                {"field_name": "aliases", "boost": 9},
-                {"field_name": "no_prefix", "boost": 8},
-                {"field_name": "category", "boost": 7},
+                {"field_name": "aliases", "boost": 7},
+                {"field_name": "no_prefix", "boost": 6},
+                {"field_name": "category", "boost": 5},
                 {"field_name": "tags", "boost": 1},  # tags are not used by default
             ]
         match, suggestions = None, None

--- a/evennia/game_template/world/help_entries.py
+++ b/evennia/game_template/world/help_entries.py
@@ -55,13 +55,4 @@ HELP_ENTRY_DICTS = [
 
         """,
     },
-    {
-        "key": "building",
-        "category": "building",
-        "text": """
-            Evennia comes with a bunch of default building commands. You can
-            find a beginner tutorial in the Evennia documentation.
-
-        """,
-    },
 ]

--- a/evennia/help/utils.py
+++ b/evennia/help/utils.py
@@ -88,8 +88,8 @@ def help_search_with_index(query, candidate_entries, suggestion_maxnum=5, fields
     if not fields:
         fields = [
             {"field_name": "key", "boost": 10},
-            {"field_name": "aliases", "boost": 9},
-            {"field_name": "category", "boost": 8},
+            {"field_name": "aliases", "boost": 7},
+            {"field_name": "category", "boost": 6},
             {"field_name": "tags", "boost": 5},
         ]
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the lunr weightings to prevent command aliases from taking matching precedence to command keys. I'm not sure why having the boost weights so close was causing this effect, but it does.

Also removes the "building" default filehelp entry, since it conflicts with the "building" category and is thus inaccessible and confusing as well as being a not-very-useful help file anyway. The existing "evennia" entry is sufficient of an example as well as being potentially useful.

#### Motivation for adding to Evennia
mostly bug fixing