### PR TITLE
Allow simple customization of default object descriptions

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -693,6 +693,7 @@ class CmdCreate(ObjManipCommand):
             )
             if errors:
                 self.msg(errors)
+                
             if not obj:
                 continue
 
@@ -702,9 +703,7 @@ class CmdCreate(ObjManipCommand):
                 )
             else:
                 string = f"You create a new {obj.typename}: {obj.name}."
-            # set a default desc
-            if not obj.db.desc:
-                obj.db.desc = "You see nothing special."
+
             if "drop" in self.switches:
                 if caller.location:
                     obj.home = caller.location

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -397,6 +397,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     objects = ObjectManager()
 
+    # Used by get_display_desc when self.db.desc is None
+    default_description = _("You see nothing special.")
+
     # populated by `return_appearance`
     appearance_template = """
 {header}
@@ -1464,10 +1467,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             if account:
                 obj.db.creator_id = account.id
 
-            # Set description if there is none, or update it if provided
-            if description or not obj.db.desc:
-                desc = description if description else "You see nothing special."
-                obj.db.desc = desc
+            # Set description if provided
+            if description:
+                obj.db.desc = description
 
         except Exception as e:
             errors.append(f"An error occurred while creating this '{key}' object: {e}")
@@ -1746,7 +1748,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             str: The desc display string.
 
         """
-        return self.db.desc or "You see nothing special."
+        return self.db.desc or self.default_description
 
     def get_display_exits(self, looker, **kwargs):
         """
@@ -3004,6 +3006,9 @@ class DefaultCharacter(DefaultObject):
         "edit:pid({account_id}) or perm(Admin)"
     )
 
+    # Used by get_display_desc when self.db.desc is None
+    default_description = _("This is a character.")
+
     @classmethod
     def get_default_lockstring(
         cls, account: "DefaultAccount" = None, caller: "DefaultObject" = None, **kwargs
@@ -3117,9 +3122,9 @@ class DefaultCharacter(DefaultObject):
             if locks:
                 obj.locks.add(locks)
 
-            # If no description is set, set a default description
-            if description or not obj.db.desc:
-                obj.db.desc = description if description else _("This is a character.")
+            # Set description if provided
+            if description:
+                obj.db.desc = description
 
         except Exception as e:
             errors.append(f"An error occurred while creating object '{key} object: {e}")
@@ -3330,6 +3335,9 @@ class DefaultRoom(DefaultObject):
     # Generally, a room isn't expected to HAVE a location, but maybe in some games?
     _content_types = ("room",)
 
+    # Used by get_display_desc when self.db.desc is None
+    default_description = _("This is a room.")
+
     @classmethod
     def create(
         cls,
@@ -3400,9 +3408,9 @@ class DefaultRoom(DefaultObject):
             if account:
                 obj.db.creator_id = account.id
 
-            # If no description is set, set a default description
-            if description or not obj.db.desc:
-                obj.db.desc = description if description else _("This is a room.")
+            # Set description if provided
+            if description:
+                obj.db.desc = description
 
         except Exception as e:
             errors.append(f"An error occurred while creating this '{key}' object: {e}")
@@ -3494,6 +3502,9 @@ class DefaultExit(DefaultObject):
     _content_types = ("exit",)
     exit_command = ExitCommand
     priority = 101
+
+    # Used by get_display_desc when self.db.desc is None
+    default_description = _("This is an exit.")
 
     # Helper classes and methods to implement the Exit. These need not
     # be overloaded unless one want to change the foundation for how
@@ -3609,9 +3620,9 @@ class DefaultExit(DefaultObject):
             if account:
                 obj.db.creator_id = account.id
 
-            # If no description is set, set a default description
-            if description or not obj.db.desc:
-                obj.db.desc = description if description else _("This is an exit.")
+            # Set description if provided
+            if description:
+                obj.db.desc = description
 
         except Exception as e:
             errors.append(f"An error occurred while creating this '{key}' object: {e}")

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1930,7 +1930,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         if hasattr(self, "_createdict"):
             # this will be set if the object was created by the utils.create function
-            # or the spawner. We want these kwargs to override the values set by 
+            # or the spawner. We want these kwargs to override the values set by
             # the initial hooks.
             cdict = self._createdict
             updates = []
@@ -1974,7 +1974,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                     self.nattributes.add(key, value)
 
             del self._createdict
-        
+
         # run the post-setup hook
         self.at_object_post_creation()
 
@@ -2057,7 +2057,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         Called when this object is spawned or updated from a prototype, after all other
         hooks have been run.
-        
+
         Keyword Args:
             prototype (dict):  The prototype that was used to spawn or update this object.
         """

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -30,6 +30,13 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertEqual(obj.db.creator_ip, self.ip)
         self.assertEqual(obj.db_home, self.room1)
 
+    def test_object_default_description(self):
+        obj, errors = DefaultObject.create("void")
+        self.assertTrue(obj,errors)
+        self.assertFalse(errors, errors)
+        self.assertIsNone(obj.db.desc)
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj)) 
+            
     def test_character_create(self):
         description = "A furry green monster, reeking of garbage."
         home = self.room1.dbref
