### PR TITLE
Fix bug adding duplicate components.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default:
 	@echo "  make fmt/format - run the black autoformatter on the source code"
 	@echo "  make lint - run black in --check mode"
 	@echo "  make test - run evennia test suite with all default values."
-	@echo "  make tests=evennia.path test - run only specific test or tests."
+	@echo "  make TESTS=evennia.path test - run only specific test or tests."
 	@echo "  make testp - run test suite using multiple cores."
 	@echo "  make release - publish evennia to pypi (requires pypi credentials)
 

--- a/evennia/commands/default/help.py
+++ b/evennia/commands/default/help.py
@@ -99,7 +99,7 @@ class CmdHelp(COMMAND_DEFAULT_CLASS):
     # separator between subtopics:
     subtopic_separator_char = r"/"
 
-    # should topics disply their help entry when clicked
+    # should topics display their help entry when clicked
     clickable_topics = HELP_CLICKABLE_TOPICS
 
     def msg_help(self, text, **kwargs):
@@ -156,7 +156,7 @@ class CmdHelp(COMMAND_DEFAULT_CLASS):
             click_topics (bool, optional): Should help topics be clickable. Default is True.
 
         Returns:
-            help_message (str): Help entry formated for console.
+            help_message (str): Help entry formatted for console.
 
         """
         separator = "|C" + "-" * self.client_width() + "|n"

--- a/evennia/contrib/base_systems/components/holder.py
+++ b/evennia/contrib/base_systems/components/holder.py
@@ -74,6 +74,9 @@ class ComponentHandler:
 
         """
         component_name = component.name
+        component_slot = component.get_component_slot()
+        if self.has(component_slot):
+            self.remove_by_name(component_slot)
         self.db_names.append(component_name)
         self.host.tags.add(component_name, category="components")
         self._set_component(component)

--- a/evennia/contrib/base_systems/components/tests.py
+++ b/evennia/contrib/base_systems/components/tests.py
@@ -295,6 +295,15 @@ class TestComponents(EvenniaTest):
         self.char1.components.add_default("replacement_inherited_test_a")
         self.assertEqual(self.char1.ic_a.replacement_field, 6)
 
+    def test_replacing_dynamic_component(self):
+        component_name = "replacement_inherited_test_a"
+        self.assertEqual(self.char1.attributes.get("component_names").count(component_name), 0)
+        self.assertTrue(self.char1.cmp.has(self.char1.ic_a.slot))
+        self.char1.components.add_default(component_name)
+        self.char1.components.add_default(component_name)
+        # Dynamically added components do not accumulate extra entries.
+        self.assertEqual(self.char1.attributes.get("component_names").count(component_name), 1)
+
 
 class CharWithSignal(ComponentHolderMixin, DefaultCharacter):
     @signals.as_listener

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -542,7 +542,7 @@ def inside(accessing_obj, accessed_obj, *args, **kwargs):
     Usage:
        inside()
 
-    True if accessing_obj is 'inside' accessing_obj. Note that this only checks
+    True if accessing_obj is 'inside' accessed_obj. Note that this only checks
     one level down. So if if the lock is on a room, you will pass but not your
     inventory (since their location is you, not the locked object).  If you
     want also nested objects to pass the lock, use the `insiderecursive`

--- a/evennia/locks/lockfuncs.py
+++ b/evennia/locks/lockfuncs.py
@@ -481,12 +481,14 @@ def objtag(accessing_obj, accessed_obj, *args, **kwargs):
     """
     Usage:
         objtag(tagkey)
-        objtag(tagkey, category):
+        objtag(tagkey, category)
 
-    Only true if `accessed_obj` has the given tag and optional category.
-
+    Only true if accessed_obj has the specified tag and optional
+    category.
     """
-    return tag(accessed_obj, None, *args, **kwargs)
+    tagkey = args[0] if args else None
+    category = args[1] if len(args) > 1 else None
+    return bool(accessed_obj.tags.get(tagkey, category=category))
 
 
 def objloctag(accessing_obj, accessed_obj, *args, **kwargs):
@@ -533,20 +535,6 @@ def is_ooc(accessing_obj, accessed_obj, *args, **kwargs):
         return not account.get_puppet(session)
     except TypeError:
         return not session.get_puppet()
