### PR TITLE
Change comparison for singular vs plural

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1515,7 +1515,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             self.aliases.add(singular, category=plural_category)
 
         if kwargs.get("return_string"):
-            return singular if count in (0, 1) else plural
+            return singular if count==1 else plural
 
         return singular, plural
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The form used for describing the absence of a noun is plural, not singular. e.g. "no apples" rather than "no apple".