### PR TITLE
make test_new_task_waiting_input more reliable on Windows

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -543,7 +543,7 @@ class TestCmdTasks(BaseEvenniaCommandTest):
         self.call(system.CmdTasks(), f"/cancel {self.task.get_id()}")
         self.task_handler.clock.advance(self.timedelay + 1)
         self.assertFalse(self.task.exists())
-        self.task = self.task_handler.add(self.timedelay, func_test_cmd_tasks)
+        self.task = self.task_handler.add(self.timedelay + 1, func_test_cmd_tasks)
         self.assertTrue(self.task.get_id(), 1)
         self.char1.msg = Mock()
         self.char1.execute_cmd("y")


### PR DESCRIPTION
This is a fix for https://github.com/evennia/evennia/issues/3596

I'm not entirely sure why it works, but the test reliably passes for me now.
Is the clock advance creating a possible race condition?

`self.task = self.task_handler.add(self.timedelay, func_test_cmd_tasks)`

If the timedelay arg for self.task_handler.add is anything other than `self.timedelay`, it passes reliably for me.
if it's `self.timedelay` then on Windows it will fail 50% of the time or so.