### PR TITLE
Don't ignore empty search candidates

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -397,7 +397,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         # if candidates were already given, use them
         candidates = kwargs.get("candidates")
-        if candidates:
+        if candidates is not None:
             return candidates
 
         # find candidates based on location


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Providing an empty list of search candidates currently results in the unexpected behavior of falling back to the default search candidates rather than finding nothing. This replaces the truthiness check to more explicitly verify that the candidates are not the default kwarg of `None`

#### Motivation for adding to Evennia
Bug fixing