### PR TITLE
Input processing should do nickreplace against inputline AND channel

### DIFF
--- a/evennia/server/inputfuncs.py
+++ b/evennia/server/inputfuncs.py
@@ -96,10 +96,10 @@ def text(session, *args, **kwargs):
         # nick replacement
         puppet = session.puppet
         if puppet:
-            txt = puppet.nicks.nickreplace(txt, categories=("inputline"), include_account=True)
+            txt = puppet.nicks.nickreplace(txt, categories=("inputline", "channel"), include_account=True)
         else:
             txt = session.account.nicks.nickreplace(
-                txt, categories=("inputline"), include_account=False
+                txt, categories=("inputline", "channel"), include_account=False
             )
     kwargs.pop("options", None)
     cmdhandler(session, txt, callertype="session", session=session, **kwargs)


### PR DESCRIPTION
I believe this is the reason why add_user_channel_alias in evennia/comms/comms.py was adding nicks into "inputline" instead of "channel".

#### Brief overview of PR changes/additions

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
