### PR TITLE
Add support to get_numbered_name() for omitting the article

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1483,8 +1483,12 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 including the count.
 
         Examples:
-            ::
-                obj.get_numbered_name(3, looker, key="foo") -> ("a foo", "three foos")
+        ::
+            - obj.get_numbered_name(3, looker, key="foo") -> ("a foo", "three foos")
+            - obj.get_numbered_name(1, looker, key="Foobert", return_string=True)
+                  -> "a Foobert"
+            - obj.get_numbered_name(1, looker, key="Foobert", return_string=True, no_article=True)
+                  -> "Foobert"
 
         """
         plural_category = "plural_key"

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1476,6 +1476,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 method is used.
             return_string (bool): If `True`, return only the singular form if count is 0,1 or
                 the plural form otherwise. If `False` (default), return both forms as a tuple.
+            no_article (bool): If `True`, do not return an article if `count` is 1.
 
         Returns:
             tuple: This is a tuple `(str, str)` with the singular and plural forms of the key
@@ -1504,6 +1505,11 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # save the singular form as an alias here too so we can display "an egg" and also
             # look at 'an egg'.
             self.aliases.add(singular, category=plural_category)
+
+        if kwargs.get("no_article") and count == 1:
+            if kwargs.get("return_string"):
+                return key
+            return key, key
 
         if kwargs.get("return_string"):
             return singular if count==1 else plural

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -185,6 +185,11 @@ class DefaultObjectTest(BaseEvenniaTest):
             pattern,
         )
 
+    def test_get_name_without_article(self):
+        self.assertEqual(self.obj1.get_numbered_name(1, self.char1, return_string=True), "an Obj")
+        self.assertEqual(
+            self.obj1.get_numbered_name(1, self.char1, return_string=True, no_article=True), "Obj"
+        )
 
 class TestObjectManager(BaseEvenniaTest):
     "Test object manager methods"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds support for a `kwarg` '`no_article`' to `get_numbered_name()`. When set to `True` and `count` is 1, it will return the key as-is without an article.

See below for usage and examples.

(Thanks to Inspector Caracal for the brainstorming on this one.)

#### Motivation for adding to Evennia

Adds support for making the names of proper-named objects scan better.

### Usage
```
from typeclasses.objects import Object

class ProperNamedObject(Object):
    """
    This is a base class for objects that have a proper name, for example "The One Ring'.

    The effect of using this class is that the object's numbered name will not include the
    indefinite article when there is only one of them in scope.
    """

    def get_numbered_name(self, count, looker, **kwargs):
        return super().get_numbered_name(count, looker, no_article=True, **kwargs)
```

#### Examples
```
>create The One Ring
You create a new Object: The One Ring.
>i
You are carrying:
 a The One Ring  You see nothing special.
```
```
>type the one ring = typeclasses.utils.ProperNamedObject
(...)
>i
You are carrying:
 The One Ring  You see nothing special.
```
```
>create The Other One Ring : typeclasses.utils.ProperNamedObject
You create a new ProperNamedObject: The Other One Ring.
>i
You are carrying:
 The One Ring        You see nothing special.
 The Other One Ring  You see nothing special.
```
