### PR TITLE
Don't use f-string for i18n

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -516,7 +516,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                 and len(self.get_all_puppets()) >= _MAX_NR_SIMULTANEOUS_PUPPETS
             ):
                 self.msg(
-                    _(f"You cannot control any more puppets (max {_MAX_NR_SIMULTANEOUS_PUPPETS})")
+                    _("You cannot control any more puppets (max {max_puppets})".format(max_puppets=_MAX_NR_SIMULTANEOUS_PUPPETS))
                 )
                 return
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Python f-strings don't work with i18n (gettext). Refactor to use `.format` instead.

#### Motivation for adding to Evennia
Bux Fixing

#### Other info (issues closed, discussion etc)
Similar issue already discussed in 2021 on [Discord](https://discordapp.com/channels/246323978879107073/246323978879107073/885436654825902090)

In that file (accounts.py) are also some Strings that are not marked for translation (`"..."` instead of `_("...")`). Is that intentionally? For example `"You are already puppeting this object."` on [Line 474](https://github.com/evennia/evennia/blob/main/evennia/accounts/accounts.py#L474). That one was at some point translated (see e.g. current german (de) PO file) but does not get pulled into the PO file on `evennia makemessages` at the moment.