### PR TITLE
Let init_evennia_properties() also init properties of parent classes

### DIFF
--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -347,12 +347,21 @@ class TypedObject(SharedMemoryModel):
         Called by creation methods; makes sure to initialize Attribute/TagProperties
         by fetching them once.
         """
-        for propkey, prop in self.__class__.__dict__.items():
-            if isinstance(prop, (AttributeProperty, TagProperty, TagCategoryProperty)):
-                try:
-                    getattr(self, propkey)
-                except Exception:
-                    log_trace()
+        evennia_properties = set()
+        for base in type(self).__mro__:
+            evennia_properties.update(
+                {
+                    propkey
+                    for propkey, prop in vars(base).items()
+                    if isinstance(prop, (AttributeProperty, TagProperty, TagCategoryProperty))
+                }
+            )
+
+        for propkey in evennia_properties:
+            try:
+                getattr(self, propkey)
+            except Exception:
+                log_trace()
 
     # initialize all handlers in a lazy fashion
     @lazy_property


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I realized a (for me) unexpected behavior. If there are `AttributeProperty`s (with default values) in a parent typeclass, they won't be initialized at object creation if they are not (yet) used in the class . Just the `AttributeProperty`s from the "direct" typeclass of the object are set at object creation. 
Therefore one could not view those attributes ingame via `examine <obj>` or `set <obj>/<attr>`.

The method `init_evennia_properties()` loops through all properties of the typeclass but not of the parent typeclasses. 
With the help of "exsavio" (Discord) we changed that to also include parent classes.

#### Motivation for adding to Evennia
Bug fixing.

#### Other info (issues closed, discussion etc)
Discussion about that finding on [Discord](https://discord.com/channels/246323978879107073/980878618685231194/1354440454367740074)