@@ -57,6 +64,13 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertFalse(errors, errors)
         self.assertEqual(obj.name, "SigurXurXorarinsson")
 
+    def test_character_default_description(self):
+        obj, errors = DefaultCharacter.create("dementor")
+        self.assertTrue(obj,errors)
+        self.assertFalse(errors, errors)
+        self.assertIsNone(obj.db.desc)
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj)) 
+
     def test_room_create(self):
         description = "A dimly-lit alley behind the local Chinese restaurant."
         obj, errors = DefaultRoom.create("alley", self.account, description=description, ip=self.ip)
@@ -64,6 +78,13 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertFalse(errors, errors)
         self.assertEqual(description, obj.db.desc)
         self.assertEqual(obj.db.creator_ip, self.ip)
+
+    def test_room_default_description(self):
+        obj, errors = DefaultRoom.create("black hole")
+        self.assertTrue(obj,errors)
+        self.assertFalse(errors, errors)
+        self.assertIsNone(obj.db.desc)
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj))
 
     def test_exit_create(self):
         description = (
@@ -77,6 +98,13 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertFalse(errors, errors)
         self.assertEqual(description, obj.db.desc)
         self.assertEqual(obj.db.creator_ip, self.ip)
+    
+    def test_exit_default_description(self):
+        obj, errors = DefaultExit.create("the nothing")
+        self.assertTrue(obj,errors)
+        self.assertFalse(errors, errors)
+        self.assertIsNone(obj.db.desc)
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj))
 
     def test_exit_get_return_exit(self):
         ex1, _ = DefaultExit.create("north", self.room1, self.room2, account=self.account)

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -32,11 +32,11 @@ class DefaultObjectTest(BaseEvenniaTest):
 
     def test_object_default_description(self):
         obj, errors = DefaultObject.create("void")
-        self.assertTrue(obj,errors)
+        self.assertTrue(obj, errors)
         self.assertFalse(errors, errors)
         self.assertIsNone(obj.db.desc)
-        self.assertEqual(obj.default_description, obj.get_display_desc(obj)) 
-            
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj))
+
     def test_character_create(self):
         description = "A furry green monster, reeking of garbage."
         home = self.room1.dbref
@@ -66,10 +66,10 @@ class DefaultObjectTest(BaseEvenniaTest):
 
     def test_character_default_description(self):
         obj, errors = DefaultCharacter.create("dementor")
-        self.assertTrue(obj,errors)
+        self.assertTrue(obj, errors)
         self.assertFalse(errors, errors)
         self.assertIsNone(obj.db.desc)
-        self.assertEqual(obj.default_description, obj.get_display_desc(obj)) 
+        self.assertEqual(obj.default_description, obj.get_display_desc(obj))
 
     def test_room_create(self):
         description = "A dimly-lit alley behind the local Chinese restaurant."
@@ -81,7 +81,7 @@ class DefaultObjectTest(BaseEvenniaTest):
 
     def test_room_default_description(self):
         obj, errors = DefaultRoom.create("black hole")
-        self.assertTrue(obj,errors)
+        self.assertTrue(obj, errors)
         self.assertFalse(errors, errors)
         self.assertIsNone(obj.db.desc)
         self.assertEqual(obj.default_description, obj.get_display_desc(obj))
@@ -98,10 +98,10 @@ class DefaultObjectTest(BaseEvenniaTest):
         self.assertFalse(errors, errors)
         self.assertEqual(description, obj.db.desc)
         self.assertEqual(obj.db.creator_ip, self.ip)
-    
+
     def test_exit_default_description(self):
         obj, errors = DefaultExit.create("the nothing")
-        self.assertTrue(obj,errors)
+        self.assertTrue(obj, errors)
         self.assertFalse(errors, errors)
         self.assertIsNone(obj.db.desc)
         self.assertEqual(obj.default_description, obj.get_display_desc(obj))
@@ -294,7 +294,7 @@ class TestObjectManager(BaseEvenniaTest):
         query = ObjectDB.objects.get_objs_with_key_or_alias("")
         self.assertFalse(query)
         query = ObjectDB.objects.get_objs_with_key_or_alias("", exact=False)
-        self.assertEqual(list(query), list(ObjectDB.objects.all().order_by('id')))
+        self.assertEqual(list(query), list(ObjectDB.objects.all().order_by("id")))
 
         query = ObjectDB.objects.get_objs_with_key_or_alias(
             "", exact=False, typeclasses="evennia.objects.objects.DefaultCharacter"


### PR DESCRIPTION
Implements Feature Request #3617 Allow simple customization of default object descriptions

- Default typeclass descriptions (Object, Rooms, Exits, Characters) no longer set a default `db.desc` if not provided in the `create` method.
- typeclass `get_display_desc` methods now refer to a class level `default_description` variable
- CreateCmd No longer sets a default `db.desc`
- "You see nothing special." default description now runs through Django translator like the other typeclass defaults

Closes #3617 