### PR TITLE
3658 bug input autofocus

### DIFF
--- a/evennia/web/static/webclient/js/plugins/goldenlayout.js
+++ b/evennia/web/static/webclient/js/plugins/goldenlayout.js
@@ -300,6 +300,14 @@ let goldenlayout = (function () {
         let typelist   = document.getElementById("typelist");
         let updatelist = document.getElementById("updatelist");
 
+        if(tab?.componentName !== 'options')
+        {
+            window.plugins["default_in"].setKeydownFocus(true);
+        }
+        else {
+            window.plugins["default_in"].setKeydownFocus(false);
+        }
+
         if( renamebox ) {
             closeRenameDropdown();
         }

--- a/evennia/web/static/webclient/js/plugins/options2.js
+++ b/evennia/web/static/webclient/js/plugins/options2.js
@@ -75,14 +75,12 @@ let options2 = (function () {
                     .click( function () {
                         optionsContainer = null;
                         tab.contentItem.remove();
-                        window.plugins["default_in"].setKeydownFocus(true);
                     });
                     optionsContainer = tab.contentItem;
                 }
             });
             main.parent.addChild( optionsComponent );
 
-            window.plugins["default_in"].setKeydownFocus(false);
         } else {
             optionsContainer.remove();
             optionsContainer = null;
@@ -150,7 +148,7 @@ let options2 = (function () {
 
         // don't claim this Prompt as completed.
         return false;
-    }
+    }   
 
     //
     //
@@ -183,7 +181,7 @@ let options2 = (function () {
         onOptionsUI: onOptionsUI,
         onPrompt: onPrompt,
         onOptionCheckboxChanged: onOptionCheckboxChanged,
-        onOpenCloseOptions: onOpenCloseOptions,
+        onOpenCloseOptions: onOpenCloseOptions
     }
 })();
 window.plugin_handler.add("options2", options2);

--- a/evennia/web/static/webclient/js/plugins/options2.js
+++ b/evennia/web/static/webclient/js/plugins/options2.js
@@ -148,8 +148,7 @@ let options2 = (function () {
 
         // don't claim this Prompt as completed.
         return false;
-    }   
-
+    }
     //
     //
     var init = function() {
@@ -181,7 +180,7 @@ let options2 = (function () {
         onOptionsUI: onOptionsUI,
         onPrompt: onPrompt,
         onOptionCheckboxChanged: onOptionCheckboxChanged,
-        onOpenCloseOptions: onOpenCloseOptions
+        onOpenCloseOptions: onOpenCloseOptions,
     }
 })();
 window.plugin_handler.add("options2", options2);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Move input focus logic to onActiveMainTabChange hook
- Remove input focus logic from individual component (options)

#### Motivation for adding to Evennia
Fixes bug #3658 Autofocus is not re-enabled after opening options

When options pane is opened it disables the input setKeydownFocus.  It never reenables it unless you specifically close out of it, either with the 'x' icon or clicking the options button until the options tab is removed.

Golden layout already has a hook `activeContentItemChanged` which is already registered to fire custom `onActiveMainTabChange`.  It seemed like a reasonable place to put the logic.  

#### Other info (issues closed, discussion etc)
Closes #3658 
