### PR TITLE
#3660 bugfix old name saved in alias

### DIFF
--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -1267,6 +1267,15 @@ class TestBuilding(BaseEvenniaCommandTest):
         )
         self.call(building.CmdName(), "Obj4=", "No names or aliases defined!")
 
+    def test_name_clears_plural(self):
+        box, _ = DefaultObject.create("Opened Box", location=self.char1)
+
+        # Force update of plural aliases (set in get_numbered_name)
+        self.char1.execute_cmd("inventory")
+        self.assertIn("one opened box", box.aliases.get(category=box.plural_category))
+        self.char1.execute_cmd("@name box=closed box")
+        self.assertIsNone(box.aliases.get(category=box.plural_category))
+
     def test_desc(self):
         oid = self.obj2.id
         self.call(building.CmdDesc(), "Obj2=TestDesc", "The description was set on Obj2.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes issue where renaming an object keeps the old plural aliases.

- Moves plural_category to object level variable
- Modifies DefaultObject `at_rename` hook to clear plural aliases
 
#### Motivation for adding to Evennia
Fixes issue #3660.

Root cause:
Plural aliases are added in the `DefaultObject.get_numbered_name` method which is called when a character uses `CmdInventory` or `CmdLook`.  If a builder renames an object, but doesn't use a command that calls get_numbered_name, the object can still be referenced by the old aliases.
 
#### Other info (issues closed, discussion etc)

Closes #3660 
