### PR TITLE
Fix rpsystem contrib searching issues

### DIFF
--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -442,7 +442,7 @@ def parse_sdescs_and_recogs(
                 (re.search(rquery, text, _RE_FLAGS), obj, text) for obj, text in candidate_map
             )
             # filter out any non-matching candidates
-            bestmatches = [(obj, m.group()) for m, obj, text in matches if m]
+            bestmatches = [(obj, mtch.group()) for mtch, obj, text in matches if mtch]
 
         else:
             # to find the longest match, we start from the marker and lengthen the

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1352,7 +1352,9 @@ class ContribRPObject(DefaultObject):
                     results.extend(
                         [
                             obj
-                            for obj in search_obj(searched_obj.key, candidates=[searched_obj], **kwargs)
+                            for obj in search_obj(
+                                searched_obj.key, candidates=[searched_obj], **kwargs
+                            )
                             if obj not in results
                         ]
                     )

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -1352,7 +1352,7 @@ class ContribRPObject(DefaultObject):
                     results.extend(
                         [
                             obj
-                            for obj in search_obj(searched_obj.key, candidates=candidates, **kwargs)
+                            for obj in search_obj(searched_obj.key, candidates=[searched_obj], **kwargs)
                             if obj not in results
                         ]
                     )

--- a/evennia/contrib/rpg/rpsystem/rpsystem.py
+++ b/evennia/contrib/rpg/rpsystem/rpsystem.py
@@ -422,7 +422,10 @@ def parse_sdescs_and_recogs(
 
         # first see if there is a number given (e.g. 1-tall)
         num_identifier, _ = marker_match.groups("")  # return "" if no match, rather than None
+        # get the beginning of the actual text, minus the numeric identifier
         match_index = marker_match.start()
+        if num_identifier:
+            match_index += len(num_identifier) + 1
         # split the emote string at the reference marker, to process everything after it
         head = string[:match_index]
         tail = string[match_index + 1 :]

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -352,31 +352,37 @@ class TestRPSystem(BaseEvenniaTest):
         self.obj2 = create_object(rpsystem.ContribRPCharacter, key="Obj2", location=self.room)
         self.obj2.sdesc.add("something")
         candidates = [self.obj1, self.obj2]
+
         # search candidates by sdesc: both objects should be found
         result = self.speaker.get_search_result("something", candidates)
-        self.assertIn(self.obj1, result)
-        self.assertIn(self.obj2, result)
+        self.assertEqual(list(result), candidates)
+
         # search by sdesc with 2-disambiguator: only second object should be found
         result = self.speaker.get_search_result("2-something", candidates)
-        self.assertNotIn(self.obj1, result)
-        self.assertIn(self.obj2, result)
+        self.assertEqual(list(result), [self.obj2])
+
         # search empty candidates: no objects should be found
         result = self.speaker.get_search_result("something", candidates=[])
-        self.assertNotIn(self.obj1, result)
-        self.assertNotIn(self.obj2, result)
+        self.assertEqual(list(result), [])
+
         # typeclass was given: only matching object should be found
         result = self.speaker.get_search_result(
             "something", candidates=candidates, typeclass=rpsystem.ContribRPCharacter
         )
-        self.assertNotIn(self.obj1, result)
-        self.assertIn(self.obj2, result)
+        self.assertEqual(list(result), [self.obj2])
+
         # search by key with player permissions: no objects should be found
         result = self.speaker.get_search_result("obj1", candidates)
-        self.assertNotIn(self.obj1, result)
+        self.assertEqual(list(result), [])
+
         # search by key with builder permissions: object should be found
         self.speaker.permissions.add("builder")
         result = self.speaker.get_search_result("obj1", candidates)
-        self.assertIn(self.obj1, result)
+        self.assertEqual(list(result), [self.obj1])
+
+        # search by key with builder permissions when NOT IN candidates: object should NOT be found
+        result = self.speaker.get_search_result("obj1", [self.obj2])
+        self.assertEqual(list(result), [])
 
 
 class TestRPSystemCommands(BaseEvenniaCommandTest):

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -346,6 +346,34 @@ class TestRPSystem(BaseEvenniaTest):
         self.assertEqual(self.speaker.search("receiver of emotes"), self.receiver1)
         self.assertEqual(self.speaker.search("colliding"), self.receiver2)
 
+    def test_get_search_result(self):
+        self.obj1 = create_object(rpsystem.ContribRPObject, key="Obj1", location=self.room)
+        self.obj1.sdesc.add("something")
+        self.obj2 = create_object(rpsystem.ContribRPCharacter, key="Obj2", location=self.room)
+        self.obj2.sdesc.add("something")
+        candidates = [self.obj1, self.obj2]
+        # search candidates by sdesc: both objects should be found
+        result = self.speaker.get_search_result("something", candidates)
+        self.assertIn(self.obj1, result)
+        self.assertIn(self.obj2, result)
+        # search empty candidates: no objects should be found
+        result = self.speaker.get_search_result("something", candidates=[])
+        self.assertNotIn(self.obj1, result)
+        self.assertNotIn(self.obj2, result)
+        # typeclass was given: only matching object should be found
+        result = self.speaker.get_search_result(
+            "something", candidates=candidates, typeclass=rpsystem.ContribRPCharacter
+        )
+        self.assertNotIn(self.obj1, result)
+        self.assertIn(self.obj2, result)
+        # search by key with player permissions: no objects should be found
+        result = self.speaker.get_search_result("obj1", candidates)
+        self.assertNotIn(self.obj1, result)
+        # search by key with builder permissions: object should be found
+        self.speaker.permissions.add("builder")
+        result = self.speaker.get_search_result("obj1", candidates)
+        self.assertIn(self.obj1, result)
+
 
 class TestRPSystemCommands(BaseEvenniaCommandTest):
     def setUp(self):

--- a/evennia/contrib/rpg/rpsystem/tests.py
+++ b/evennia/contrib/rpg/rpsystem/tests.py
@@ -356,6 +356,10 @@ class TestRPSystem(BaseEvenniaTest):
         result = self.speaker.get_search_result("something", candidates)
         self.assertIn(self.obj1, result)
         self.assertIn(self.obj2, result)
+        # search by sdesc with 2-disambiguator: only second object should be found
+        result = self.speaker.get_search_result("2-something", candidates)
+        self.assertNotIn(self.obj1, result)
+        self.assertIn(self.obj2, result)
         # search empty candidates: no objects should be found
         result = self.speaker.get_search_result("something", candidates=[])
         self.assertNotIn(self.obj1, result)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR modifies the `get_search_result` method to avoid erroneous global searches and multimatches, and `parse_sdescs_and_recogs` to correctly remove the multimatch disambiguator from the actual string to be matched

I also added a new test to verify the correct behaviors.

#### Motivation for adding to Evennia
Bug fixing