### PR TITLE
Fix permission fallback when creating characters

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -939,7 +939,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
         # parse inputs
         character_key = kwargs.pop("key", self.key)
         character_ip = kwargs.pop("ip", self.db.creator_ip)
-        character_permissions = kwargs.pop("permissions", self.permissions)
+        character_permissions = kwargs.pop("permissions", self.permissions.all())
 
         # Load the appropriate Character class
         character_typeclass = kwargs.pop("typeclass", self.default_character_typeclass)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
At the moment, the fallback permissions for characters reference the entire permissions handler rather than the permissions within the handler. This causes the undesirable behavior of permission strings like `"developer,player"` being added to new characters, rather than the expected separate permissions of `"developer"` and `"player"`

#### Motivation for adding to Evennia
Bug fixing