### PR TITLE
Add alias/delete switch

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -790,6 +790,23 @@ class TestBuilding(BaseEvenniaCommandTest):
         self.call(building.CmdSetObjAlias(), "Obj2 =", "Cleared aliases from Obj2")
         self.call(building.CmdSetObjAlias(), "Obj2 =", "No aliases to clear.")
 
+        self.call(building.CmdSetObjAlias(), "Obj =", "Cleared aliases from Obj: testobj1b")
+        self.call(building.CmdSetObjAlias(),
+            "/category Obj = testobj1b:category1",
+            "Alias(es) for 'Obj' set to 'testobj1b' (category: 'category1')."
+        )
+        self.call(
+            building.CmdSetObjAlias(),
+            "/category Obj = testobj1b:category2",
+            "Alias(es) for 'Obj' set to 'testobj1b,testobj1b' (category: 'category2')."
+        )
+        self.call(
+            building.CmdSetObjAlias(), # delete both occurences of alias 'testobj1b'
+            "/delete Obj = testobj1b",
+            "Alias 'testobj1b' deleted from Obj."
+        )
+        self.call(building.CmdSetObjAlias(), "Obj =", "No aliases to clear.")
+
     def test_copy(self):
         self.call(
             building.CmdCopy(),


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds `alias/delete` switch to allow deletion of a specific alias. For simplicity's sake, it deletes the specified alias from all categories.

#### Motivation for adding to Evennia

There was no (non-Python) way to delete a specific alias without deleting them all and re-adding the ones you wanted.

#### Examples

```
>alias box
Aliases for box: 'a box'[category:'plural_key'], 'one box'[category:'plural_key']
```
```
>alias/category box=cube:geometry
Alias(es) for 'box' set to 'a box,cube,one box' (category: 'geometry').
```
```
>alias/category box=cube:shape
Alias(es) for 'box' set to 'a box,cube,cube,one box' (category: 'shape').
```
```
>alias box
Aliases for box: 'a box'[category:'plural_key'], 'cube'[category:'geometry'],
'cube'[category:'shape'], 'one box'[category:'plural_key']
```
```
>alias/delete box=cube
Alias 'cube' deleted from box.
```
```
>alias box
Aliases for box: 'a box'[category:'plural_key'], 'one box'[category:'plural_key']
````
