### PR TITLE
Fixing funcparser issues

### DIFF
--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -339,6 +339,7 @@ class FuncParser:
                 # always store escaped characters verbatim
                 if curr_func:
                     infuncstr += char
+                    curr_func.rawstr += char
                 else:
                     fullstr += char
                 escaped = False
@@ -372,7 +373,8 @@ class FuncParser:
                         curr_func.open_lsquare = open_lsquare
                         curr_func.open_lcurly = open_lcurly
                         # we must strip the remaining funcstr so it's not counted twice
-                        curr_func.rawstr = curr_func.rawstr[: -len(infuncstr)]
+                        if len(infuncstr) > 0:
+                            curr_func.rawstr = curr_func.rawstr[: -len(infuncstr)]
                         current_kwarg = ""
                         infuncstr = ""
                         double_quoted = -1

--- a/evennia/utils/tests/test_funcparser.py
+++ b/evennia/utils/tests/test_funcparser.py
@@ -231,6 +231,8 @@ class TestFuncParser(TestCase):
             ("Test literal3 $typ($lit(1)aaa)", "Test literal3 <class 'str'>"),
             ("Test literal4 $typ(aaa$lit(1))", "Test literal4 <class 'str'>"),
             ("Test spider's thread", "Test spider's thread"),
+            ("Test invalid syntax $a=$b", "Test invalid syntax $a=$b"),
+            (r"Test invalid syntax $a\= b", "Test invalid syntax $a= b"),
         ]
     )
     def test_parse(self, string, expected):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Addresses some funcparser issues identified in #3692 where funcparser would eat characters.

#### Motivation for adding to Evennia
Fix bugs seen in #3692 

#### Other info (issues closed, discussion etc)
This is not a full fix for #3692 as that specifically requests `help nick` (as the example) to return as it is written, and the parser seems to eat escapes '\' by design.  So in example case the literal
`nick tm\=$1=page tallman=$1` 
 becomes
`nick tm=$1=page tallman=$1`
Without the escape character.