### PR TITLE
Fix CmdPage tracebacks

### DIFF
--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -1382,7 +1382,7 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
                 if target and target.isnumeric():
                     # a number to specify a historic page
                     number = int(target)
-                elif target:
+                elif message:
                     target_obj = self.caller.search(target, quiet=True)
                     if target_obj:
                         # a proper target
@@ -1393,7 +1393,7 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
                         message = target + " " + (message[0] if message else "")
                 else:
                     # a single-word message
-                    message = message[0].strip()
+                    message = target.strip()
 
         pages = list(pages_we_sent) + list(pages_we_got)
         pages = sorted(pages, key=lambda page: page.date_created)

--- a/evennia/commands/default/comms.py
+++ b/evennia/commands/default/comms.py
@@ -1389,11 +1389,11 @@ class CmdPage(COMMAND_DEFAULT_CLASS):
                         targets = [target_obj[0]]
                         message = message[0].strip()
                     else:
-                        # a message with a space in it - put it back together
-                        message = target + " " + (message[0] if message else "")
+                        # a message with a space in it - use the original args
+                        message = self.args.strip()
                 else:
-                    # a single-word message
-                    message = target.strip()
+                    # a single-word message - use the original args
+                    message = self.args.strip()
 
         pages = list(pages_we_sent) + list(pages_we_got)
         pages = sorted(pages, key=lambda page: page.date_created)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In certain cases, CmdPage can fail with a traceback.

- When attempting to `tell` someone without providing a message
- When attempting to `tell` someone a single-word reply

This fixes the code to prevent those errors.

#### Motivation for adding to Evennia
Bug fixing