### PR TITLE
Fix LLM contrib client headers

### DIFF
--- a/evennia/contrib/rpg/llm/llm_client.py
+++ b/evennia/contrib/rpg/llm/llm_client.py
@@ -37,7 +37,7 @@ from evennia.utils.utils import make_iter
 
 DEFAULT_LLM_HOST = "http://127.0.0.1:5000"
 DEFAULT_LLM_PATH = "/api/v1/generate"
-DEFAULT_LLM_HEADERS = {"Content-Type": "application/json"}
+DEFAULT_LLM_HEADERS = {"Content-Type": ["application/json"]}
 DEFAULT_LLM_PROMPT_KEYNAME = "prompt"
 DEFAULT_LLM_API_TYPE = ""  # or openai
 DEFAULT_LLM_REQUEST_BODY = {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Puts the header value in a list.

The content of the headers are expected to be iterables, so passing a string into it causes the header value to be broken up into a list of individual characters, like so:
`Headers({b'content-type': [b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'j', b's', b'o', b'n']})`

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
This isn't a breaking issue when running a local API server like koboldcpp, since they don't validate request headers, but it does completely break with remote APIs so it's better to have the default/example be correct.