### PR TITLE
Remove redundant and incorrect session-clearing from `at_server_cold_start`

### DIFF
--- a/evennia/server/service.py
+++ b/evennia/server/service.py
@@ -673,12 +673,6 @@ class EvenniaServerService(MultiService):
         shutdown or a reset.
 
         """
-        # We need to do this just in case the server was killed in a way where
-        # the normal cleanup operations did not have time to run.
-        from evennia.objects.models import ObjectDB
-
-        ObjectDB.objects.clear_all_sessids()
-
         # Remove non-persistent scripts
         from evennia.scripts.models import ScriptDB
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The server-start code which calls this hook already correctly handles whether or not the session IDs should be cleared or not. The removed code is thus only serving to break session tracking when using `reset` mode.

#### Motivation for adding to Evennia
Bug fixing