### PR TITLE
Fix default justify behaviour in EvEditor

### DIFF
--- a/evennia/utils/eveditor.py
+++ b/evennia/utils/eveditor.py
@@ -731,7 +731,7 @@ class CmdEditorGroup(CmdEditorBase):
                     + " [f]ull (default), [c]enter, [r]right or [l]eft"
                 )
                 return
-            align = align_map[self.arg1.lower()] if self.arg1 else "f"
+            align = align_map[self.arg1.lower()] if self.arg1 else "l"
             width = _DEFAULT_WIDTH
             if self.arg2:
                 value = self.arg2.lstrip("=")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changed the default align of the `:j` command in EvEditor to "left", to match both the behaviour indicated in EvEditor help and the default behaviour of `utils.justify`.

#### Motivation for adding to Evennia

Align functionality between Python and in-game, and avoid unintended behaviour!