### PR TITLE
Properly reinitialize contents cache

### DIFF
--- a/evennia/objects/models.py
+++ b/evennia/objects/models.py
@@ -60,7 +60,7 @@ class ContentsHandler:
         Returns:
             Objects (list of ObjectDB)
         """
-        return list(obj for obj in self.obj.locations_set.all() if obj.pk)
+        return list(self.obj.locations_set.all())
 
     def init(self):
         """

--- a/evennia/objects/models.py
+++ b/evennia/objects/models.py
@@ -60,7 +60,7 @@ class ContentsHandler:
         Returns:
             Objects (list of ObjectDB)
         """
-        return list(self.obj.locations_set.all())
+        return list(obj for obj in self.obj.locations_set.all() if obj.pk)
 
     def init(self):
         """
@@ -68,6 +68,7 @@ class ContentsHandler:
 
         """
         objects = self.load()
+        self._typecache = defaultdict(dict)
         self._pkcache = {obj.pk: True for obj in objects}
         for obj in objects:
             try:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The contents cache handler currently has an oversights when reinitalizing:

1. The typecache is not reset before being initialized in `init`, allowing invalid data to persist and continue erroring.
2. ~~The `load` function includes objects that have been deleted but are still in memory, leading to idcache errors.~~

This PR corrects this.

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Resolves #3646 (or at least the parts of it that weren't my own fault)