### PR TITLE
Add missing bracket in sethome message

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1397,7 +1397,7 @@ class CmdSetHome(CmdLink):
             obj.home = new_home
             if old_home:
                 string = (
-                    f"Home location of {obj} was changed from {old_home}({old_home.dbref} to"
+                    f"Home location of {obj} was changed from {old_home}({old_home.dbref}) to"
                     f" {new_home}({new_home.dbref})."
                 )
             else:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added a missing closing bracket to the `sethome` message:

```
>sethome me = here
Home location of Chiizujin was changed from Limbo(#2 to Limbo(#2).

                               |
                               V

>sethome me = here
Home location of Chiizujin was changed from Limbo(#2) to Limbo(#2).
```
#### Motivation for adding to Evennia

Typo fix.