### PR TITLE
Fix aliases not being shown for disambiguation

### DIFF
--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -6,6 +6,7 @@ import time
 
 from anything import Anything
 from evennia import DefaultObject, create_object, default_cmds
+from evennia.commands.default import building
 from evennia.commands.default.tests import BaseEvenniaCommandTest
 from evennia.utils.test_resources import BaseEvenniaTest
 
@@ -413,10 +414,9 @@ class TestRPSystemCommands(BaseEvenniaCommandTest):
 
         expected_first_call = [
             "More than one match for 'Mushroom' (please narrow target):",
-            f" Mushroom-1 []",
-            f" Mushroom-2 []",
+            f" Mushroom-1",
+            f" Mushroom-2",
         ]
-
         self.call(default_cmds.CmdLook(), "Mushroom", "\n".join(expected_first_call))  # PASSES
 
         expected_second_call = f"Mushroom(#{mushroom1.id})\nThe first mushroom is brown."
@@ -424,3 +424,13 @@ class TestRPSystemCommands(BaseEvenniaCommandTest):
 
         expected_third_call = f"Mushroom(#{mushroom2.id})\nThe second mushroom is red."
         self.call(default_cmds.CmdLook(), "Mushroom-2", expected_third_call)  # FAILS
+
+        expected_fourth_call = "Alias(es) for 'Mushroom' set to 'fungus'."
+        self.call(building.CmdSetObjAlias(), "Mushroom-1 = fungus", expected_fourth_call) #PASSES
+
+        expected_fifth_call = [
+            "More than one match for 'Mushroom' (please narrow target):",
+            f" Mushroom-1 [fungus]",
+            f" Mushroom-2",
+        ]
+        self.call(default_cmds.CmdLook(), "Mushroom", "\n".join(expected_fifth_call)) # PASSES

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2403,9 +2403,9 @@ def at_search_result(matches, caller, query="", quiet=False, **kwargs):
                 aliases = result.aliases.all(return_objs=True)
                 # remove pluralization aliases
                 aliases = [
-                    alias
+                    alias.db_key
                     for alias in aliases
-                    if hasattr(alias, "category") and alias.category not in ("plural_key",)
+                    if alias.db_category != "plural_key"
                 ]
             else:
                 # result is likely a Command, where `.aliases` is a list of strings.
@@ -2416,7 +2416,7 @@ def at_search_result(matches, caller, query="", quiet=False, **kwargs):
                 name=result.get_display_name(caller)
                 if hasattr(result, "get_display_name")
                 else query,
-                aliases=" [{alias}]".format(alias=";".join(aliases) if aliases else ""),
+                aliases=" [{alias}]".format(alias=";".join(aliases)) if aliases else "",
                 info=result.get_extra_info(caller),
             )
         matches = None


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixed missing alias display when utils.at_search_result() asks for disambiguation.

Additionally, objects without aliases were showing '[]' (instead of nothing) due to a misplaced 'if'.

Old:
```
More than one match for 'box' (please narrow target):
 box-1 []
 box-2 []
```
New:
```
More than one match for 'box' (please narrow target):
 box-1 [cube]
 box-2
```


Unit tests for this only exist as part of contrib/rpg and were testing for the presence of '[]' since this is what at_search_result()  always returned. These test have been updated to test for the new behaviour.

#### Motivation for adding to Evennia

When utils.at_search_result() asks for disambiguation it always lists the aliases as '[]' for every matching object, whether or not it has any (non-pluralisation) aliases. This doesn't seem to be the desired behaviour.
