### PR TITLE
Resolving SyntaxWarnings for Py 3.13

### DIFF
--- a/evennia/help/models.py
+++ b/evennia/help/models.py
@@ -206,7 +206,7 @@ class HelpEntry(SharedMemoryModel):
             return "#"
 
     def web_get_detail_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to view details for
         this object.
 
@@ -242,7 +242,7 @@ class HelpEntry(SharedMemoryModel):
             return "#"
 
     def web_get_update_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to update this
         object.
 
@@ -278,7 +278,7 @@ class HelpEntry(SharedMemoryModel):
             return "#"
 
     def web_get_delete_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to delete this object.
 
         ex. Oscar (Character) = '/characters/oscar/1/delete/'

--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -1471,7 +1471,7 @@ class DbHolder:
 # Nick templating
 #
 
-"""
+r"""
 This supports the use of replacement templates in nicks:
 
 This happens in two steps:

--- a/evennia/typeclasses/models.py
+++ b/evennia/typeclasses/models.py
@@ -948,7 +948,7 @@ class TypedObject(SharedMemoryModel):
             return "#"
 
     def web_get_detail_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to view details for
         this object.
 
@@ -988,7 +988,7 @@ class TypedObject(SharedMemoryModel):
             return "#"
 
     def web_get_puppet_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to puppet a specific
         object.
 
@@ -1026,7 +1026,7 @@ class TypedObject(SharedMemoryModel):
             return "#"
 
     def web_get_update_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to update this
         object.
 
@@ -1065,7 +1065,7 @@ class TypedObject(SharedMemoryModel):
             return "#"
 
     def web_get_delete_url(self):
-        """
+        r"""
         Returns the URI path for a View that allows users to delete this object.
 
         Returns:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fix:

```
> evennia migrate
/home/jake/evennia/evennia/evennia/typeclasses/models.py:951: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/typeclasses/models.py:991: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/typeclasses/models.py:1029: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/typeclasses/models.py:1068: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/typeclasses/attributes.py:1474: SyntaxWarning: invalid escape sequence '\@'
  """
/home/jake/evennia/evennia/evennia/help/models.py:209: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/help/models.py:245: SyntaxWarning: invalid escape sequence '\w'
  """
/home/jake/evennia/evennia/evennia/help/models.py:281: SyntaxWarning: invalid escape sequence '\w'
```

#### Additional Notes:
Occurred on WSL running Ubuntu with Py 3.13
