### PR TITLE
Add proper name support to get_numbered_name()

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -108,13 +108,13 @@ class TestGeneral(BaseEvenniaCommandTest):
         self.call(general.CmdNick(), "/list", "Defined Nicks:")
 
     def test_get_and_drop(self):
-        self.call(general.CmdGet(), "Obj", "You pick up an Obj")
-        self.call(general.CmdDrop(), "Obj", "You drop an Obj")
+        self.call(general.CmdGet(), "Obj", "You pick up Obj")
+        self.call(general.CmdDrop(), "Obj", "You drop Obj")
 
     def test_give(self):
         self.call(general.CmdGive(), "Obj to Char2", "You aren't carrying Obj.")
         self.call(general.CmdGive(), "Obj = Char2", "You aren't carrying Obj.")
-        self.call(general.CmdGet(), "Obj", "You pick up an Obj")
+        self.call(general.CmdGet(), "Obj", "You pick up Obj")
         self.call(general.CmdGive(), "Obj to Char2", "You give")
         self.call(general.CmdGive(), "Obj = Char", "You give", caller=self.char2)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1467,6 +1467,10 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         shown once. Also the singular display version, such as 'an apple', 'a tree' is determined
         from this method.
 
+        If the object's key starts with an upper-case letter and count is 1 then the key will be
+        returned as is for both singular and plural. This behavior can be disabled by setting the
+        attibute 'no_proper_name=True' on the object.
+
         Args:
             count (int): Number of objects of this type
             looker (Object): Onlooker. Not used by default.
@@ -1488,6 +1492,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         plural_category = "plural_key"
         key = kwargs.get("key", self.get_display_name(looker))
+
         raw_key = self.name
         key = ansi.ANSIString(key)  # this is needed to allow inflection of colored names
         try:
@@ -1504,6 +1509,11 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # save the singular form as an alias here too so we can display "an egg" and also
             # look at 'an egg'.
             self.aliases.add(singular, category=plural_category)
+
+        if self.attributes.get("proper_named") is not False and key[0].isupper() and count == 1:
+            if kwargs.get("return_string"):
+                return key
+            return key, key
 
         if kwargs.get("return_string"):
             return singular if count==1 else plural


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Objects created with a key beginning with an upper-case letter are now treated by `get_numbered_name()` as being proper-named and will return the key as-is. The default behaviour can be restored per-object by setting the object attribute `proper_named=False`.

See below for examples.

#### Motivation for adding to Evennia

This makes the names of proper-named objects scan better. I think the behaviour will work naturally for most cases, but can be overridden for exceptions.

I will add unit tests if you decide to accept this change.

#### Regarding existing unit tests

The existing unit tests use and object called "Obj", which is proper-named. That tests looking for things like `You pick up an Obj.` have been changed to look for `You pick up Obj.`, etc. While this looks a little odd it is correct for these instances.

A better way would be to rename the objects along the lines of "obj" and "box" (another that caused failures). However, the casing is quite deeply embedded in the test suite for objects and would require many other changed to expected outputs, so I'm reluctant to change it.

As I mentioned above, I will add additional tests to cover differences between, for example, "Obj" and "obj".

#### Examples
```
>create ring
You create a new Object: ring.
>i
You are carrying:
 a ring  You see nothing special.
```
```
>create The One Ring
You create a new Object: The One Ring.
>i
You are carrying:
 The One Ring  You see nothing special.
 a ring        You see nothing special.
```
```
>create Evennia manual
You create a new Object: Evennia manual.
>i
You are carrying:
 Evennia manual  You see nothing special.
 The One Ring    You see nothing special.
 a ring          You see nothing special.
```
```
>set manual/proper_named = False
Created attribute Evennia manual/proper_named [category:None] = False
>i
You are carrying:
 an Evennia manual  You see nothing special.
 The One Ring       You see nothing special.
 a ring             You see nothing special.
```
](https://github.com/evennia/evennia/pull/3465/files)