### PR TITLE
Fix editor echo not displaying correctly for lines with whitespace

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -414,7 +414,7 @@ class CmdLineInput(CmdEditorBase):
 
                 self.caller.msg("|b%02i|||n (|g%s|n) %s" % (cline, indent, raw(line)))
             else:
-                self.caller.msg("|b%02i|||n %s" % (cline, raw(self.args)))
+                self.caller.msg("|b%02i|||n %s" % (cline, raw(line)))
 
 
 class CmdEditorGroup(CmdEditorBase):

--- a/evennia/utils/tests/test_eveditor.py
+++ b/evennia/utils/tests/test_eveditor.py
@@ -168,13 +168,13 @@ class TestEvEditor(BaseEvenniaCommandTest):
             eveditor.CmdLineInput(),
             'First test "line".',
             raw_string='First test "line".',
-            msg='01First test "line" .',
+            msg='01First test "line".',
         )
         self.call(
             eveditor.CmdLineInput(),
             "Second 'line'.",
             raw_string="Second 'line'.",
-            msg="02Second 'line' .",
+            msg="02Second 'line'.",
         )
         self.assertEqual(
             self.char1.ndb._eveditor.get_buffer(), "First test \"line\".\nSecond 'line'."

--- a/evennia/utils/tests/test_eveditor.py
+++ b/evennia/utils/tests/test_eveditor.py
@@ -156,6 +156,13 @@ class TestEvEditor(BaseEvenniaCommandTest):
             "First test line\nInserted-New Replaced Second line-End\n test line\n:",
         )
 
+        self.call(
+            eveditor.CmdLineInput(),
+            "  Whitespace   echo    test     line.",
+            raw_string="  Whitespace   echo    test     line.",
+            msg="05  Whitespace   echo    test     line.",
+        )
+
     def test_eveditor_COLON_UU(self):
         eveditor.EvEditor(self.char1)
         self.call(


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When in normal editing mode (i.e. not in code editing mode) and adding lines with extra whitespace (leading or between words) the input echoing does not correctly reflect what is actually added to the buffer (the extra space is stripped).

This fixes the echo to correctly show what is added.

#### Motivation for adding to Evennia

Correct editor echo display.

#### Other info

**Before (in the editor):**
```
>  This  line   has    whitespace.
01| This line has whitespace.
>:
----------Line Editor [topic test]--------------------------------------------
01|   This  line   has    whitespace.
----------[l:01 w:004 c:0033]------------(:h for help)------------------------
```
**After (in the editor):**
```
>  This  line   has    whitespace.
01|   This  line   has    whitespace.
>:
----------Line Editor [topic test]--------------------------------------------
01|   This  line   has    whitespace.
----------[l:01 w:004 c:0033]------------(:h for help)------------------------
```
