### PR TITLE
Add sethelp/category switch for changing database help topic's category

### DIFF
--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -780,13 +780,14 @@ class CmdSetHelp(CmdHelp):
     Edit the help database.
 
     Usage:
-      sethelp[/switches] <topic>[[;alias;alias][,category[,locks]] [= <text>]
-
+      sethelp[/switches] <topic>[[;alias;alias][,category[,locks]]
+                [= <text or new category>]
     Switches:
       edit - open a line editor to edit the topic's help text.
       replace - overwrite existing help topic.
       append - add text to the end of existing topic with a newline between.
       extend - as append, but don't add a newline.
+      category - change category of existing help topic.
       delete - remove help topic.
 
     Examples:
@@ -794,6 +795,7 @@ class CmdSetHelp(CmdHelp):
       sethelp/append pickpocketing,Thievery = This steals ...
       sethelp/replace pickpocketing, ,attr(is_thief) = This steals ...
       sethelp/edit thievery
+      sethelp/category thievery = classes
 
     If not assigning a category, the `settings.DEFAULT_HELP_CATEGORY` category
     will be used. If no lockstring is specified, everyone will be able to read
@@ -840,7 +842,7 @@ class CmdSetHelp(CmdHelp):
 
     key = "sethelp"
     aliases = []
-    switch_options = ("edit", "replace", "append", "extend", "delete")
+    switch_options = ("edit", "replace", "append", "extend", "category", "delete")
     locks = "cmd:perm(Helper)"
     help_category = "Building"
     arg_regex = None
@@ -857,7 +859,7 @@ class CmdSetHelp(CmdHelp):
 
         if not self.args:
             self.msg(
-                "Usage: sethelp[/switches] <topic>[;alias;alias][,category[,locks,..] = <text>"
+                "Usage: sethelp[/switches] <topic>[[;alias;alias][,category[,locks]] [= <text or new category>]"
             )
             return
 
@@ -984,6 +986,19 @@ class CmdSetHelp(CmdHelp):
                 old_entry.entrytext += "\n%s" % self.rhs
             old_entry.aliases.add(aliases)
             self.msg(f"Entry updated:\n{old_entry.entrytext}{aliastxt}")
+            return
+
+        if "category" in switches:
+            # set the category
+            if not old_entry:
+                self.msg(f"Could not find topic '{topicstr}'{aliastxt}.")
+                return
+            if not self.rhs:
+                self.msg("You must supply a category.")
+                return
+            category = self.rhs.lower()
+            old_entry.help_category = category
+            self.msg(f"Category for entry '{topicstr}'{aliastxt} changed to '{category}'.")
             return
 
         if "delete" in switches or "del" in switches:

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -197,6 +197,12 @@ class TestHelp(BaseEvenniaCommandTest):
             cmdset=CharacterCmdSet(),
         )
         self.call(help_module.CmdHelp(), "testhelp", "Help for testhelp", cmdset=CharacterCmdSet())
+        self.call(
+            help_module.CmdSetHelp(),
+            "/category testhelp = misc",
+            "Category for entry 'testhelp' changed to 'misc'.",
+            cmdset=CharacterCmdSet(),
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Add `sethelp/category` switch to change the category of a database help topic.

#### Motivation for adding to Evennia

There was no in-game way to change the category of a database help topic once created.

#### Other info

I wasn't sure exactly how to represent the usage for this but I gave it my best guess based on other help topics.

**Examples:**

*Note that the filehelp topic 'evennia' is not present in these examples. See https://github.com/evennia/evennia/pull/3457.*

```
>help
(...)
test      test2                                                                              
```
```
>sethelp/category test2 = misc
Category for entry 'test2' changed to 'misc'.
```
```
help
(...)
-- General ----------------------------------------------------------------------------------
test                                                                                         
-- Misc -------------------------------------------------------------------------------------
test2                                                                                        
```
