### PR TITLE
Fix exit order sorting sometimes being incorrect for exits not in the sort order

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1595,7 +1595,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 return names
             sort_index = {name: key for key, name in enumerate(exit_order)}
             names = sorted(names)
-            end_pos = len(names) + 1
+            end_pos = len(sort_index)
             names.sort(key=lambda name: sort_index.get(name, end_pos))
             return names
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes cases where exits not specified in the sort order were not appearing at the end of the list as they should.

#### Motivation for adding to Evennia

Bug fix.

#### Other info (issues closed, discussion etc)

**Before:**

`Exits: north, hatch, and southwest`

**After:**

`Exits: north, southwest, and hatch`

