### PR TITLE
Fix editor search/replace feedback when replacing markup

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -673,13 +673,13 @@ class CmdEditorGroup(CmdEditorBase):
                     if not self.linerange:
                         caller.msg(
                             _("Search-replaced {arg1} -> {arg2} for lines {l1}-{l2}.").format(
-                                arg1=self.arg1, arg2=self.arg2, l1=lstart + 1, l2=lend
+                                arg1=raw(self.arg1), arg2=raw(self.arg2), l1=lstart + 1, l2=lend
                             )
                         )
                     else:
                         caller.msg(
                             _("Search-replaced {arg1} -> {arg2} for {line}.").format(
-                                arg1=self.arg1, arg2=self.arg2, line=self.lstr
+                                arg1=raw(self.arg1), arg2=raw(self.arg2), line=self.lstr
                             )
                         )
                 buf = linebuffer[:lstart] + sarea.split("\n") + linebuffer[lend:]


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When using the search/replace function in the editor, the feedback message displays incorrectly if markup is involved.

#### Motivation for adding to Evennia

Bug fix.

#### Other info

**Before**
```
>:
----------Line Editor [topic test]--------------------------------------------
01| A line with |rred text|n in it.
----------[l:01 w:007 c:0031]------------(:h for help)------------------------
```
```
>:s \|r |b
Search-replaced \ ->  for lines 1-1.
```
In the above message, `->` is displayed in red and `for lines 1-1.` is displayed in blue. The message also doesn't reflect what was changed since the markup has been replaced with ANSI codes.
```
>:
----------Line Editor [topic test]--------------------------------------------
01| A line with |bred text|n in it.
----------[l:01 w:007 c:0031]------------(:h for help)------------------------
```
**After**
```
>:
----------Line Editor [topic test]--------------------------------------------
01| A line with |rred text|n in it.
----------[l:01 w:007 c:0031]------------(:h for help)------------------------
```
```
>:s \|r |b
Search-replaced \|r -> |b for lines 1-1.
```
There are no colours in the message and it correctly reflects what the change was.
```
>:
----------Line Editor [topic test]--------------------------------------------
01| A line with |bred text|n in it.
----------[l:01 w:007 c:0031]------------(:h for help)------------------------
```
The other code path (line range specified):
```
>:s 1:1 \|b |r
Search-replaced \|b -> |r for line 1.
```
Correct, with no colours.
