### PR TITLE
Prevents admin from walking out non-existent exits in the wilderness

### DIFF
--- a/evennia/contrib/grid/wilderness/wilderness.py
+++ b/evennia/contrib/grid/wilderness/wilderness.py
@@ -682,7 +682,7 @@ class WildernessExit(DefaultExit):
         Returns:
             bool: True if traversing_object is allowed to traverse
         """
-        return True
+        return self.wilderness.is_valid_coordinates(new_coordinates)
 
     def at_traverse(self, traversing_object, target_location):
         """


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When navigating the wilderness as an Admin you can see exits that are otherwise invalid.  If you try to use one of these invalid exits, you will encounter stack traces and your character will get stuck unable to teleport themselves out.  You have to go ooc, switch characters, teleport them to safety, and switch back.

#### Motivation for adding to Evennia

Suggested this to `evennia-minimud` but it was rejected on the grounds that the issue is with the contrib, so I'm suggesting it here.

#### Other info (issues closed, discussion etc)

Probably not relevant, but since I mention it above, that rejected pull request:

https://github.com/InspectorCaracal/evennia-minimud/pull/10