### PR TITLE
Fix room creation showing room name instead of typeclass path

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -1028,7 +1028,7 @@ class CmdDig(ObjManipCommand):
         if new_room.aliases.all():
             alias_string = " (%s)" % ", ".join(new_room.aliases.all())
 
-        room_string = f"Created room {new_room}({new_room.dbref}){alias_string} of type {new_room}."
+        room_string = f"Created room {new_room}({new_room.dbref}){alias_string} of type {new_room.typeclass_path}."
 
         # create exit to room
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When rooms are created in-game with `dig` or `tunnel`, the feedback message shows the room's name/key instead of its typeclass path.

#### Motivation for adding to Evennia

Bug fix.

#### Other info

**Before**
```
>dig cave1
Created room cave1(#3) of type cave1.
```
**After**
```
>dig cave2
Created room cave2(#4) of type typeclasses.rooms.Room.
```
