### PR TITLE
Fix weighted_rows() sometimes 'losing' items

### DIFF
--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2070,7 +2070,7 @@ def format_grid(elements, width=78, sep="  ", verbatim_elements=None, line_prefi
                     else:
                         row += " " * max(0, width - lrow)
                     rows.append(row)
-                    row = ""
+                    row = element
                     ic = 0
                 else:
                     # add a new slot


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When `format_grid()` uses `_weighted_rows()` and the last item on a row spills over into the last column (as it is allowed to do), the first item of the next row is lost.

This can be demonstrated using `help` with a clean game installation and a client width of 88 (see *other info* section).

#### Motivation for adding to Evennia

Fix grid items not being displayed under certain conditions.

#### Other info

**Note:** I have only tested this change using help and do not know if it might negatively impact other areas where `format_grid()` is used.

**Before:**

```
>help
-------------------------------------------Commands------------------------------------------

-- Admin ------------------------------------------------------------------------------------
ban          boot         emit         perm         unban        userpassword                
                                                                                             
-- Building ---------------------------------------------------------------------------------
(...)
```
The 'wall' topic is missing from the list.
```
>help admin

-- Admin ------------------------------------------------------------------------------------
ban        boot       emit       perm       unban      userpassword          wall            
```
The 'wall' topic has now appeared in the list due to different width calculations.

**After:**

```
>help
-------------------------------------------Commands------------------------------------------

-- Admin ------------------------------------------------------------------------------------
ban          boot         emit         perm         unban        userpassword                
wall                                                                                         
-- Building ---------------------------------------------------------------------------------
(...)
```
```
>help admin

-- Admin ------------------------------------------------------------------------------------
ban        boot       emit       perm       unban      userpassword          wall            
```

All topics are now present regardless of column widths and spill-overs.
