### PR TITLE
Avoid certain tracebacks when creating accounts

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -778,6 +778,9 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
         In this case we're simply piggybacking on this feature to apply
         additional normalization per Evennia's standards.
         """
+        if not isinstance(username, str):
+            username = str(username)
+
         username = super(DefaultAccount, cls).normalize_username(username)
 
         # strip excessive spaces in accountname
@@ -1010,8 +1013,8 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
         account = None
         errors = []
 
-        username = kwargs.get("username")
-        password = kwargs.get("password")
+        username = kwargs.get("username", "")
+        password = kwargs.get("password", "")
         email = kwargs.get("email", "").strip()
         guest = kwargs.get("guest", False)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Despite using code that assumes username and password are strings, `DefaultAccount.create` currently uses the default fallback value of `None` if they aren't provided.

This updates that to use an empty string instead, and additionally updates `normalize_username` to enforce that the provided username is normalized to a string.

#### Motivation for adding to Evennia
Fixing edge cases