### PR TITLE
Change page date/times to display in local time based on style timezone setting

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -18,7 +18,7 @@ from evennia.locks.lockhandler import LockException
 from evennia.utils import create, logger, search, utils
 from evennia.utils.evmenu import ask_yes_no
 from evennia.utils.logger import tail_log_file
-from evennia.utils.utils import class_from_module, strip_unsafe_input, utc_to_local
+from evennia.utils.utils import class_from_module, strip_unsafe_input, time_as_timezone
 
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 CHANNEL_DEFAULT_TYPECLASS = class_from_module(
@@ -1485,7 +1485,7 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
                     sender = f" {sender} " if multi_send else f" {sender}"
 
                 time_zone = self.account.options.get("timezone")
-                date_created = utc_to_local(page.date_created, time_zone)
+                date_created = time_as_timezone(page.date_created, time_zone)
                 listing.append(
                     template.format(
                         date=utils.datetime_format(date_created, time_zone),

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -18,7 +18,7 @@ from evennia.locks.lockhandler import LockException
 from evennia.utils import create, logger, search, utils
 from evennia.utils.evmenu import ask_yes_no
 from evennia.utils.logger import tail_log_file
-from evennia.utils.utils import class_from_module, strip_unsafe_input
+from evennia.utils.utils import class_from_module, strip_unsafe_input, utc_to_local
 
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 CHANNEL_DEFAULT_TYPECLASS = class_from_module(
@@ -1484,9 +1484,11 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
                     receiver = f"{receiver} " if multi_recv else ""
                     sender = f" {sender} " if multi_send else f" {sender}"
 
+                time_zone = self.account.options.get("timezone")
+                date_created = utc_to_local(page.date_created, time_zone)
                 listing.append(
                     template.format(
-                        date=utils.datetime_format(page.date_created),
+                        date=utils.datetime_format(date_created, time_zone),
                         clr=clr,
                         sender=sender,
                         receiver=receiver,

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -21,6 +21,7 @@ import textwrap
 import threading
 import traceback
 import types
+import pytz
 from ast import literal_eval
 from collections import OrderedDict, defaultdict
 from inspect import getmembers, getmodule, getmro, ismodule, trace
@@ -668,13 +669,16 @@ def time_format(seconds, style=0):
     return retval.strip()
 
 
-def datetime_format(dtobj):
+def datetime_format(dtobj, time_zone=None):
     """
     Pretty-prints the time since a given time.
 
     Args:
         dtobj (datetime): An datetime object, e.g. from Django's
             `DateTimeField`.
+        time_zone (tzfile): If provided, `dtobj` is adjusted to
+            the given time zone for the elapsed time calculations.
+            This should be used if `dtobj` is not UTC.
 
     Returns:
         deltatime (str): A string describing how long ago `dtobj`
@@ -683,6 +687,8 @@ def datetime_format(dtobj):
     """
 
     now = timezone.now()
+    if time_zone:
+        now = utc_to_local(now, time_zone)
 
     if dtobj.year < now.year:
         # another year (Apr 5, 2019)
@@ -3095,3 +3101,23 @@ def value_is_integer(value):
         return False
 
     return True
+
+
+def utc_to_local(utc_time, time_zone):
+    """
+    Convert a date/time from UTC to a local date/time based on `timezone`.
+
+    Args:
+        utc_time (datetime): The time to convert.
+        time_zone (tzfile): The time zone to convert to.
+
+    Returns
+        result (datetime): The converted time.
+    """
+    if not time_zone:
+        return utc_time
+    # don't convert a time that's not UTC
+    if utc_time.utcoffset().total_seconds() != 0:
+        return utc_time
+
+    return utc_time.replace(tzinfo=pytz.utc).astimezone(time_zone)

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -688,7 +688,7 @@ def datetime_format(dtobj, time_zone=None):
 
     now = timezone.now()
     if time_zone:
-        now = utc_to_local(now, time_zone)
+        now = time_as_timezone(now, time_zone)
 
     if dtobj.year < now.year:
         # another year (Apr 5, 2019)
@@ -3103,21 +3103,18 @@ def value_is_integer(value):
     return True
 
 
-def utc_to_local(utc_time, time_zone):
+def time_as_timezone(base_time, time_zone):
     """
-    Convert a date/time from UTC to a local date/time based on `timezone`.
+    Convert a date/time to a local date/time based on `timezone`.
 
     Args:
-        utc_time (datetime): The time to convert.
+        base_time (datetime): The time to convert.
         time_zone (tzfile): The time zone to convert to.
 
     Returns
         result (datetime): The converted time.
     """
-    if not time_zone:
-        return utc_time
-    # don't convert a time that's not UTC
-    if utc_time.utcoffset().total_seconds() != 0:
-        return utc_time
+    if not time_zone or base_time.tzname() == time_zone.zone:
+        return base_time
 
-    return utc_time.replace(tzinfo=pytz.utc).astimezone(time_zone)
+    return base_time.astimezone(time_zone)

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -676,9 +676,9 @@ def datetime_format(dtobj, time_zone=None):
     Args:
         dtobj (datetime): An datetime object, e.g. from Django's
             `DateTimeField`.
-        time_zone (tzfile): If provided, `dtobj` is adjusted to
-            the given time zone for the elapsed time calculations.
-            This should be used if `dtobj` is not UTC.
+        time_zone (tzfile): If provided, the current date/time is
+             adjusted to the given time zone for the elapsed time
+             calculations. This should be used if `dtobj` is not UTC.
 
     Returns:
         deltatime (str): A string describing how long ago `dtobj`


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The `page` command currently shows page date/times in UTC. This changes the date/times to the local time zone based on the setting in `style`.

#### Motivation for adding to Evennia

Show local time for pages.

#### Other info

**UTC:**
```
>page
Your latest pages:
 14:07:52 to Chiizujin:> Test.
 14:07:52 from Chiizujin:< Test.
```
**Local time:**
```
>page
Your latest pages:
 00:07:52 to Chiizujin:> Test.
 00:07:52 from Chiizujin:< Test.
```