-
-
-def objtag(accessing_obj, accessed_obj, *args, **kwargs):
-    """
-    Usage:
-        objtag(tagkey)
-        objtag(tagkey, category)
-
-    Only true if accessed_obj has the specified tag and optional
-    category.
-    """
-    tagkey = args[0] if args else None
-    category = args[1] if len(args) > 1 else None
-    return bool(accessed_obj.tags.get(tagkey, category=category))
 
 
 def inside(accessing_obj, accessed_obj, *args, **kwargs):

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -132,7 +132,7 @@ class ObjectSessionHandler:
 
         Notes:
             We will only add a session/sessid if this actually also exists
-            in the the core sessionhandler.
+            in the core sessionhandler.
 
         """
         try:
@@ -446,7 +446,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     @property
     def has_account(self):
-        """True is this object has an associated account."""
+        """True if this object has an associated account."""
         return self.sessions.count()
 
     def get_cmdset_providers(self) -> dict[str, "CmdSetProvider"]:
@@ -478,7 +478,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         Returns the contents of this object, i.e. all
         objects that has this object set as its location.
-        This should be publically available.
+        This should be publicly available.
 
         Args:
             exclude (DefaultObject): Object to exclude from returned
@@ -1548,7 +1548,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         if not self.pk or not self.at_object_delete():
             # This object has already been deleted,
-            # or the pre-delete check return False
+            # or the pre-delete check returns False
             return False
 
         # See if we need to kick the account off.
@@ -1653,7 +1653,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     def get_extra_display_name_info(self, looker=None, **kwargs):
         """
-        Adds any extra display information to the object's name. By default this is is the
+        Adds any extra display information to the object's name. By default this is the
         object's dbref in parentheses, if the looker has permission to see it.
 
         Args:
@@ -1715,7 +1715,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             plural = key
         singular = _INFLECT.an(key)
         if not self.aliases.get(plural, category=self.plural_category):
-            # we need to wipe any old plurals/an/a in case key changed in the interrim
+            # we need to wipe any old plurals/an/a in case key changed in the interim
             self.aliases.clear(category=self.plural_category)
             self.aliases.add(plural, category=self.plural_category)
             # save the singular form as an alias here too so we can display "an egg" and also
@@ -2074,7 +2074,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
     def at_init(self):
         """
         This is always called whenever this object is initiated --
-        that is, whenever it its typeclass is cached from memory. This
+        that is, whenever its typeclass is cached from memory. This
         happens on-demand first time the object is used or activated
         in some way after being created but also after each server
         restart or reload.
@@ -2240,7 +2240,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     def at_pre_object_leave(self, leaving_object, destination, **kwargs):
         """
-        Called just before this object is about lose an object that was
+        Called just before this object is about to lose an object that was
         previously 'inside' it. Return False to abort move.
 
         Args:
@@ -2261,19 +2261,19 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     def at_pre_object_receive(self, arriving_object, source_location, **kwargs):
         """
-        Called just before this object received another object. If this
+        Called just before this object receives another object. If this
         method returns `False`, the move is aborted and the moved entity
         remains where it was.
 
         Args:
             arriving_object (DefaultObject): The object moved into this one
-            source_location (DefaultObject): Where `moved_object` came from.
+            source_location (DefaultObject): Where `arriving_object` came from.
                 Note that this could be `None`.
             **kwargs: Arbitrary, optional arguments for users
                 overriding the call (unused by default).
 
         Returns:
-            bool: If False, abort move and `moved_obj` remains where it was.
+            bool: If False, abort move and `arriving_object` remains where it was.
 
         Notes:
 
@@ -2746,7 +2746,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 overriding the call (unused by default).
 
         Returns:
-            shouldgive (bool): If the object should be given or not.
+            bool: If the object should be given or not.
 
         Notes:
             If this method returns `False` or `None`, the giving is cancelled


### PR DESCRIPTION
Adding a component to a ComponentHandler replaces the entry in _loaded_components, but adds to some lists (signals and the "component_names" attribute). The lists keep growing and cause undesireable behaviors (duplicate signal handling, inability to remove the components).

This change explicitly removes components with the same slot name before insertion. It also results in new calls to at_removed() which did not happen in previous component replacements but should have.

#### Brief overview of PR changes/additions

This is a minor fix to contrib.base_systems.components to properly handle replacing components with the same slot.

#### Motivation for adding to Evennia

The pre-existing behavior results in duplicate signal delivery and the inability to remove previous component instances.

#### Other info (issues closed, discussion etc)
