### PR TITLE
Fix `GlobalScriptsContainer` scripts attribute reference

### DIFF
--- a/evennia/utils/containers.py
+++ b/evennia/utils/containers.py
@@ -244,7 +244,7 @@ class GlobalScriptContainer(Container):
         """
         if not self.loaded:
             self.load_data()
-        return self.scripts.values()
+        return list(self.loaded_data.values())
 
 
 # Create all singletons


### PR DESCRIPTION
#### Brief overview of PR changes/additions
There is no `scripts` attribute on the `GlobalScriptsContainer` class; the correct attribute is `loaded_data`, as is done in the base `Container` class. As a result, attempting to do `GLOBAL_SCRIPTS.all()` currently results in the following traceback:

```
  File "./evennia/evennia/utils/containers.py", line 247, in all
    return self.scripts.values()
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'values'
```

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Reported on Discord