### PR TITLE
Fix for #3622 - check if attr.strvalue exists

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2831,7 +2831,7 @@ class CmdExamine(ObjManipCommand):
 
         key, category, value = attr.db_key, attr.db_category, attr.value
         valuetype = ""
-        if value is None and attr.strvalue is not None:
+        if value is None and getattr(attr, "strvalue", None) is not None:
             value = attr.strvalue
             valuetype = " |B[strvalue]|n"
         typ = self._get_attribute_value_type(value)
@@ -2850,7 +2850,7 @@ class CmdExamine(ObjManipCommand):
 
         key, category, value = attr.db_key, attr.db_category, attr.value
         valuetype = ""
-        if value is None and attr.strvalue is not None:
+        if value is None and getattr(attr, "strvalue", None) is not None:
             value = attr.strvalue
             valuetype = " |B[strvalue]|n"
         typ = self._get_attribute_value_type(value)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -2831,7 +2831,7 @@ class CmdExamine(ObjManipCommand):
 
         key, category, value = attr.db_key, attr.db_category, attr.value
         valuetype = ""
-        if value is None and getattr(attr, "strvalue", None) is not None:
+        if value is None and attr.strvalue is not None:
             value = attr.strvalue
             valuetype = " |B[strvalue]|n"
         typ = self._get_attribute_value_type(value)
@@ -2850,7 +2850,7 @@ class CmdExamine(ObjManipCommand):
 
         key, category, value = attr.db_key, attr.db_category, attr.value
         valuetype = ""
-        if value is None and getattr(attr, "strvalue", None) is not None:
+        if value is None and attr.strvalue is not None:
             value = attr.strvalue
             valuetype = " |B[strvalue]|n"
         typ = self._get_attribute_value_type(value)

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -62,7 +62,7 @@ class IAttribute:
         return LockHandler(self)
 
     key = property(lambda self: self.db_key)
-    strvalue = property(lambda self: self.db_strvalue)
+    strvalue = property(lambda self: getattr(self, 'db_strvalue', None))
     category = property(lambda self: self.db_category)
     model = property(lambda self: self.db_model)
     attrtype = property(lambda self: self.db_attrtype)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Check if attr.strvalue exists before attempting to use it.

When an .ndb.item is set to None, it has no attribute db_strvalue. Later when examining an object we attempt to access its attributes' db_strvalue. InMemoryAttributes only have one if the value is not None.

Alternatively, we may want to set any default db_strvalue (i.e. in InMemoryAttribute's init function), but updating the check accomplishes the same result.

#### Motivation for adding to Evennia
Bug fix

#### Other info (issues closed, discussion etc)
Fix for https://github.com/evennia/evennia/issues/3622 and https://github.com/evennia/evennia/issues/3602
