### PR TITLE
Add internationalization (i18n via gettext)

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1382,13 +1382,14 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
             if obj.has_account:
                 if home:
-                    string = "Your current location has ceased to exist,"
-                    string += " moving you to (#{dbid})."
-                    obj.msg(_(string).format(dbid=home.dbid))
+                    string = _(
+                        "Your current location has ceased to exist,"
+                        " moving you to (#{dbid})."
+                    )
+                    obj.msg(string.format(dbid=home.dbid))
                 else:
                     # Famous last words: The account should never see this.
-                    string = "This place should not exist ... contact an admin."
-                    obj.msg(_(string))
+                    obj.msg(_("This place should not exist ... contact an admin."))
             obj.move_to(home, move_type="teleport")
 
     @classmethod
@@ -2141,7 +2142,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             puppeting this Object.
 
         """
-        self.msg(f"You become |w{self.key}|n.")
+        self.msg(_("You become |w{key}|n.").format(key=self.key))
         self.account.db._last_puppet = self
 
     def at_pre_unpuppet(self, **kwargs):
@@ -2798,7 +2799,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # TODO: This if-statment will be removed in Evennia 1.0
             return True
         if not self.access(dropper, "drop", default=False):
-            dropper.msg(f"You cannot drop {self.get_display_name(dropper)}")
+            dropper.msg(_("You cannot drop {obj}").format(obj=self.get_display_name(dropper)))
             return False
         return True
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1383,8 +1383,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             if obj.has_account:
                 if home:
                     string = _(
-                        "Your current location has ceased to exist,"
-                        " moving you to (#{dbid})."
+                        "Your current location has ceased to exist," " moving you to (#{dbid})."
                     )
                     obj.msg(string.format(dbid=home.dbid))
                 else:
@@ -1794,9 +1793,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         exits = self.filter_visible(self.contents_get(content_type="exit"), looker, **kwargs)
         exit_names = (exi.get_display_name(looker, **kwargs) for exi in exits)
-        exit_names = iter_to_str(_sort_exit_names(exit_names))
-
-        return f"|wExits:|n {exit_names}" if exit_names else ""
+        exit_names = iter_to_str(_sort_exit_names(exit_names), endsep=_("and"))
+        e = _("Exits")
+        return f"|w{e}:|n {exit_names}" if exit_names else ""
 
     def get_display_characters(self, looker, **kwargs):
         """
@@ -1813,10 +1812,10 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             self.contents_get(content_type="character"), looker, **kwargs
         )
         character_names = iter_to_str(
-            char.get_display_name(looker, **kwargs) for char in characters
+            (char.get_display_name(looker, **kwargs) for char in characters), endsep=_("and")
         )
-
-        return f"|wCharacters:|n {character_names}" if character_names else ""
+        c = _("Characters")
+        return f"|w{c}:|n {character_names}" if character_names else ""
 
     def get_display_things(self, looker, **kwargs):
         """
@@ -1842,8 +1841,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             thing = thinglist[0]
             singular, plural = thing.get_numbered_name(nthings, looker, key=thingname)
             thing_names.append(singular if nthings == 1 else plural)
-        thing_names = iter_to_str(thing_names)
-        return f"|wYou see:|n {thing_names}" if thing_names else ""
+        thing_names = iter_to_str(thing_names, endsep=_("and"))
+        s = _("You see")
+        return f"|w{s}:|n {thing_names}" if thing_names else ""
 
     def get_display_footer(self, looker, **kwargs):
         """
@@ -2321,7 +2321,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         if msg:
             string = msg
         else:
