### PR TITLE
Update contrib account for character creator

### DIFF
--- a/evennia/contrib/rpg/character_creator/README.md
+++ b/evennia/contrib/rpg/character_creator/README.md
@@ -100,15 +100,19 @@ character creator menu, as well as supporting exiting/resuming the process. In
 addition, unlike the core command, it's designed for the character name to be
 chosen later on via the menu, so it won't parse any arguments passed to it.
 
-### Changes to `Account.at_look`
+### Changes to `Account`
 
-The contrib version works mostly the same as core evennia, but adds an
-additional check to recognize an in-progress character. If you've modified your
-own `at_look` hook, it's an easy addition to make: just add this section to the
+The contrib version works mostly the same as core evennia, but modifies `ooc_appearance_template`
+to match the contrib's command syntax, and the `at_look` method to recognize an in-progress
+character.
+
+If you've modified your own `at_look` hook, it's an easy change to add: just add this section to the
 playable character list loop.
 
 ```python
+    # the beginning of the loop starts here
     for char in characters:
+        # ...
         # contrib code starts here
         if char.db.chargen_step:
             # currently in-progress character; don't display placeholder names

--- a/evennia/contrib/rpg/character_creator/character_creator.py
+++ b/evennia/contrib/rpg/character_creator/character_creator.py
@@ -98,9 +98,26 @@ class ContribCmdCharCreate(MuxAccountCommand):
 
 class ContribChargenAccount(DefaultAccount):
     """
-    A modified Account class that makes minor changes to the OOC look
-    output to incorporate in-progress characters.
+    A modified Account class that changes the OOC look output to better match the contrib and
+    incorporate in-progress characters.
     """
+
+    ooc_appearance_template = """
+--------------------------------------------------------------------
+{header}
+
+{sessions}
+
+  |whelp|n - more commands
+  |wcharcreate|n - create new character
+  |wchardelete <name>|n - delete a character
+  |wic <name>|n - enter the game as character (|wooc|n to get back here)
+  |wic|n - enter the game as latest character controlled.
+
+{characters}
+{footer}
+--------------------------------------------------------------------
+""".strip()
 
     def at_look(self, target=None, session=None, **kwargs):
         """
@@ -156,7 +173,7 @@ class ContribChargenAccount(DefaultAccount):
         txt_sessions = "|wConnected session(s):|n\n" + "\n".join(sess_strings)
 
         if not characters:
-            txt_characters = "You don't have a character yet. Use |wcharcreate|n."
+            txt_characters = "You don't have a character yet."
         else:
             max_chars = (
                 "unlimited"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The contrib's account currently uses the default `ooc_appearance_template` string, which doesn't match the contrib's modified `charcreate` command usage. This corrects that oversight, and modifies the documentation accordingly.