### PR TITLE
Fix EvEditor responding to valid direction commands in the current location

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -822,6 +822,7 @@ class EvEditorCmdSet(CmdSet):
     """CmdSet for the editor commands"""
 
     key = "editorcmdset"
+    priority = 150  # override other cmdsets.
     mergetype = "Replace"
 
     def at_cmdset_creation(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

If an exit's direction command exists in your current location, then `EvEditor` will treat matching input as those commands and move you around the game.

This is fixed by using the same priority for `EvEditorCmdSet` as already exists for `SaveYesNoCmdSet` (150).

#### Motivation for adding to Evennia

Bug fix.

#### Examples:

**Before:**
```
>desc/edit
----------Line Editor [desc]--------------------------------------------------
01| This is a room.
----------[l:01 w:004 c:0015]------------(:h for help)------------------------
>e
room2(#51)
This is a room.
Exits: west
```
**After (in the same initial room):**
```
>desc/edit
----------Line Editor [desc]--------------------------------------------------
01| This is a room.
----------[l:01 w:004 c:0015]------------(:h for help)------------------------
>e
02| e
```

