### PR TITLE
upgrade docs to sphinx 8

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,18 +1,17 @@
 # requirements for building the docs
 
-sphinx==3.2.1
-myst-parser==0.15.2
-myst-parser[linkify]==0.15.2
-Jinja2 < 3.1
+sphinx==8.2.3
+myst-parser==4.0.1
+myst-parser[linkify]==4.0.1
+Jinja2==3.1.6
 
-# pinned to allow for sphinx 3.x to still work, latest required 5+
-alabaster==0.7.13
-sphinxcontrib-applehelp<1.0.7
-sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.0.5
-sphinxcontrib-qthelp<1.0.7
+alabaster==1.0.0
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-serializinghtml<1.1.10
+sphinxcontrib-serializinghtml==2.0.0
 
 # sphinx-multiversion with evennia fixes 
 git+https://github.com/evennia/sphinx-multiversion.git@evennia-mods#egg=sphinx-multiversion

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -95,7 +95,7 @@
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1)|e }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1)|e }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {%- for css in css_files %}
       {%- if css|attr("filename") %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ import sys
 from collections import namedtuple
 
 # from recommonmark.transform import AutoStructify
-from sphinx.util.osutil import cd
+from contextlib import chdir
 
 # -- Project information -----------------------------------------------------
 
@@ -252,7 +252,7 @@ if not _no_autodoc:
 
     sys.path.insert(1, EV_ROOT)
 
-    with cd(EV_ROOT):
+    with chdir(EV_ROOT):
         # set up Evennia so its sources can be parsed
         os.environ["DJANGO_SETTINGS_MODULE"] = "evennia.settings_default"
 


### PR DESCRIPTION
upgrade docs to Sphinx 8

fixes https://github.com/evennia/evennia/issues/3613

i've only had a quick look at this, and i haven't tested multi-version.

i did notice that the API listing is expanded by default now.

for instance /evennia/docs/build/latest/api/evennia.utils.html#evennia-utils

looks like this now:

![docs_new](https://github.com/user-attachments/assets/27e37afb-6fdc-407c-95c9-6f371483b8dd)

instead of this:

![docs_old](https://github.com/user-attachments/assets/537ac72c-11a7-4f83-b00e-92fa3ef1525c)

sorry for the repost, i suck with git.
