### PR TITLE
Ensure partial-match object searches only match the start of words

### DIFF
--- a/evennia/objects/manager.py
+++ b/evennia/objects/manager.py
@@ -322,7 +322,7 @@ class ObjectDBManager(TypedObjectManager):
             )
 
         # convert search term to partial-match regex
-        search_regex = r".* ".join(re.escape(word) for word in ostring.split()) + r'.*'
+        search_regex = r".* ".join(r"\b" + re.escape(word) for word in ostring.split()) + r'.*'
 
         # do the fuzzy search and return whatever it matches
         return (

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -266,13 +266,13 @@ class TestObjectManager(BaseEvenniaTest):
         query = ObjectDB.objects.get_objs_with_key_or_alias("")
         self.assertFalse(query)
         query = ObjectDB.objects.get_objs_with_key_or_alias("", exact=False)
-        self.assertEqual(list(query), list(ObjectDB.objects.all().order_by('id')))
+        self.assertEqual(list(query), list(ObjectDB.objects.all().order_by("id")))
 
         query = ObjectDB.objects.get_objs_with_key_or_alias(
             "", exact=False, typeclasses="evennia.objects.objects.DefaultCharacter"
         )
         self.assertEqual(list(query), [self.char1, self.char2])
-        
+
     def test_key_alias_search_partial_match(self):
         """
         verify that get_objs_with_key_or_alias will partial match the first part of
@@ -280,7 +280,7 @@ class TestObjectManager(BaseEvenniaTest):
         """
         self.obj1.key = "big sword"
         self.obj2.key = "shiny sword"
-        
+
         # beginning of "sword", should match both
         query = ObjectDB.objects.get_objs_with_key_or_alias("sw", exact=False)
         self.assertEqual(list(query), [self.obj1, self.obj2])
@@ -296,7 +296,7 @@ class TestObjectManager(BaseEvenniaTest):
         # beginning of "sword" then "big", should NOT match
         query = ObjectDB.objects.get_objs_with_key_or_alias("sw b", exact=False)
         self.assertEqual(list(query), [])
-        
+
     def test_search_object(self):
         self.char1.tags.add("test tag")
         self.obj1.tags.add("test tag")

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -272,7 +272,31 @@ class TestObjectManager(BaseEvenniaTest):
             "", exact=False, typeclasses="evennia.objects.objects.DefaultCharacter"
         )
         self.assertEqual(list(query), [self.char1, self.char2])
+        
+    def test_key_alias_search_partial_match(self):
+        """
+        verify that get_objs_with_key_or_alias will partial match the first part of
+        any words in the name, when given in the correct order
+        """
+        self.obj1.key = "big sword"
+        self.obj2.key = "shiny sword"
+        
+        # beginning of "sword", should match both
+        query = ObjectDB.objects.get_objs_with_key_or_alias("sw", exact=False)
+        self.assertEqual(list(query), [self.obj1, self.obj2])
 
+        # middle of "sword", should NOT match
+        query = ObjectDB.objects.get_objs_with_key_or_alias("wor", exact=False)
+        self.assertEqual(list(query), [])
+
+        # beginning of "big" then "sword", should match obj1
+        query = ObjectDB.objects.get_objs_with_key_or_alias("b sw", exact=False)
+        self.assertEqual(list(query), [self.obj1])
+
+        # beginning of "sword" then "big", should NOT match
+        query = ObjectDB.objects.get_objs_with_key_or_alias("sw b", exact=False)
+        self.assertEqual(list(query), [])
+        
     def test_search_object(self):
         self.char1.tags.add("test tag")
         self.obj1.tags.add("test tag")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a missing word-boundary condition to the key-alias search regex in the relevant ObjectDB method, as well as a unit test to verify this expected partial-match behavior going forward.

#### Motivation for adding to Evennia
Bug fixing

#### Other info (issues closed, discussion etc)
Issue was identified by Uncle Buff on Discord, thanks!