### PR TITLE
fix(find/loc): show dbref of target location instead of target

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3289,7 +3289,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
                 if "loc" in self.switches and not is_account and result.location:
                     string += (
                         f" (|wlocation|n: |g{result.location.get_display_name(caller)}"
-                        f"{result.get_extra_display_name_info(caller)}|n)"
+                        f"{result.location.get_extra_display_name_info(caller)}|n)"
                     )
         else:
             # Not an account/dbref search but a wider search; build a queryset.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
There is a minor bug in the `find/loc` command that displays the result's dbref instead of the result's location's dbref. This PR should fix it to display the correct dbref

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
