### PR TITLE
fix format strings for i18n

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -475,7 +475,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
             return
         if not obj.access(self, "puppet"):
             # no access
-            self.msg(_("You don't have permission to puppet '{key}'.".format(key=obj.key)))
+            self.msg(_("You don't have permission to puppet '{key}'.").format(key=obj.key))
             return
         if obj.account:
             # object already puppeted
@@ -484,27 +484,21 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                     # we may take over another of our sessions
                     # output messages to the affected sessions
                     if _MULTISESSION_MODE in (1, 3):
-                        txt1 = _(
-                            "Sharing |c{name}|n with another of your sessions.".format(
-                                name=obj.name
-                            )
-                        )
-                        txt2 = "|c{name}|n|G is now shared from another of your sessions.|n".format(
+                        txt1 = _("Sharing |c{name}|n with another of your sessions.").format(
                             name=obj.name
                         )
+                        txt2 = _(
+                            "|c{name}|n|G is now shared from another of your sessions.|n"
+                        ).format(name=obj.name)
                         self.msg(txt1, session=session)
                         self.msg(txt2, session=obj.sessions.all())
                     else:
-                        txt1 = _(
-                            "Taking over |c{name}|n from another of your sessions.".format(
-                                name=obj.name
-                            )
+                        txt1 = _("Taking over |c{name}|n from another of your sessions.").format(
+                            name=obj.name
                         )
                         txt2 = _(
-                            "|c{name}|n|R is now acted from another of your sessions.|n".format(
-                                name=obj.name
-                            )
-                        )
+                            "|c{name}|n|R is now acted from another of your sessions.|n"
+                        ).format(name=obj.name)
                         self.msg(txt1, session=session)
                         self.msg(txt2, session=obj.sessions.all())
                         self.unpuppet_object(obj.sessions.get())
@@ -530,10 +524,8 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
                 and len(self.get_all_puppets()) >= _MAX_NR_SIMULTANEOUS_PUPPETS
             ):
                 self.msg(
-                    _(
-                        "You cannot control any more puppets (max {max_puppets})".format(
-                            max_puppets=_MAX_NR_SIMULTANEOUS_PUPPETS
-                        )
+                    _("You cannot control any more puppets (max {max_puppets})").format(
+                        max_puppets=_MAX_NR_SIMULTANEOUS_PUPPETS
                     )
                 )
                 return


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The formating of the strings via `.format()` has to be called "after" translation via `gettext()`.
`_("...").format()` instead of `_("...".format())`
Otherwise the string will not be translated because at runtime the format method returns a String with already filled out content which then does not match any translation message via gettext().

#### Motivation for adding to Evennia
Bux fixing.

#### Other info (issues closed, discussion etc)
similar discussion: [Stackoverflow: Translating formatted strings in Django not working](https://stackoverflow.com/questions/44957261/translating-formatted-strings-in-django-not-working)