### PR TITLE
update SQLite PRAGMAs for faster DB

### DIFF
--- a/evennia/server/service.py
+++ b/evennia/server/service.py
@@ -284,9 +284,10 @@ class EvenniaServerService(MultiService):
         ):
             cursor = connection.cursor()
             cursor.execute("PRAGMA cache_size=10000")
-            cursor.execute("PRAGMA synchronous=OFF")
+            cursor.execute("PRAGMA synchronous=1")
             cursor.execute("PRAGMA count_changes=OFF")
             cursor.execute("PRAGMA temp_store=2")
+            cursor.execute("PRAGMA journal_mode=WAL")
 
     def update_defaults(self):
         """


### PR DESCRIPTION
A tiny update that should provide a decent performance gain for SQLite.

Testing it is a bit of a chore.  I didn't create a test because I wasn't sure how to set up Django's test DB to test this.
I also didn't have luck creating a test which changes the journaling mode automatically because the DB doesn't like doing that at any other time besides startup, it seems.

Test command:

```
import time
from evennia.commands.command import Command
from evennia.utils.create import create_object

class CmdTestDB(Command):
    """
    test SQLite speed by creating/deleting 1000 objects
    """
    key = 'testdb'

    def func(self):
        caller = self.caller
        count = 1000
        start = time.time()
        for _ in range(count):
            obj = create_object(key='test', typeclass='evennia.objects.objects.DefaultObject')
            obj.delete()
        elapsed = time.time() - start
        caller.msg(f"Created and deleted {count} objects in {elapsed} seconds!")
```

Run the command a few times, note the results. 

Edit sqlite3_prep() function from evennia/evennia/server/service.py:

Change:
```
cursor = connection.cursor()
cursor.execute("PRAGMA cache_size=10000")
cursor.execute("PRAGMA synchronous=OFF")
cursor.execute("PRAGMA count_changes=OFF")
cursor.execute("PRAGMA temp_store=2")
```

To:
```
cursor = connection.cursor()
cursor.execute("PRAGMA cache_size=10000")
cursor.execute("PRAGMA synchronous=1")
cursor.execute("PRAGMA count_changes=OFF")
cursor.execute("PRAGMA temp_store=2")
cursor.execute("PRAGMA journal_mode=WAL")
```

Reload the server and run the command a few times, note the results.
Note: After running in WAL mode, reverting the code doesn't change the journaling mode of the db, I don't think.

Here are results for Windows 11, Ryzen 9 7900X with SSD:

Default settings of PRAGMA journal_mode=DELETE and PRAGMA synchronous=0:

Created and deleted 1000 objects in 10.764227151870728 seconds!
Created and deleted 1000 objects in 9.781527757644653 seconds!
Created and deleted 1000 objects in 9.209701776504517 seconds!
Created and deleted 1000 objects in 9.199149131774902 seconds!
Created and deleted 1000 objects in 9.233259916305542 seconds!

Proposed settings of PRAGMA journal_mode=WAL and PRAGMA synchronous=1:

Created and deleted 1000 objects in 5.748546361923218 seconds!
Created and deleted 1000 objects in 5.716841697692871 seconds!
Created and deleted 1000 objects in 5.708944797515869 seconds!
Created and deleted 1000 objects in 5.697698593139648 seconds!
Created and deleted 1000 objects in 5.7547266483306885 seconds!

Linux results are much less impressive, but there is still a tiny improvement.
Results for Ubuntu 22 on the same hardware:

Default:

Created and deleted 1000 objects in 5.769589185714722 seconds!
Created and deleted 1000 objects in 5.742905616760254 seconds!
Created and deleted 1000 objects in 5.769495964050293 seconds!
Created and deleted 1000 objects in 5.765765905380249 seconds!
Created and deleted 1000 objects in 5.777475357055664 seconds!

WAL:

Created and deleted 1000 objects in 5.371000289916992 seconds!
Created and deleted 1000 objects in 5.34570050239563 seconds!
Created and deleted 1000 objects in 5.360833168029785 seconds!
Created and deleted 1000 objects in 5.34778904914856 seconds!
Created and deleted 1000 objects in 5.359269857406616 seconds!