-            string = "{object} is leaving {origin}, heading for {destination}."
+            string = _("{object} is leaving {origin}, heading for {destination}.")
 
         location = self.location
         exits = [
@@ -2333,9 +2333,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         mapping.update(
             {
                 "object": self,
-                "exit": exits[0] if exits else "somewhere",
-                "origin": location or "nowhere",
-                "destination": destination or "nowhere",
+                "exit": exits[0] if exits else _("somewhere"),
+                "origin": location or _("nowhere"),
+                "destination": destination or _("nowhere"),
             }
         )
 
@@ -2406,9 +2406,9 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         mapping.update(
             {
                 "object": self,
-                "exit": exits[0] if exits else "somewhere",
-                "origin": origin or "nowhere",
-                "destination": destination or "nowhere",
+                "exit": exits[0] if exits else _("somewhere"),
+                "origin": origin or _("nowhere"),
+                "destination": destination or _("nowhere"),
             }
         )
 
@@ -2672,9 +2672,11 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         if not target.access(self, "view"):
             try:
-                return "Could not view '%s'." % target.get_display_name(self, **kwargs)
+                return _("Could not view '{target_name}'.").format(
+                    target_name=target.get_display_name(self, **kwargs)
+                )
             except AttributeError:
-                return "Could not view '%s'." % target.key
+                return _("Could not view '{target_name}'.").format(target_name=target.key)
 
         description = target.return_appearance(self, **kwargs)
 
@@ -2911,15 +2913,15 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             # whisper mode
             msg_type = "whisper"
             msg_self = (
-                '{self} whisper to {all_receivers}, "|n{speech}|n"'
+                _('{self} whisper to {all_receivers}, "|n{speech}|n"')
                 if msg_self is True
                 else msg_self
             )
-            msg_receivers = msg_receivers or '{object} whispers: "|n{speech}|n"'
+            msg_receivers = msg_receivers or _('{object} whispers: "|n{speech}|n"')
             msg_location = None
         else:
-            msg_self = '{self} say, "|n{speech}|n"' if msg_self is True else msg_self
-            msg_location = msg_location or '{object} says, "{speech}"'
+            msg_self = _('{self} say, "|n{speech}|n"') if msg_self is True else msg_self
+            msg_location = msg_location or _('{object} says, "{speech}"')
             msg_receivers = msg_receivers or message
 
         custom_mapping = kwargs.get("mapping", {})
@@ -2928,7 +2930,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         if msg_self:
             self_mapping = {
-                "self": "You",
+                "self": _("You"),
                 "object": self.get_display_name(self),
                 "location": location.get_display_name(self) if location else None,
                 "receiver": None,
@@ -2944,7 +2946,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         if receivers and msg_receivers:
             receiver_mapping = {
-                "self": "You",
+                "self": _("You"),
                 "object": None,
                 "location": None,
                 "receiver": None,
@@ -2971,7 +2973,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         if self.location and msg_location:
             location_mapping = {
-                "self": "You",
+                "self": _("You"),
                 "object": self,
                 "location": location,
                 "all_receivers": ", ".join(str(recv) for recv in receivers) if receivers else None,
@@ -3196,7 +3198,7 @@ class DefaultCharacter(DefaultObject):
 
         """
         if account and cls.objects.filter_family(db_key__iexact=name):
-            return f"|rA character named '|w{name}|r' already exists.|n"
+            return _("|rA character named '|w{name}|r' already exists.|n").format(name=name)
 
     def basetype_setup(self):
         """
@@ -3500,7 +3502,9 @@ class ExitCommand(_COMMAND_DEFAULT_CLASS):
 
         """
         if self.obj.destination:
-            return " (exit to %s)" % self.obj.destination.get_display_name(caller, **kwargs)
+            return _(" (exit to {destination})").format(
+                destination=self.obj.destination.get_display_name(caller, **kwargs)
+            )
         else:
             return " (%s)" % self.obj.get_display_name(caller, **kwargs)
 

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1383,7 +1383,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             if obj.has_account:
                 if home:
                     string = _(
-                        "Your current location has ceased to exist," " moving you to (#{dbid})."
+                        "Your current location has ceased to exist, moving you to (#{dbid})."
                     )
                     obj.msg(string.format(dbid=home.dbid))
                 else:

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -1793,7 +1793,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
         exits = self.filter_visible(self.contents_get(content_type="exit"), looker, **kwargs)
         exit_names = (exi.get_display_name(looker, **kwargs) for exi in exits)
-        exit_names = iter_to_str(_sort_exit_names(exit_names), endsep=_("and"))
+        exit_names = iter_to_str(_sort_exit_names(exit_names), endsep=_(", and"))
         e = _("Exits")
         return f"|w{e}:|n {exit_names}" if exit_names else ""
 
@@ -1812,7 +1812,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             self.contents_get(content_type="character"), looker, **kwargs
         )
         character_names = iter_to_str(
-            (char.get_display_name(looker, **kwargs) for char in characters), endsep=_("and")
+            (char.get_display_name(looker, **kwargs) for char in characters), endsep=_(", and")
         )
         c = _("Characters")
         return f"|w{c}:|n {character_names}" if character_names else ""
@@ -1841,7 +1841,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
             thing = thinglist[0]
             singular, plural = thing.get_numbered_name(nthings, looker, key=thingname)
             thing_names.append(singular if nthings == 1 else plural)
-        thing_names = iter_to_str(thing_names, endsep=_("and"))
+        thing_names = iter_to_str(thing_names, endsep=_(", and"))
         s = _("You see")
         return f"|w{s}:|n {thing_names}" if thing_names else ""
 

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -36,6 +36,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import smart_str
 from django.utils.text import slugify
+from django.utils.translation import gettext as _
 
 import evennia
 from evennia.locks.lockhandler import LockHandler
@@ -883,7 +884,7 @@ class TypedObject(SharedMemoryModel):
         """
 
         if self.location == looker:
-            return " (carried)"
+            return _(" (carried)")
         return ""
 
     def at_rename(self, oldname, newname):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Marked some more strings for translation so you don't need to overwrite whole methods of e.g. `DefaultObject` in your own game just to translate the simple messages defined there (without changing the behavior of the methods).

**Disclaimer:** [get_numbered_name()](https://github.com/evennia/evennia/blob/main/evennia/objects/objects.py#L1674) is impossible to translate via gettext because it uses [inflect](https://pypi.org/project/inflect/) for inflection (only works in english). So you still need to overwrite this method in your foreign language.

#### Motivation for adding to Evennia
Internationalization

#### Other info (issues closed, discussion etc)
