### PR TITLE
Fix editor's range specification

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -305,12 +305,9 @@ class CmdEditorBase(_COMMAND_DEFAULT_CLASS):
         linerange = False
         if arglist and arglist[0].count(":") == 1:
             part1, part2 = arglist[0].split(":")
-            if part1 and part1.isdigit():
-                lstart = min(max(0, int(part1)) - 1, nlines)
-                linerange = True
-            if part2 and part2.isdigit():
-                lend = min(lstart + 1, int(part2)) + 1
-                linerange = True
+            lstart = min(max(1, int(part1)), nlines) - 1 if utils.value_is_integer(part1) else 0
+            lend = min(max(lstart + 1, int(part2)), nlines) if utils.value_is_integer(part2) else nlines
+            linerange = True
         elif arglist and arglist[0].isdigit():
             lstart = min(max(0, int(arglist[0]) - 1), nlines)
             lend = lstart + 1

--- a/evennia/utils/tests/test_eveditor.py
+++ b/evennia/utils/tests/test_eveditor.py
@@ -8,6 +8,67 @@ from evennia.utils import eveditor
 
 
 class TestEvEditor(BaseEvenniaCommandTest):
+    def test_eveditor_ranges(self):
+        eveditor.EvEditor(self.char1)
+        self.call(
+            eveditor.CmdEditorGroup(),
+            "",
+            cmdstring=":",
+            msg="Line Editor []\n01\n[l:01 w:000 c:0000](:h for help)",
+        )
+        self.call(eveditor.CmdLineInput(), "line 1", raw_string="line 1", msg="01line 1")
+        self.call(eveditor.CmdLineInput(), "line 2", raw_string="line 2", msg="02line 2")
+        self.call(eveditor.CmdLineInput(), "line 3", raw_string="line 3", msg="03line 3")
+        self.call(eveditor.CmdLineInput(), "line 4", raw_string="line 4", msg="04line 4")
+        self.call(eveditor.CmdLineInput(), "line 5", raw_string="line 5", msg="05line 5")
+        self.call(
+            eveditor.CmdEditorGroup(),
+            "", # list whole buffer
+            cmdstring=":",
+            msg="Line Editor []\n01line 1\n02line 2\n"
+            "03line 3\n04line 4\n05line 5\n"
+            "[l:05 w:010 c:0034](:h for help)",
+        )
+        self.call(
+            eveditor.CmdEditorGroup(),
+            ":", # list empty range
+            cmdstring=":",
+            msg="Line Editor []\n01line 1\n02line 2\n"
+            "03line 3\n04line 4\n05line 5\n"
+            "[l:05 w:010 c:0034](:h for help)",
+        )
+        self.call(
+            eveditor.CmdEditorGroup(),
+            ":4", # list from start to line 4
+            cmdstring=":",
+            msg="Line Editor []\n01line 1\n02line 2\n"
+            "03line 3\n04line 4\n"
+            "[l:04 w:008 c:0027](:h for help)",
+        )
+        self.call(
+            eveditor.CmdEditorGroup(),
+            "2:", # list from line 2 to end
+            cmdstring=":",
+            msg="Line Editor []\n02line 2\n03line 3\n"
+            "04line 4\n05line 5\n"
+            "[l:04 w:008 c:0027](:h for help)",
+        )
+        self.call(
+            eveditor.CmdEditorGroup(),
+            "-10:10", # try to list invalid range (too large)
+            cmdstring=":",
+            msg="Line Editor []\n01line 1\n02line 2\n"
+            "03line 3\n04line 4\n05line 5\n"
+            "[l:05 w:010 c:0034](:h for help)",
+        )
+        self.call(
+            eveditor.CmdEditorGroup(),
+            "3:1", # try to list invalid range (reversed)
+            cmdstring=":",
+            msg="Line Editor []\n03line 3\n"
+            "[l:01 w:002 c:0006](:h for help)",
+        )
+
     def test_eveditor_view_cmd(self):
         eveditor.EvEditor(self.char1)
         self.call(
@@ -244,7 +305,7 @@ class TestEvEditor(BaseEvenniaCommandTest):
             msg="Line Editor []\n01\n[l:01 w:000 c:0000](:h for help)",
         )
         self.call(eveditor.CmdLineInput(), "line 1", raw_string="line 1", msg="01line 1")
-        self.call(eveditor.CmdEditorGroup(), "1:2", cmdstring=":f", msg="Flood filled lines 1-2.")
+        self.call(eveditor.CmdEditorGroup(), "1:2", cmdstring=":f", msg="Flood filled line 1.")
         self.assertEqual(self.char1.ndb._eveditor.get_buffer(), "line 1")
 
     def test_eveditor_COLON_J(self):

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -3077,3 +3077,21 @@ def ip_from_request(request, exclude=None) -> str:
 
     logger.log_warn("ip_from_request: No valid IP address found in request. Using remote_addr.")
     return remote_addr
+
+
+def value_is_integer(value):
+    """
+    Determines if a value can be type-cast to an integer.
+
+    Args:
+        value (any): The value to check.
+
+    Returns:
+        result (bool): Whether it can be type-cast to an integer or not.
+    """
+    try:
+        int(value)
+    except ValueError:
+        return False
+
+    return True


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The editor's range specification (n:n) returns at most two lines. This has been fixed.

Also, as part of this:
 - An existing unit test has been corrected
 - New unit tests have been added to test various ranges
 - `utils.value_is_integer(value)` has been added which returns `True` if `value` can be type-cast to an integer and `False` otherwise. This is to allow checking for negative integers, which `str.isdigit()` can't do.

#### Motivation for adding to Evennia

Fix editor range specification.

#### Other info

**Test buffer**
```
>:
----------Line Editor [desc]--------------------------------------------------
01| line 1
02| line 2
03| line 3
04| line 4
05| line 5
----------[l:05 w:010 c:0034]------------(:h for help)------------------------
```
**Before**
```
>: 1:5
----------Line Editor [desc]--------------------------------------------------
01| line 1
02| line 2
----------[l:02 w:004 c:0013]------------(:h for help)------------------------
```
**After**
```
>: 1:5
----------Line Editor [desc]--------------------------------------------------
01| line 1
02| line 2
03| line 3
04| line 4
05| line 5
----------[l:05 w:010 c:0034]------------(:h for help)------------------------
```
**Changed unit test**

```
def test_eveditor_COLON_F(self):
    eveditor.EvEditor(self.char1)
    self.call(
        eveditor.CmdEditorGroup(),
        "",
        cmdstring=":",
        msg="Line Editor []\n01\n[l:01 w:000 c:0000](:h for help)",
    )
    self.call(eveditor.CmdLineInput(), "line 1", raw_string="line 1", msg="01line 1")
    self.call(eveditor.CmdEditorGroup(), "1:2", cmdstring=":f", msg="Flood filled lines 1-2.
```

This test expects the output "Flood filled lines 1-2." for a buffer containing only one line. After the fix the above command will return "Flood filled line 1.", which is correct. The test has been updated to look for the new output.
