### PR TITLE
Avoid loading cmdsets that don't need to be checked

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -361,7 +361,12 @@ def get_and_merge_cmdsets(
                     local_objlist = yield (
                         location.contents_get(exclude=obj) + obj.contents_get() + [location]
                     )
-                    local_objlist = [o for o in local_objlist if not o._is_deleted]
+                    local_objlist = [
+                        o
+                        for o in local_objlist
+                        if not o._is_deleted
+                        and o.access(caller, access_type="call", no_superuser_bypass=True)
+                    ]
                     for lobj in local_objlist:
                         try:
                             # call hook in case we need to do dynamic changing to cmdset
@@ -375,12 +380,7 @@ def get_and_merge_cmdsets(
                         chain.from_iterable(
                             lobj.cmdset.cmdset_stack
                             for lobj in local_objlist
-                            if (
-                                lobj.cmdset.current
-                                and lobj.access(
-                                    caller, access_type="call", no_superuser_bypass=True
-                                )
-                            )
+                            if lobj.cmdset.current
                         )
                     )
                     for cset in local_obj_cmdsets:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
At the moment, the cmdhandler will load all of the command sets on all of the objects in a room when checking for merged commands, *regardless* of whether those objects will even allow you to call the commands on them. In most cases, this has no noticeable effect - however, in cases where there are a large number of commands attached to these objects, it can cause significant overhead by loading those cmdsets, despite them never being used.

This PR moves the lock check on the objects to the portion of the code which builds the list of objects to check, avoiding that cmdset-building for objects that are not callable.

#### Motivation for adding to Evennia
Avoiding certain edge-case lag issues.