### PR TITLE
Add session_caller attr to MuxCommand to extend CmdParser functionality.

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -261,6 +261,7 @@ def _progressive_cmd_run(cmd, generator, response=None):
 
 class NoCmdSets(Exception):
     "No cmdsets found. Critical error."
+
     pass
 
 
@@ -594,6 +595,7 @@ def cmdhandler(
             cmd.session = session
             cmd.account = account
             cmd.raw_string = unformatted_raw_string
+
             # cmd.obj  # set via on-object cmdset handler for each command,
             # since this may be different for every command when
             # merging multiple cmdsets
@@ -686,7 +688,11 @@ def cmdhandler(
             else:
                 # no explicit cmdobject given, figure it out
                 cmdset = yield get_and_merge_cmdsets(
-                    caller, cmdset_providers_list, callertype, raw_string, cmdid=cmdid
+                    caller,
+                    cmdset_providers_list,
+                    callertype,
+                    raw_string,
+                    cmdid=cmdid,
                 )
                 if not cmdset:
                     # this is bad and shouldn't happen.
@@ -703,7 +709,7 @@ def cmdhandler(
                 # Parse the input string and match to available cmdset.
                 # This also checks for permissions, so all commands in match
                 # are commands the caller is allowed to call.
-                matches = yield _COMMAND_PARSER(raw_string, cmdset, caller)
+                matches = yield _COMMAND_PARSER(raw_string, cmdset, caller, session)
 
                 # Deal with matches
 

--- a/evennia/commands/cmdparser.py
+++ b/evennia/commands/cmdparser.py
@@ -111,7 +111,7 @@ def try_num_differentiators(raw_string):
         return None, None
 
 
-def cmdparser(raw_string, cmdset, caller, match_index=None):
+def cmdparser(raw_string, cmdset, caller, session, match_index=None):
     """
     This function is called by the cmdhandler once it has
     gathered and merged all valid cmdsets valid for this particular parsing.
@@ -166,7 +166,15 @@ def cmdparser(raw_string, cmdset, caller, match_index=None):
         matches = build_matches(raw_string, cmdset, include_prefixes=False)
 
     # only select command matches we are actually allowed to call.
-    matches = [match for match in matches if match[2].access(caller, "cmd")]
+    matches = [
+        match
+        for match in matches
+        if (
+            match[2].access(caller, "cmd")
+            or getattr(match[2], "session_caller", False)
+            and match[2].access(session, "cmd")
+        )
+    ]
 
     # try to bring the number of matches down to 1
     if len(matches) > 1:

--- a/evennia/commands/cmdparser.py
+++ b/evennia/commands/cmdparser.py
@@ -111,7 +111,7 @@ def try_num_differentiators(raw_string):
         return None, None
 
 
-def cmdparser(raw_string, cmdset, caller, session, match_index=None):
+def cmdparser(raw_string, cmdset, caller, session=None, match_index=None):
     """
     This function is called by the cmdhandler once it has
     gathered and merged all valid cmdsets valid for this particular parsing.
@@ -120,6 +120,8 @@ def cmdparser(raw_string, cmdset, caller, session, match_index=None):
         raw_string (str): The unparsed text entered by the caller.
         cmdset (CmdSet): The merged, currently valid cmdset
         caller (Session, Account or Object): The caller triggering this parsing.
+        session (Session): The session controlling the caller if caller and
+                           session are different.
         match_index (int, optional): Index to pick a given match in a
             list of same-named command matches. If this is given, it suggests
             this is not the first time this function was called: normally

--- a/evennia/commands/command.py
+++ b/evennia/commands/command.py
@@ -16,7 +16,7 @@ from django.utils.text import slugify
 from evennia.locks.lockhandler import LockHandler
 from evennia.utils.ansi import ANSIString
 from evennia.utils.evtable import EvTable
-from evennia.utils.utils import fill, is_iter, lazy_property, make_iter
+from evennia.utils.utils import is_iter, lazy_property, make_iter
 
 CMD_IGNORE_PREFIXES = settings.CMD_IGNORE_PREFIXES
 
@@ -594,7 +594,7 @@ Command \"{cmdname}\" has no defined `func()` method. Available properties on th
                 "help-entry-detail",
                 kwargs={"category": slugify(self.help_category), "topic": slugify(self.key)},
             )
-        except Exception as e:
+        except Exception:
             return "#"
 
     def web_get_admin_url(self):

--- a/evennia/commands/default/account.py
+++ b/evennia/commands/default/account.py
@@ -25,7 +25,7 @@ from codecs import lookup as codecs_lookup
 from django.conf import settings
 
 import evennia
-from evennia.utils import create, logger, search, utils
+from evennia.utils import logger, search, utils
 
 COMMAND_DEFAULT_CLASS = utils.class_from_module(settings.COMMAND_DEFAULT_CLASS)
 
@@ -253,12 +253,12 @@ class CmdIC(COMMAND_DEFAULT_CLASS):
 
     key = "ic"
     # lock must be all() for different puppeted objects to access it.
-    locks = "cmd:all()"
+    locks = "cmd:is_ooc()"
     aliases = "puppet"
     help_category = "General"
 
     # this is used by the parent
-    account_caller = True
+    session_caller = True
 
     def func(self):
         """

--- a/evennia/commands/default/muxcommand.py
+++ b/evennia/commands/default/muxcommand.py
@@ -111,6 +111,8 @@ class MuxCommand(Command):
             self.rhs_split = "="
         if not hasattr(self, "account_caller"):
             self.account_caller = False
+        if not hasattr(self, "session_caller"):
+            self.session_caller = False
 
         # split out switches
         switches, delimiters = [], self.rhs_split

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -521,9 +521,8 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
     ):
         return True
 
-    if getattr(accessed_obj, "session_caller", False):
-        obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
-        account = obj.account if utils.inherits_from(obj, evennia.DefaultObject) else obj
+    obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
+    account = obj.account if utils.inherits_from(obj, evennia.DefaultObject) else obj
 
     if not account:
         return True

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -514,8 +514,17 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
     only when out of character. When not logged in at all, this
     function will still return True.
     """
-    obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
-    account = obj.account if utils.inherits_from(obj, evennia.DefaultObject) else obj
+    if (
+        getattr(accessed_obj, "session_caller", False)
+        and utils.inherits_from(accessing_obj, evennia.server.serversession.ServerSession)
+        and not accessing_obj.get_puppet()
+    ):
+        return True
+
+    if getattr(accessed_obj, "session_caller", False):
+        obj = accessed_obj.obj if hasattr(accessed_obj, "obj") else accessed_obj
+        account = obj.account if utils.inherits_from(obj, evennia.DefaultObject) else obj
+
     if not account:
         return True
     try:
@@ -533,20 +542,6 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
         return not account.get_puppet(session)
     except TypeError:
         return not session.get_puppet()
-
-
-def objtag(accessing_obj, accessed_obj, *args, **kwargs):
-    """
-    Usage:
-        objtag(tagkey)
-        objtag(tagkey, category)
-
-    Only true if accessed_obj has the specified tag and optional
-    category.
-    """
-    tagkey = args[0] if args else None
-    category = args[1] if len(args) > 1 else None
-    return bool(accessed_obj.tags.get(tagkey, category=category))
 
 
 def inside(accessing_obj, accessed_obj, *args, **kwargs):

--- a/evennia/locks/tests.py
+++ b/evennia/locks/tests.py
@@ -7,13 +7,14 @@ the stability and integrity of the codebase during updates.
 This module tests the lock functionality of Evennia.
 
 """
+
 from evennia.utils.test_resources import BaseEvenniaTest
 
 try:
     # this is a special optimized Django version, only available in current Django devel
     from django.utils.unittest import TestCase, override_settings
 except ImportError:
-    from django.test import TestCase, override_settings
+    from django.test import override_settings
 
 from evennia import settings_default
 from evennia.locks import lockfuncs
@@ -213,7 +214,12 @@ class TestLockfuncs(BaseEvenniaTest):
         self.assertEqual(False, lockfuncs.is_ooc(self.char1, self.char1))
 
     def test_is_ooc__session(self):
-        self.assertEqual(False, lockfuncs.is_ooc(self.session, self.char1))
+        self.account.unpuppet_all()
+        self.char1.session_caller = True
+        self.assertTrue(lockfuncs.is_ooc(self.session, self.char1))
+
+        self.char1.session_caller = False
+        self.assertTrue(lockfuncs.is_ooc(self.session, self.char1))
 
     def test_is_ooc__account(self):
         self.assertEqual(False, lockfuncs.is_ooc(self.account, self.char1))
@@ -230,7 +236,8 @@ class TestPermissionCheck(BaseEvenniaTest):
     def test_check__success(self):
         """Test combinations that should pass the check"""
         self.assertEqual(
-            [perm for perm in self.char1.account.permissions.all()], ["developer", "player"]
+            [perm for perm in self.char1.account.permissions.all()],
+            ["developer", "player"],
         )
         self.assertTrue(self.char1.permissions.check("Builder"))
         self.assertTrue(self.char1.permissions.check("Builder", "Player"))
@@ -248,7 +255,8 @@ class TestPermissionCheck(BaseEvenniaTest):
         self.char1.account.permissions.add("Builder")
 
         self.assertEqual(
-            [perm for perm in self.char1.account.permissions.all()], ["builder", "player"]
+            [perm for perm in self.char1.account.permissions.all()],
+            ["builder", "player"],
         )
         self.assertFalse(self.char1.permissions.check("Developer"))
         self.assertFalse(self.char1.permissions.check("Developer", "Player", require_all=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,3 +170,6 @@ omit = [
   "*.pyc",
   "*.service",
 ]
+
+[tool.ruff]
+line-length = 100


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Add session_caller attr to MuxCommand to extend CmdParser functionality.

#### Other info (issues closed, discussion etc)

Note: There is still a bug where the command will not populate in CmdHelp's display despite it being available to the character. Can address this in another PR or tackle it later.

Misc: Unused import removal, removing duplicate method objtag, and minor linting

Resolves [BUG] MULTISESSION_MODE 3 / Command Locks Bug #3583
