### PR TITLE
Room creation commands now default the new room's typeclass to that of the caller's location

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -200,7 +200,14 @@ class ObjManipCommand(COMMAND_DEFAULT_CLASS):
                 errors. (which might be empty.)
         """
 
-        found_typeclass = typeclass or self.default_typeclasses.get(obj_type, None)
+        if obj_type == "room" and self.caller.location and inherits_from(
+            self.caller.location, "evennia.objects.objects.DefaultRoom"
+        ):
+            loc_typeclass = self.caller.location.typeclass_path
+        else:
+            loc_typeclass = None
+
+        found_typeclass = typeclass or loc_typeclass or self.default_typeclasses.get(obj_type, None)
         if not found_typeclass:
             return None, [f"No typeclass found for object type '{obj_type}'."]
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The comments in `ObjManipCommand.get_object_typeclass` state:
> For instance, when using dig, the system can use this to autodetect which kind of Room typeclass to use based on where the builder is currently located.

However, this is not the case as rooms are always created as `typeclasses.rooms.Room` if no typeclass is specified.

This PR adds that behaviour.

#### Motivation for adding to Evennia

"New" feature.

#### Other info

I'm not sure whether or not this should be included as it changes the default behaviour of some commands, though the comment suggests that this might have originally been intended. Or maybe it was removed at some point and the comment wasn't updated.

#### Examples
**Before**
```
>ex
--------------------------------------------------------------------------------
Name/key: cave (#13)
Typeclass: TestRoom (typeclasses.rooms.TestRoom)
(...)
>dig/teleport cave2
(...)
>ex
--------------------------------------------------------------------------------
Name/key: cave2 (#14)
Typeclass: Room (typeclasses.rooms.Room)
(...)
```
**After**
```
>ex
--------------------------------------------------------------------------------
Name/key: cave (#12)
Typeclass: TestRoom (typeclasses.rooms.TestRoom)
(...)
>dig/teleport cave3
(...)
>ex
--------------------------------------------------------------------------------
Name/key: cave3 (#15)
Typeclass: TestRoom (typeclasses.rooms.TestRoom)
(...)
```
```
>ex
--------------------------------------------------------------------------------
Name/key: cave2 (#14)
Typeclass: Room (typeclasses.rooms.Room)
(...)
>dig/tele cave4
(...)
>ex
--------------------------------------------------------------------------------
Name/key: cave4 (#16)
Typeclass: Room (typeclasses.rooms.Room)
(...)
```
```
dig/teleport cave5:typeclasses.rooms.TestRoom
(...)
>ex
--------------------------------------------------------------------------------
Name/key: cave5 (#17)
Typeclass: TestRoom (typeclasses.rooms.TestRoom)
(...)
```
```
>tunnel s=cave6
(...)
>s
(...)
>ex
--------------------------------------------------------------------------------
Name/key: cave6 (#18)
Typeclass: TestRoom (typeclasses.rooms.TestRoom)
(...)
```
