### PR TITLE
Fix rpsystem search

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1320,12 +1320,7 @@ class ContribRPObject(DefaultObject):
     def get_search_result(
         self,
         searchdata,
-        attribute_name=None,
-        typeclass=None,
         candidates=None,
-        exact=False,
-        use_dbref=None,
-        tags=None,
         **kwargs,
     ):
         """
@@ -1352,12 +1347,12 @@ class ContribRPObject(DefaultObject):
 
             if not results and is_builder:
                 # builders get a chance to search only by key+alias
-                results = search_obj(searchdata)
+                results = search_obj(searchdata, candidates=candidates, **kwargs)
         else:
             # global searches / #drefs end up here. Global searches are
             # only done in code, so is controlled, #dbrefs are turned off
             # for non-Builders.
-            results = search_obj(searchdata)
+            results = search_obj(searchdata, **kwargs)
         return results
 
     def get_posed_sdesc(self, sdesc, **kwargs):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The update to rpsystem to keep it in line with the recent search refactor failed to pass any of the keyword arguments on to the core search, thus breaking all global and dbref searches.

This fixes that.

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Closes #3439 