### PR TITLE
add_user_channel_alias was adding nicks into inputline category

### DIFF
--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -550,7 +550,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
         user.nicks.add(
             msg_nick_pattern,
             msg_nick_replacement,
-            category="inputline",
+            category="channel",
             pattern_is_regex=True,
             **kwargs,
         )


### PR DESCRIPTION
add_user_channel_alias was adding nicks into inputline category, it really should be adding it into "channel" category.

#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
