### PR TITLE
Log stack trace when object creation fails

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1481,8 +1481,8 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating this '{key}' object: {e}")
-            logger.log_err(e)
+            errors.append(f"An error occurred while creating '{key}' object: {e}")
+            logger.log_trace()
 
         return obj, errors
 
@@ -3148,8 +3148,8 @@ class DefaultCharacter(DefaultObject):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating object '{key} object: {e}")
-            logger.log_err(e)
+            errors.append(f"An error occurred while creating '{key}' object: {e}")
+            logger.log_trace()
 
         return obj, errors
 
@@ -3434,8 +3434,8 @@ class DefaultRoom(DefaultObject):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating this '{key}' object: {e}")
-            logger.log_err(e)
+            errors.append(f"An error occurred while creating '{key}' object: {e}")
+            logger.log_trace()
 
         return obj, errors
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1481,8 +1481,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating this '{key}' object: {e}")
-            logger.log_err(e)
+            err_msg = f"An error occurred while creating '{key}' object: {e}"
+            errors.append(err_msg)
+            logger.log_trace()
 
         return obj, errors
 
@@ -3148,8 +3149,9 @@ class DefaultCharacter(DefaultObject):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating object '{key} object: {e}")
-            logger.log_err(e)
+            err_msg = f"An error occurred while creating '{key}' object: {e}"
+            errors.append(err_msg)
+            logger.log_trace()
 
         return obj, errors
 
@@ -3434,8 +3436,9 @@ class DefaultRoom(DefaultObject):
                 obj.db.desc = description
 
         except Exception as e:
-            errors.append(f"An error occurred while creating this '{key}' object: {e}")
-            logger.log_err(e)
+            err_msg = f"An error occurred while creating '{key}' object: {e}"
+            errors.append(err_msg)
+            logger.log_trace()
 
         return obj, errors
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Log the full trace when object creation fails.

#### Motivation for adding to Evennia
`["An error occurred while creating object 'orange cat object: '>' not supported between instances of 'int' and 'NoneType'"]`

That was the only error available to me when the create command failed in-game. I figured out the problem by adding the trace line in evennia core and feel that it will be useful to others. It would have taken more effort to debug.

#### Other info (issues closed, discussion etc)
Found it a prior issue on discord: https://discord.com/channels/246323978879107073/980878618685231194/1311335819168186412
<img width="653" alt="image" src="https://github.com/user-attachments/assets/336ab374-fa7a-4700-be62-d70719005e40" />

The same search string ("An error occurred while creating") in discord comes up with many results of people trying to debug where they went wrong with insufficient information to get help.