### PR TITLE
Fix file help topic category casing differences appearing as duplicates

### DIFF
--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -227,7 +227,7 @@ class FileHelpStorageHandler:
 
         for dct in loaded_help_dicts:
             key = dct.get("key").lower().strip()
-            category = dct.get("category", _DEFAULT_HELP_CATEGORY).strip()
+            category = dct.get("category", _DEFAULT_HELP_CATEGORY).lower().strip()
             aliases = list(dct.get("aliases", []))
             entrytext = dct.get("text", "")
             locks = dct.get("locks", "")

--- a/evennia/help/tests.py
+++ b/evennia/help/tests.py
@@ -138,5 +138,5 @@ class TestFileHelp(TestCase):
         for inum, helpentry in enumerate(result):
             self.assertEqual(HELP_ENTRY_DICTS[inum]["key"], helpentry.key)
             self.assertEqual(HELP_ENTRY_DICTS[inum].get("aliases", []), helpentry.aliases)
-            self.assertEqual(HELP_ENTRY_DICTS[inum]["category"], helpentry.help_category)
+            self.assertEqual(HELP_ENTRY_DICTS[inum]["category"].lower(), helpentry.help_category)
             self.assertEqual(HELP_ENTRY_DICTS[inum]["text"], helpentry.entrytext)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The categories of help topics in files are not lower-cased when they are read which results in the appearance of duplicated categories in the "Game & World" section of the help index when a database help topic is added, as database topic categories are forced to lower-case when created. This also happens if file topics are created with different category casing.

This also causes the default 'evennia' help topic not to be listed when doing `help general` as it is created with a category of 'General' but the query is 'general'.

Command help topics do not have this problem even if their casing is different.

This fix forces the categories of file help topics to lower case when they are read. See *other info* section for examples.

#### Motivation for adding to Evennia

Prevent "duplicated" help categories.

#### Other info

**Before:**

```
>sethelp test = Test.
Topic 'test' was successfully created.
```
```
>help
(...)
-- General ----------------------------------------------------------------------------------
evennia                                                                                      
-- General ----------------------------------------------------------------------------------
test                                                                                         
```
```
>help general
(...)
-- General ----------------------------------------------------------------------------------
test                                                                                         
```

**After:**
```
>sethelp test = Test.
Topic 'test' was successfully created.
```
```
>help
(...)
evennia  test
```
Category name is not shown for `help` if there is only one; this is the intended behaviour.
```
>help general
(...)
-- General ----------------------------------------------------------------------------------
evennia   test                                                                               
```
