### PR TITLE
fix create/destroy bug that surfaced in Twisted 24, get rid of some uses of returnValue()

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -630,14 +630,12 @@ def cmdhandler(
             if isinstance(ret, types.GeneratorType):
                 # cmd.func() is a generator, execute progressively
                 _progressive_cmd_run(cmd, ret)
-                ret = yield ret
                 # note that the _progressive_cmd_run will itself run
                 # the at_post_cmd etc as it finishes; this is a bit of
                 # code duplication but there seems to be no way to
                 # catch the StopIteration here (it's not in the same
                 # frame since this is in a deferred chain)
             else:
-                ret = yield ret
                 # post-command hook
                 yield cmd.at_post_cmd()
 

--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -646,9 +646,6 @@ def cmdhandler(
                 else:
                     caller.ndb.last_cmd = None
 
-            # return result to the deferred
-            return ret
-
         except InterruptCommand:
             # Do nothing, clean exit
             pass
@@ -757,10 +754,9 @@ def cmdhandler(
                 cmd = copy(cmd)
 
             # A normal command.
-            ret = yield _run_command(
+            yield _run_command(
                 cmd, cmdname, args, raw_cmdname, cmdset, session, account, cmdset_providers
             )
-            return ret
 
         except ErrorReported as exc:
             # this error was already reported, so we
@@ -774,7 +770,7 @@ def cmdhandler(
             sysarg = exc.sysarg
 
             if syscmd:
-                ret = yield _run_command(
+                yield _run_command(
                     syscmd,
                     syscmd.key,
                     sysarg,
@@ -784,7 +780,7 @@ def cmdhandler(
                     account,
                     cmdset_providers,
                 )
-                return ret
+                return
             elif sysarg:
                 # return system arg
                 error_to.msg(err_helper(exc.sysarg, cmdid=cmdid))

--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -37,7 +37,7 @@ from weakref import WeakValueDictionary
 from django.conf import settings
 from django.utils.translation import gettext as _
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import deferLater
 
 from evennia.commands.cmdset import CmdSet
@@ -390,7 +390,7 @@ def get_and_merge_cmdsets(
                         # explicitly.
                         cset.old_duplicates = cset.duplicates
                         cset.duplicates = True if cset.duplicates is None else cset.duplicates
-                returnValue(local_obj_cmdsets)
+                return local_obj_cmdsets
             except Exception:
                 _msg_err(caller, _ERROR_CMDSETS)
                 raise ErrorReported(raw_string)
@@ -408,9 +408,9 @@ def get_and_merge_cmdsets(
                 _msg_err(caller, _ERROR_CMDSETS)
                 raise ErrorReported(raw_string)
             try:
-                returnValue(obj.get_cmdsets(caller=caller, current=current))
+                return obj.get_cmdsets(caller=caller, current=current)
             except AttributeError:
-                returnValue((CmdSet(), []))
+                return (CmdSet(), [])
 
         local_obj_cmdsets = []
 
@@ -486,7 +486,7 @@ def get_and_merge_cmdsets(
         # if cmdset:
         #     caller.cmdset.current = cmdset
 
-        returnValue(cmdset)
+        return cmdset
     except ErrorReported:
         raise
     except Exception:
@@ -600,7 +600,7 @@ def cmdhandler(
 
             if _testing:
                 # only return the command instance
-                returnValue(cmd)
+                return cmd
 
             # assign custom kwargs to found cmd object
             for key, val in kwargs.items():
@@ -619,7 +619,7 @@ def cmdhandler(
             abort = yield cmd.at_pre_cmd()
             if abort:
                 # abort sequence
-                returnValue(abort)
+                return abort
 
             # Parse and execute
             yield cmd.parse()
@@ -649,7 +649,7 @@ def cmdhandler(
                     caller.ndb.last_cmd = None
 
             # return result to the deferred
-            returnValue(ret)
+            return ret
 
         except InterruptCommand:
             # Do nothing, clean exit
@@ -762,7 +762,7 @@ def cmdhandler(
             ret = yield _run_command(
                 cmd, cmdname, args, raw_cmdname, cmdset, session, account, cmdset_providers
             )
-            returnValue(ret)
+            return ret
 
         except ErrorReported as exc:
             # this error was already reported, so we
@@ -786,7 +786,7 @@ def cmdhandler(
                     account,
                     cmdset_providers,
                 )
-                returnValue(ret)
+                return ret
             elif sysarg:
                 # return system arg
                 error_to.msg(err_helper(exc.sysarg, cmdid=cmdid))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ extra = [
   "django-extensions >= 3.1.0",
 
   # xyzroom contrib
-  "scipy == 1.12.0",
+  "scipy == 1.15.1",
 
   # Git contrib
   "gitpython >= 3.1.27",


### PR DESCRIPTION
#### Brief overview of PR changes/additions

fixes https://github.com/evennia/evennia/issues/3724
twisted.internet.defer.returnValue is deprecated and slated for removal.

#### Motivation for adding to Evennia

bugfix

#### Other info (issues closed, discussion etc)

in the lines i removed(`ret = yield ret`), `ret` is always None or a generator in my testing.... never a Deferred (this is inside func decorated with \@inlineCallbacks).  Since it's not a Deferred I don't think it can be yielded.  Why is it failing now?  Not sure, but Twisted did make a change that allows you to yield coroutines as well, so my best guess is that change is causing it to fail now.

3.13 tests were failing because scipy 1.12.0 wheels weren't available for 3.13...bumped version so tests can run
