### PR TITLE
Remove last_login update on disconnect

### DIFF
--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -161,9 +161,6 @@ class ServerSession(_BASE_SESSION_CLASS):
             account = self.account
             if self.puppet:
                 account.unpuppet_object(self)
-            uaccount = account
-            uaccount.last_login = timezone.now()
-            uaccount.save()
             # calling account hook
             account.at_disconnect(reason)
             self.logged_in = False


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This removes a few lines of code which update the `last_login` attribute on Accounts when their session is disconnected.

#### Motivation for adding to Evennia
While it seems this was done deliberately at some point, it doesn't make any actual sense with the intent of `last_login` representing the last time the account logged in. Especially as the most recent account *activity* is iirc tracked elsewhere.