### PR TITLE
Correct help for editor's paste command

### DIFF
--- a/docs/source/Components/EvEditor.md
+++ b/docs/source/Components/EvEditor.md
@@ -134,7 +134,7 @@ the in-editor help command (`:h`).
 
  :y  <l>        - yank (copy) line <l> to the copy buffer
  :x  <l>        - cut line <l> and store it in the copy buffer
- :p  <l>        - put (paste) previously copied line directly after <l>
+ :p  <l>        - put (paste) previously copied line directly before <l>
  :i  <l> <txt>  - insert new text <txt> at line <l>. Old line will move down
  :r  <l> <txt>  - replace line <l> with text <txt>
  :I  <l> <txt>  - insert text at the beginning of line <l>

--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -88,7 +88,7 @@ _HELP_TEXT = _(
 
  :y  <l>        - yank (copy) line(s) <l> to the copy buffer
  :x  <l>        - cut line(s) <l> and store it in the copy buffer
- :p  <l>        - put (paste) previously copied line(s) directly after <l>
+ :p  <l>        - put (paste) previously copied line(s) directly before <l>
  :i  <l> <txt>  - insert new text <txt> at line <l>. Old line will move down
  :r  <l> <txt>  - replace line <l> with text <txt>
  :I  <l> <txt>  - insert text at the beginning of line <l>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Correct the help for the editor's `:p` command. The help states that it pastes the line after `<l>`, but it actually pastes it before `<l>` (see *other info*).

#### Motivation for adding to Evennia

Correcting help/documentation.

#### Other info
```
>:
----------Line Editor [desc]--------------------------------------------------
01| line 1
02| line 2
03| line 3
----------[l:03 w:010 c:0051]------------(:h for help)------------------------
```
```
>:y 3
Line 3, ['line 3'] yanked.
```
```
>:p 1
Pasted buffer ['line 3'] to line 1.
>:
----------Line Editor [desc]--------------------------------------------------
01| line 3
02| line 1
03| line 2
04| line 3
----------[l:04 w:012 c:0058]------------(:h for help)------------------------
```
