### PR TITLE
Support full capitalization in GMCP commands

### DIFF
--- a/evennia/server/portal/telnet_oob.py
+++ b/evennia/server/portal/telnet_oob.py
@@ -257,11 +257,8 @@ class TelnetOOB:
         if cmdname in EVENNIA_TO_GMCP:
             gmcp_cmdname = EVENNIA_TO_GMCP[cmdname]
         elif "_" in cmdname:
-            if cmdname.istitle():
-                # leave without capitalization
-                gmcp_cmdname = ".".join(word for word in cmdname.split("_"))
-            else:
-                gmcp_cmdname = ".".join(word.capitalize() for word in cmdname.split("_"))
+            # enforce initial capitalization of each command part, leaving fully-capitalized sections intact
+            gmcp_cmdname = ".".join(word.capitalize() if not word.isupper() else word for word in cmdname.split("_"))
         else:
             gmcp_cmdname = "Core.%s" % (cmdname if cmdname.istitle() else cmdname.capitalize())
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Changes the GMCP command encoding to only run capitalize() on command parts that are not fully uppercase.

#### Motivation for adding to Evennia
A previous conversation on Discord identified the current GMCP encoding's command capitalization as somewhat lacking, based on their own previous use of GMCP in other MUD libraries. Additionally, today a specific use-case arose that is currently impossible: sending a Mudlet package install command, as per [the Mudlet docs](https://wiki.mudlet.org/w/Manual:GMCP_Extensions) - it requires the ability to send a fully capitalized command section, `Client.GUI`.

#### Other info (issues closed, discussion etc)
I'm not extremely familiar with the specifications of the GMCP protocol, so I wrote this under the assumption that mixed-case command parts are not allowed.