### PR TITLE
Add post-creation and spawn hooks to DefaultObject

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -2052,8 +2052,8 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     def at_object_spawn(self):
         """
-        Called once when this object is first spawned or updated from a prototype, after all the
-        creation hooks have been run and the object has been saved.
+        Called when this object is spawned or updated from a prototype, after all other
+        hooks have been run.
         """
         pass
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -310,7 +310,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                             False, deletion is aborted. Note that all objects
                             inside a deleted object are automatically moved
                             to their <home>, they don't need to be removed here.
-     at_object_spawn()    - called when object is spawned from a prototype or updated
+     at_object_post_spawn() - called when object is spawned from a prototype or updated
                             by the spawner to apply prototype changes.
      at_init()            - called whenever typeclass is cached from memory,
                             at least once every server restart/reload
@@ -2050,10 +2050,13 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         return True
 
-    def at_object_spawn(self):
+    def at_object_post_spawn(self, prototype=None):
         """
         Called when this object is spawned or updated from a prototype, after all other
         hooks have been run.
+        
+        Keyword Args:
+            prototype (dict):  The prototype that was used to spawn or update this object.
         """
         pass
 

--- a/evennia/prototypes/spawner.py
+++ b/evennia/prototypes/spawner.py
@@ -803,8 +803,8 @@ def batch_update_objects_with_prototype(
         if do_save:
             changed += 1
             obj.save()
-            if spawn_hook := getattr(obj, "at_object_spawn", None):
-                spawn_hook()
+            if spawn_hook := getattr(obj, "at_object_post_spawn", None):
+                spawn_hook(prototype=prototype)
 
     return changed
 
@@ -872,7 +872,7 @@ def batch_create_object(*objparams):
             if code:
                 exec(code, {}, {"evennia": evennia, "obj": obj})
         # run the spawned hook
-        if spawn_hook := getattr(obj, "at_object_spawn", None):
+        if spawn_hook := getattr(obj, "at_object_post_spawn", None):
             spawn_hook()
         objs.append(obj)
     return objs

--- a/evennia/prototypes/spawner.py
+++ b/evennia/prototypes/spawner.py
@@ -803,6 +803,8 @@ def batch_update_objects_with_prototype(
         if do_save:
             changed += 1
             obj.save()
+            if spawn_hook := getattr(obj, "at_object_spawn", None):
+                spawn_hook()
 
     return changed
 
@@ -869,6 +871,9 @@ def batch_create_object(*objparams):
         for code in objparam[7]:
             if code:
                 exec(code, {}, {"evennia": evennia, "obj": obj})
+        # run the spawned hook
+        if spawn_hook := getattr(obj, "at_object_spawn", None):
+            spawn_hook()
         objs.append(obj)
     return objs
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This adds two additional hooks to `DefaultObject` and integrates them into the appropriate locations.

1. `at_object_post_creation` - An additional hook which is added to `at_first_save` *after* the attributes etc. from `create_object` or prototypes have been applied. Named to match the pattern of `at_object_post_copy`
2. `at_object_spawn` - A specific hook intended for additional post-spawning processing of updates applied by a prototype. It is called both when the object is initially spawned, and when the object is updated to match any changes to the prototype.

#### Other info (issues closed, discussion etc)
This should fulfill the feature requests and use-case requirements presented in #3095

#### Additional notes
I played it safe when integrating the new `at_object_spawn` hook into the spawner code and used `getattr`, just in case someone decides to use the prototype spawner in unexpected ways like spawning accounts or something.