### PR TITLE
Fix incorrect example code in equipment tutorial

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
@@ -407,13 +407,14 @@ class EquipmentHandler:
        
         for to_backpack_obj in to_backpack:
             # put stuff in backpack
-            slots[WieldLocation.BACKPACK].append(to_backpack_obj)
+            if to_backpack_obj:
+                slots[WieldLocation.BACKPACK].append(to_backpack_obj)
        
         # store new state
         self._save() 
 ``` 
 
-Here we remember that every `EvAdventureObject` has an `inventory_use_slot` property that tells us where it goes. So we just need to move the object to that slot, replacing whatever is in that place from before. Anything we replace goes back to the backpack. 
+Here we remember that every `EvAdventureObject` has an `inventory_use_slot` property that tells us where it goes. So we just need to move the object to that slot, replacing whatever is in that place from before. Anything we replace goes back to the backpack, as long as it's actually an item and not `None`, in the case where we are moving an item into an empty slot.
 
 ## Get everything 
 

--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
@@ -402,7 +402,7 @@ class EquipmentHandler:
             to_backpack = [obj]
         else:
             # for others (body, head), just replace whatever's there
-            replaced = [obj]
+            to_backpack = [slots[use_slot]]
             slots[use_slot] = obj
        
         for to_backpack_obj in to_backpack:

--- a/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part3/Beginner-Tutorial-Equipment.md
@@ -407,7 +407,7 @@ class EquipmentHandler:
        
         for to_backpack_obj in to_backpack:
             # put stuff in backpack
-            slots[use_slot].append(to_backpack_obj)
+            slots[WieldLocation.BACKPACK].append(to_backpack_obj)
        
         # store new state
         self._save() 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The code to replace equipment in a single-item slot referenced a variable that is never used before or after, and incorrectly set it to the item that is doing the replacement instead of the item being replaced, which causes the replaced item to not be moved back into the backpack.

It also incorrectly attempted to append items meant to move to the backpack to the current use_slot, causing an error if the item being moved is not already going to the backpack.

When moving an object into an empty slot, the example code was adding `None` entries into the backpack slots.

#### Motivation for adding to Evennia
Fix broken example code.

#### Other info (issues closed, discussion etc)
