### PR TITLE
fix SyntaxWarnings

### DIFF
--- a/evennia/commands/default/admin.py
+++ b/evennia/commands/default/admin.py
@@ -212,7 +212,7 @@ class CmdBan(COMMAND_DEFAULT_CLASS):
             typ = "IP"
             ban = ipban[0]
             # replace * with regex form and compile it
-            ipregex = ban.replace(".", "\.")
+            ipregex = ban.replace(".", r"\.")
             ipregex = ipregex.replace("*", "[0-9]{1,3}")
             ipregex = re.compile(r"%s" % ipregex)
             bantup = ("", ban, ipregex, now, reason)

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3249,7 +3249,7 @@ class CmdFind(COMMAND_DEFAULT_CLASS):
             try:
                 # Check that rhs is either a valid dbref or dbref range
                 bounds = tuple(
-                    sorted(dbref(x, False) for x in re.split("[-\s]+", self.rhs.strip()))
+                    sorted(dbref(x, False) for x in re.split(r"[-\s]+", self.rhs.strip()))
                 )
 
                 # dbref() will return either a valid int or None

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -814,7 +814,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
             return "#"
 
     def web_get_detail_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to view details for
         this object.
 
@@ -850,7 +850,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
             return "#"
 
     def web_get_update_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to update this
         object.
 
@@ -886,7 +886,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
             return "#"
 
     def web_get_delete_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to delete this object.
 
         ex. Oscar (Character) = '/characters/oscar/1/delete/'

--- a/evennia/help/filehelp.py
+++ b/evennia/help/filehelp.py
@@ -128,7 +128,7 @@ class FileHelpEntry:
         return LockHandler(self)
 
     def web_get_detail_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to view details for
         this object.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

fix these warnings:
```
Superuser created successfully.
/Users/jake/Evennia/evennia/evennia/comms/comms.py:817: SyntaxWarning: invalid escape sequence '\w'
  """
/Users/jake/Evennia/evennia/evennia/comms/comms.py:853: SyntaxWarning: invalid escape sequence '\w'
  """
/Users/jake/Evennia/evennia/evennia/comms/comms.py:889: SyntaxWarning: invalid escape sequence '\w'
  """
/Users/jake/Evennia/evennia/evennia/commands/default/admin.py:215: SyntaxWarning: invalid escape sequence '\.'
  ipregex = ban.replace(".", "\.")
/Users/jake/Evennia/evennia/evennia/commands/default/building.py:3252: SyntaxWarning: invalid escape sequence '\s'
  sorted(dbref(x, False) for x in re.split("[-\s]+", self.rhs.strip()))
/Users/jake/Evennia/evennia/evennia/help/filehelp.py:131: SyntaxWarning: invalid escape sequence '\w'
  """
```

thx @jaborsh and @InspectorCaracal
