### PR TITLE
Fix bug that prevented exits with an ordinal alias from displaying

### DIFF
--- a/evennia/contrib/grid/ingame_map_display/ingame_map_display.py
+++ b/evennia/contrib/grid/ingame_map_display/ingame_map_display.py
@@ -125,16 +125,11 @@ class Map(object):
         Returns:
             string: The exit name as a compass direction or an empty string.
         """
-        exit_name = ex.name
-        if exit_name not in _COMPASS_DIRECTIONS:
-            compass_aliases = [
-                direction in ex.aliases.all() for direction in _COMPASS_DIRECTIONS.keys()
-            ]
-            if compass_aliases[0]:
-                exit_name = compass_aliases[0]
-            if exit_name not in _COMPASS_DIRECTIONS:
-                return ""
-        return exit_name
+        return (
+            ex.name
+            if ex.name in _COMPASS_DIRECTIONS
+            else next((alias for alias in ex.aliases.all() if alias in _COMPASS_DIRECTIONS), "")
+        )
 
     def update_pos(self, room, exit_name):
         """

--- a/evennia/contrib/grid/ingame_map_display/tests.py
+++ b/evennia/contrib/grid/ingame_map_display/tests.py
@@ -32,7 +32,7 @@ class TestIngameMap(BaseEvenniaCommandTest):
         )
         create_object(
             exits.Exit,
-            key="west",
+            key="shopfront",
             aliases=["w"],
             location=self.east_room,
             destination=self.west_room,

--- a/evennia/contrib/grid/ingame_map_display/tests.py
+++ b/evennia/contrib/grid/ingame_map_display/tests.py
@@ -33,7 +33,7 @@ class TestIngameMap(BaseEvenniaCommandTest):
         create_object(
             exits.Exit,
             key="shopfront",
-            aliases=["w"],
+            aliases=["w","west"],
             location=self.east_room,
             destination=self.west_room,
         )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
```
left ass cheek: Hi - Using the in-game map display contrib, I'm confused how checking for compass directions in exit aliases is supposed to work in this code from exit_name_as_ordinal:
        if exit_name not in _COMPASS_DIRECTIONS:
            compass_aliases = [
                direction in ex.aliases.all() for direction in _COMPASS_DIRECTIONS.keys()
            ]
            if compass_aliases[0]:
                exit_name = compass_aliases[0]
            if exit_name not in _COMPASS_DIRECTIONS:
                return ""

compass_aliases is a list of booleans, which makes sense checking a value with an if statement (although - it only checks north for some reason anyway?) but in the next line, exit_name is set to that boolean value, and then compared to _COMPASS_DIRECTIONS keys, which are strings representing north, south, etc. So since True and False aren't compass directions, the entire alias-checking block always returns False, even if it were checking all the directions (and not just [0] which corresponds to north)
I assume this isn't intended behavior? If so, if I fix it would it be valuable to share?
```

#### Motivation for adding to Evennia
Fix above bug noticed by discord user

#### Other info (issues closed, discussion etc)
