### PR TITLE
Fix protoype object updates changing cached prototype

### DIFF
--- a/evennia/prototypes/spawner.py
+++ b/evennia/prototypes/spawner.py
@@ -323,7 +323,7 @@ def prototype_from_object(obj):
         prot["prototype_locks"] = "spawn:all();edit:all()"
         prot["prototype_tags"] = []
     else:
-        prot = prot[0]
+        prot = prot[0].copy()
 
     prot["key"] = obj.db_key or hashlib.md5(bytes(str(time.time()), "utf-8")).hexdigest()[:6]
     prot["typeclass"] = obj.db_typeclass_path


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes behaviour in https://github.com/evennia/evennia/issues/3505.

This was caused by the spawned object being used as a comparison for the update directly updating the dict in the prototype cache if it found one, rather than copy of it. This resulted in the cached prototype  being changed to reflect the spawned object.

#### Motivation for adding to Evennia

Bug fix.

#### Other info

Note that this does *not* change the repeated save request behaviour mentioned in the bug report.

**Before**

Starting with an object spawned from a prototype and then adding a new tag ('tag_on_object') directly to the object:
```
>tag test
Tags on test: 'tag_on_object', 'test' (category: from_prototype)
```
Add a new tag to the prototype:
```
Actions: examine <num> | remove <num>
Back (attrs) | Forward (locks) | Index | Validate prototype | Quit

 1: new_tag          
```
Save and update spawned objects, then say "no" at the second save prompt:
```
Do you want to save/overwrite the existing prototype 'test'?
(...)
>n
```
View tags on prototype, without exiting the wizard:
```
Actions: examine <num> | remove <num>
Back (attrs) | Forward (locks) | Index | Validate prototype | Quit

 1: new_tag          
```
Reload the prototype while still in the wizard. The prototype in the wizard now has the tags that the spawned object had before it was updated:
```
Actions: examine <num> | remove <num>
Back (attrs) | Forward (locks) | Index | Validate prototype | Quit

 1: tag_on_object      
 2: test               
```
Note that the database has the correct tags. so ~quitting the wizard~ restarting the server and reloading the template will result in the correct tags.

The spawned object has the new tag:
```
>tag test
Tags on test: 'new_tag', 'tag_on_object', 'test' (category: from_prototype)
```

**After**

Starting from the same point as the start of the "before" test:
```
>tag test
Tags on test: 'tag_on_object', 'test' (category: from_prototype)
```
Go through the same steps to add a new tag, save, update, and say "no" at the second save prompt. Look at the tags on the prototype, without leaving the wizard:
```
Actions: examine <num> | remove <num>
Back (attrs) | Forward (locks) | Index | Validate prototype | Quit

 1: new_tag     
```
Reload the prototype while staying in the wizard and check the tags:
```
Actions: examine <num> | remove <num>
Back (attrs) | Forward (locks) | Index | Validate prototype | Quit

 1: new_tag          
```
The object has the new tag:
```
tag test
Tags on test: 'new_tag', 'tag_on_object', 'test' (category: from_prototype)
```
