### PR TITLE
#3661 Fixing docstring/game template mismatch.

### DIFF
--- a/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Python-classes-and-objects.md
+++ b/docs/source/Howtos/Beginner-Tutorial/Part1/Beginner-Tutorial-Python-classes-and-objects.md
@@ -377,7 +377,6 @@ class ObjectParent:
     """
     class docstring 
     """
-    pass
 
 class Object(ObjectParent, DefaultObject):
     """


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Game Template does not actually have `pass` beneath the ObjectParent docstring. In #3661 this was pointed out. PR resolves.
