### PR TITLE
Copied objects retain plural alias category.

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -397,7 +397,10 @@ class CmdCopy(ObjManipCommand):
             if not from_obj:
                 return
             to_obj_name = "%s_copy" % from_obj_name
-            to_obj_aliases = ["%s_copy" % alias for alias in from_obj.aliases.all()]
+            to_obj_aliases = [
+                (f"{alias}_copy", category)
+                for alias, category in from_obj.aliases.all(return_key_and_category=True)
+            ]
             copiedobj = ObjectDB.objects.copy_object(
                 from_obj, new_key=to_obj_name, new_aliases=to_obj_aliases
             )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`CmdCopy` now receives (alias,category) pairs from ObjectDB to ensure plural categories are not lost on the new object.

#### Other info (issues closed, discussion etc)
Of note is #3432 which describes a longstanding issue regarding plural aliases in the first place.

Resolves #3746 
