### PR TITLE
--gamedir doesn't work as GAMEDIR gets overwritten

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1787,8 +1787,11 @@ def init_game_directory(path, check_db=True, need_gamedir=True):
             be run in a valid game directory.
 
     """
-    # set the GAMEDIR path
-    if need_gamedir:
+    global GAMEDIR
+    # Set the GAMEDIR path if not set already
+    ## Declaring it global doesn't set the variable
+    ## This check is needed for evennia --gamedir to work
+    if need_gamedir and 'GAMEDIR' not in globals():
         set_gamedir(path)
 
     # Add gamedir to python path


### PR DESCRIPTION
Whether altgamedir from argparse has set GAMEDIR or not, the GAMEDIR is set based on the present working directory. This stops `evennia --gamedir /some/path/not/the/pwd` from having any effect (tested in podman with `docker.io/evennia/evennia:latest` )

#### Brief overview of PR changes/additions
Check if GAMEDIR is set, don't set it again if so

#### Motivation for adding to Evennia
To allow podman to run Evennia with, e.g.,
```podman run -it --rm -p 4000:4000 -p 4001:4001 -p 4002:4002 -v /path/to/my/games:/usr/src/game evennia/evennia evennia $@```

#### Other info (issues closed, discussion etc)
None