### PR TITLE
Fix 'defense_type' typos in beginner tutorial + EvAdventure utils.py

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Objects.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Objects.md
@@ -248,7 +248,7 @@ class EvAdventureWeapon(EvAdventureObject):
     quality = AttributeProperty(3, autocreate=False)
     
     attack_type = AttributeProperty(Ability.STR, autocreate=False)
-    defend_type = AttributeProperty(Ability.ARMOR, autocreate=False)
+    defense_type = AttributeProperty(Ability.ARMOR, autocreate=False)
     
     damage_roll = AttributeProperty("1d6", autocreate=False)
 
@@ -387,7 +387,7 @@ class EvAdventureRuneStone(EvAdventureWeapon, EvAdventureConsumable):
     quality = AttributeProperty(3, autocreate=False)
 
     attack_type = AttributeProperty(Ability.INT, autocreate=False)
-    defend_type = AttributeProperty(Ability.DEX, autocreate=False)
+    defense_type = AttributeProperty(Ability.DEX, autocreate=False)
     
     damage_roll = AttributeProperty("1d8", autocreate=False)
 

--- a/evennia/contrib/tutorials/evadventure/utils.py
+++ b/evennia/contrib/tutorials/evadventure/utils.py
@@ -37,7 +37,7 @@ def get_obj_stats(obj, owner=None):
         carried = f", Worn: [{carried.value}]" if carried else ""
 
     attack_type = getattr(obj, "attack_type", None)
-    defense_type = getattr(obj, "attack_type", None)
+    defense_type = getattr(obj, "defense_type", None)
 
     return _OBJ_STATS.format(
         key=obj.key,


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The beginner tutorial had mixed use of 'defend_type' vs 'defense_type'. The canonical utils.py uses 'defense_type', so I've switched the other uses to that.

utils.py also had a copy/paste error causing the defense_type to be reported as the attack_type in the object description string, this has been fixed.

#### Motivation for adding to Evennia
Working tutorial code.

#### Other info (issues closed, discussion etc)
