### PR TITLE
Exclude viewer from displayed contents

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1434,7 +1434,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         return [
             obj
             for obj in obj_list
-            if (obj.access(looker, "view") and obj.access(looker, "search", default=True))
+            if obj != looker and (obj.access(looker, "view") and obj.access(looker, "search", default=True))
         ]
 
     # name and return_appearance hooks


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The recent addition of the `filter_visible` method didn't include the check to make sure the viewer isn't included.

#### Motivation for adding to Evennia
Bug fixing