### PR TITLE
Add width argument to editor's :j and :f commands

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -97,10 +97,11 @@ _HELP_TEXT = _(
 
  :s <l> <w> <txt> - search/replace word or regex <w> in buffer or on line <l>
 
- :j <l> <a> =<w>  - justify buffer or line <l>. <a> is f, c, l or r. <w> is
-                    width. Default for <a> is l (left). Default for <w> is {_DEFAULT_WIDTH}
- :f <l> =<w>      - flood-fill entire buffer or line <l> to width <w>.
-                    Equivalent to :j <l> l
+ :j <l> <a> = <w> - justify buffer or line <l>. <a> is f, c, l or r. <w> is
+                    width. <a> and <w> are optional and default to l (left)
+                    and {_DEFAULT_WIDTH} respectively
+ :f <l> = <w>     - flood-fill entire buffer or line <l> to width <w>.
+                    Equivalent to :j <l> l. <w> is optional, as for :j
  :fi <l>    - indent entire buffer or line <l>
  :fd <l>    - de-indent entire buffer or line <l>
 

--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -67,7 +67,7 @@ _DEFAULT_WIDTH = settings.CLIENT_DEFAULT_WIDTH
 # -------------------------------------------------------------
 
 _HELP_TEXT = _(
-    """
+    f"""
  <txt>  - any non-command is appended to the end of the buffer.
  :  <l> - view buffer or only line(s) <l>
  :: <l> - raw-view buffer or only line(s) <l>
@@ -97,8 +97,10 @@ _HELP_TEXT = _(
 
  :s <l> <w> <txt> - search/replace word or regex <w> in buffer or on line <l>
 
- :j <l> <w> - justify buffer or line <l>. <w> is f, c, l or r. Default f (full)
- :f <l>     - flood-fill entire buffer or line <l>. Equivalent to :j <l> l
+ :j <l> <a> =<w>  - justify buffer or line <l>. <a> is f, c, l or r. <w> is
+                    width. Default for <a> is l (left). Default for <w> is {_DEFAULT_WIDTH}
+ :f <l> =<w>      - flood-fill entire buffer or line <l> to width <w>.
+                    Equivalent to :j <l> l
  :fi <l>    - indent entire buffer or line <l>
  :fd <l>    - de-indent entire buffer or line <l>
 
@@ -686,7 +688,14 @@ class CmdEditorGroup(CmdEditorBase):
                 editor.update_buffer(buf)
         elif cmd == ":f":
             # :f <l> flood-fill buffer or <l> lines of buffer.
+            # :f <l> =<w> flood-fill buffer or <l> lines of buffer to width <w>.
             width = _DEFAULT_WIDTH
+            if self.arg1:
+                value = self.arg1.lstrip("=")
+                if not value.isdigit():
+                    self.caller.msg("Width must be a number.")
+                    return
+                width = int(value)
             if not self.linerange:
                 lstart = 0
                 lend = self.cline + 1
@@ -698,7 +707,7 @@ class CmdEditorGroup(CmdEditorBase):
             buf = linebuffer[:lstart] + fbuf.split("\n") + linebuffer[lend:]
             editor.update_buffer(buf)
         elif cmd == ":j":
-            # :f <l> <w>  justify buffer of <l> with <w> as align (one of
+            # :j <l> <a> =<w> justify buffer of <l> to width <w> with <a> as align (one of
             # f(ull), c(enter), r(ight) or l(left). Default is full.
             align_map = {
                 "full": "f",
@@ -711,7 +720,10 @@ class CmdEditorGroup(CmdEditorBase):
                 "l": "l",
             }
             align_name = {"f": "Full", "c": "Center", "l": "Left", "r": "Right"}
-            width = _DEFAULT_WIDTH
+            # shift width arg right if no alignment specified
+            if self.arg1.startswith('='):
+                self.arg2 = self.arg1
+                self.arg1 = None
             if self.arg1 and self.arg1.lower() not in align_map:
                 self.caller.msg(
                     _("Valid justifications are")
@@ -719,6 +731,13 @@ class CmdEditorGroup(CmdEditorBase):
                 )
                 return
             align = align_map[self.arg1.lower()] if self.arg1 else "f"
+            width = _DEFAULT_WIDTH
+            if self.arg2:
+                value = self.arg2.lstrip("=")
+                if not value.isdigit():
+                    self.caller.msg("Width must be a number.")
+                    return
+                width = int(value)
             if not self.linerange:
                 lstart = 0
                 lend = self.cline + 1


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds the ability to optionally specify a width for the editor's `:j` and `:f` commands. Changes `<w>` (alignment) to `<a>` in help so that `<w>` can be used to represent width.

A new syntax element (`=`) had to be introduced to prevent a clash between the numeric arguments `<l>` and `<w>` when some arguments are omitted (e.g. does `:j 10` mean 'justify line 10' or 'justify to width 10'?)

#### Motivation for adding to Evennia

New feature.

#### Examples
```
>:
----------Line Editor [topic test]--------------------------------------------
01| A long line of text to test the editor's justification command with a custom
width.
----------[l:01 w:015 c:0083]------------(:h for help)------------------------
```
```
>:j
Full-justified lines 1-1.
>:
----------Line Editor [topic test]--------------------------------------------
01| A  long  line of text to test the editor's justification command with a custom
02| width.
----------[l:02 w:015 c:0085]------------(:h for help)------------------------
```
```
>:j =40
Full-justified lines 1-2.
>:
----------Line Editor [topic test]--------------------------------------------
01| A long line of text to test the editor's
02| justification   command  with  a  custom
03| width.
----------[l:03 w:015 c:0088]------------(:h for help)------------------------
```
```
>:j r =40
Right-justified lines 1-3.
>:
----------Line Editor [topic test]--------------------------------------------
01| A long line of text to test the editor's
02|      justification command with a custom
03|                                   width.
----------[l:03 w:015 c:0122]------------(:h for help)------------------------
```
```
>:j 1:2 l =60
Left-justified lines 1-2.
>:
----------Line Editor [topic test]--------------------------------------------
01| A long line of text to test the editor's justification      
02| command with a custom                                       
03|                                   width.
----------[l:03 w:015 c:0162]------------(:h for help)------------------------
```
```
>:f =30
Flood filled lines 1-3.
>:
----------Line Editor [topic test]--------------------------------------------
01| A long line of text to test
02| the editor's justification
03| command with a custom
04| width.
----------[l:04 w:015 c:0083]------------(:h for help)------------------------
```
