### PR TITLE
Update multimatch template

### DIFF
--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -3464,7 +3464,7 @@ class ExitCommand(_COMMAND_DEFAULT_CLASS):
 
     """
 
-    obj = None
+    #obj = None
 
     def func(self):
         """
@@ -3504,7 +3504,7 @@ class ExitCommand(_COMMAND_DEFAULT_CLASS):
         if self.obj.destination:
             return " (exit to %s)" % self.obj.destination.get_display_name(caller, **kwargs)
         else:
-            return " (%s)" % self.obj.get_display_name(caller, **kwargs)
+            return _(" (exit)")
 
 
 #

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -3484,6 +3484,9 @@ class ExitCommand(_COMMAND_DEFAULT_CLASS):
                 # No shorthand error message. Call hook.
                 self.obj.at_failed_traverse(self.caller)
 
+    def get_display_name(self, looker=None, **kwargs):
+        return self.obj.get_display_name(looker, **kwargs)
+
     def get_extra_info(self, caller, **kwargs):
         """
         Shows a bit of information on where the exit leads.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I noticed that the [at_search_result()](https://github.com/evennia/evennia/blob/main/evennia/utils/utils.py#L2357) method does not show the "real" name/key of an exit if there is a multimatch but rather just list them with the command query. 
If that is an alias of the exit the "real" name of the exit does not show up in the multimatch list but which could be important to know to choose the right one.
For objects this issue does not apply, because they have a `get_display_name()` method but `ExitCommand` lacks this.

So i added a `get_display_name()` for `ExitCommand` that reflects the according exit. Now a multimatch on exits looks the same as a multimatch on objects (except the `extra_info`part in parentheses).
Therefore the fallback of [get_extra_info()](https://github.com/evennia/evennia/blob/main/evennia/objects/objects.py#L3487) to return the display_name if no destination is set is obsolete, so it now just returns `" (exit)"` if the exit has no destination.

##### Further Idea:
Maybe we could even hide the extra info about the exit's destination (especially if the "real names" are unique)? Otherwise it would give players advanced info (destination room) they normally should not get easily.

Therefore we could change [get_extra_info()](https://github.com/evennia/evennia/blob/main/evennia/objects/objects.py#L3487) of the `ExitCommand` to just return `" (exit)"` to discrimminate exits against other objects with same names (similar to `" (carried)"` for objects in the inventory).


#### Motivation for adding to Evennia
Bug fixing.

#### Other info (issues closed, discussion etc)


#### example scenario

```
dig/tel multimatch-room
create/drop apple;fruit
create/drop pear/fruit
dig upstairs=stairs up;stairs;up,stairs down;stairs;down
dig downstairs=stairs down;stairs;down,stairs up;stairs;up
```

##### before
```
multimatch-room
This is a room.
Exits: stairs up and stairs down
You see: an apple and a pear
```

`get fruit`

```
More than one match for 'fruit' (please narrow target):
 apple-1 [fruit]
 pear-1 [fruit]
```

`stairs`

```
More than one match for 'stairs' (please narrow target):
 stairs-1 [up;stairs] (exit to upstairs)
 stairs-2 [down;stairs] (exit to downstairs)
```

##### after

```
multimatch-room
This is a room.
Exits: stairs up and stairs down
You see: an apple and a pear
```

`get fruit`

```
More than one match for 'fruit' (please narrow target):
 apple-1 [fruit]
 pear-1 [fruit]
```

`stairs`

```
More than one match for 'stairs' (please narrow target):
 stairs up-1 [stairs;up] (exit to upstairs)
 stairs down-1 [down;stairs] (exit to downstairs)
``` 
 
