### PR TITLE
Fix traceback when using sethelp/edit to create a new topic

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -953,7 +953,7 @@ class CmdSetHelp(CmdHelp):
             else:
                 helpentry = create.create_help_entry(
                     topicstr,
-                    self.rhs,
+                    self.rhs if self.rhs is not None else "",
                     category=category,
                     locks=lockstring,
                     aliases=aliases,


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Creating a new help entry using the form `sethelp/edit topic` (without `= ...`), results in a NULL/None entry being created in the database which then causes a traceback when issuing `help topic`. This also results in any text entered into the editor for the initial creation being lost.

This change defaults `self.rhs` to an empty string if it is `None` at creation when using `/edit`.

#### Motivation for adding to Evennia

Prevent potential loss of an initial help topic edit.

#### Other info

**Before:**
```
>sethelp/edit test
----------Line Editor [topic test]--------------------------------------------
01|
----------[l:01 w:000 c:0000]------------(:h for help)------------------------
>This is a very important help topic.
01| This is a very important help topic.
>:wq
Saved help entry.
Closing the editor.
```
```
>help
(...)
------------------------------------- Game & World -------------------------------------
evennia  test
```
```
>help test
Traceback (most recent call last):
(...)
TypeError: expected string or bytes-like object, got 'NoneType'

An untrapped error occurred.
(Traceback was logged 24-03-30 00:55:40).
```
```
>sethelp/edit test
Buffer is of type <class 'NoneType'>). Continuing, it is converted to a string (and will
be saved as such)!
----------Line Editor [topic test]--------------------------------------------
01| None
----------[l:01 w:001 c:0004]------------(:h for help)------------------------
```

**After:**
```
>sethelp/edit test
----------Line Editor [topic test]--------------------------------------------
01|
----------[l:01 w:000 c:0000]------------(:h for help)------------------------
>This is a very important help topic.
01| This is a very important help topic.
>:wq
Saved help entry.
Closing the editor.
```
```
>help test
----------------------------------------------------------------------------------------
Help for test

This is a very important help topic.
----------------------------------------------------------------------------------------
```
```
>sethelp/delete test
Deleted help entry 'test'.
```
```
>sethelp/edit test=This is a very important help topic.
----------Line Editor [topic test]--------------------------------------------
01| This is a very important help topic.
----------[l:01 w:007 c:0036]------------(:h for help)------------------------
>:q
Closing the editor.
```
```
>help test
---------------------------------------------------------------------------------------------
Help for test

This is a very important help topic.
---------------------------------------------------------------------------------------------
```
