### PR TITLE
Update web templates to use correct base.html

### DIFF
--- a/evennia/web/templates/website/channel_detail.html
+++ b/evennia/web/templates/website/channel_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }} ({{ object }})

--- a/evennia/web/templates/website/channel_list.html
+++ b/evennia/web/templates/website/channel_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/character_form.html
+++ b/evennia/web/templates/website/character_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/character_list.html
+++ b/evennia/web/templates/website/character_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/character_manage_list.html
+++ b/evennia/web/templates/website/character_manage_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/generic_form.html
+++ b/evennia/web/templates/website/generic_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Form

--- a/evennia/web/templates/website/help_detail.html
+++ b/evennia/web/templates/website/help_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }} ({{ object|title }})

--- a/evennia/web/templates/website/help_list.html
+++ b/evennia/web/templates/website/help_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/object_confirm_delete.html
+++ b/evennia/web/templates/website/object_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/object_detail.html
+++ b/evennia/web/templates/website/object_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }} ({{ object }})

--- a/evennia/web/templates/website/object_list.html
+++ b/evennia/web/templates/website/object_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 {{ view.page_title }}

--- a/evennia/web/templates/website/registration/password_change_done.html
+++ b/evennia/web/templates/website/registration/password_change_done.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Password Changed

--- a/evennia/web/templates/website/registration/password_change_form.html
+++ b/evennia/web/templates/website/registration/password_change_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Password Change

--- a/evennia/web/templates/website/registration/password_reset_complete.html
+++ b/evennia/web/templates/website/registration/password_reset_complete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Forgot Password - Reset Successful

--- a/evennia/web/templates/website/registration/password_reset_confirm.html
+++ b/evennia/web/templates/website/registration/password_reset_confirm.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Forgot Password - Reset

--- a/evennia/web/templates/website/registration/password_reset_done.html
+++ b/evennia/web/templates/website/registration/password_reset_done.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Forgot Password - Reset Link Sent

--- a/evennia/web/templates/website/registration/password_reset_form.html
+++ b/evennia/web/templates/website/registration/password_reset_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Forgot Password

--- a/evennia/web/templates/website/registration/register.html
+++ b/evennia/web/templates/website/registration/register.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "website/base.html" %}
 
 {% block titleblock %}
 Register


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This changes the extensions of "base.html" in the website templates to the more accurate and specific "website/base.html"

#### Motivation for adding to Evennia
The current templates will use any `base.html` template provided in the game dir as first priority, resulting in most of the website breaking if you create your own webclient base template.