### PR TITLE
Make FileHelpEntry hashable so it does not fail equality checks

### DIFF
--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -121,7 +121,7 @@ class FileHelpEntry:
         return f"<FileHelpEntry {self.key}>"
 
     def __hash__(self):
-        return hash((self.key, self.help_category, self.lock_storage))
+        return hash(self.key)
 
     @lazy_property
     def locks(self):

--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -120,6 +120,9 @@ class FileHelpEntry:
     def __repr__(self):
         return f"<FileHelpEntry {self.key}>"
 
+    def __hash__(self):
+        return hash((self.key, self.help_category, self.lock_storage))
+
     @lazy_property
     def locks(self):
         return LockHandler(self)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This hashes FileHelpEntry so it can pass equality checks. A lack of this causes `do_search` in help.py to fail at this line: https://github.com/evennia/evennia/blob/88afac2874160bada78189b82eff3782db1705f7/evennia/commands/default/help.py#L505

This is because removal has to check for equality.

#### Motivation for adding to Evennia

Production bug on Secrets of Aelandris breaking several help files

#### Other info (issues closed, discussion etc)
