### PR TITLE
Fix typo in default `msg_contents` mapping

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -944,7 +944,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         you = from_obj or self
 
         if "you" not in mapping:
-            mapping[you] = you
+            mapping["you"] = you
 
         contents = self.contents
         if exclude:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The code checks if the key `"you"` exists, but then adds a key of the actual object referenced by `you` instead of using the string. This seems an evident typo preventing the intended `"{you} does something with {obj}."` third-person functionality.

#### Motivation for adding to Evennia
bug fixing