### PR TITLE
Enhance help text formatting in EvMenu

### DIFF
--- a/docs/source/Components/EvMenu.md
+++ b/docs/source/Components/EvMenu.md
@@ -13,28 +13,29 @@ You chose yes!
 Thanks for your answer. Goodbye!
 ```
 
-_EvMenu_ is used for generate branching multi-choice menus. Each menu 'node' can
-accepts specific options as input or free-form input. Depending what the player
-chooses, they are forwarded to different nodes in the menu.
+_EvMenu_ is used to generate branching multi-choice menus. Each menu 'node' can accept specific
+options as input or free-form input. Depending what the player chooses, they are forwarded to
+different nodes in the menu.
 
-The `EvMenu` utility class is located in [evennia/utils/evmenu.py](evennia.utils.evmenu).
-It allows for easily adding interactive menus to the game; for example to implement Character creation, building commands or similar. Below is an example of offering NPC conversation choices:
+The `EvMenu` utility class is located in [evennia/utils/evmenu.py](evennia.utils.evmenu). It allows
+for easily adding interactive menus to the game; for example to implement Character creation,
+building commands or similar. Below is an example of offering NPC conversation choices:
 
 This is how the example menu at the top of this page will look in code:
 
 ```python
 from evennia.utils import evmenu
 
-def _handle_answer(caller, raw_input, **kwargs):
+def _handle_answer(caller, raw_string, **kwargs):
     answer = kwargs.get("answer")
     caller.msg(f"You chose {answer}!")
     return "end"  # name of next node
 
-def node_question(caller, raw_input, **kwargs):
+def node_question(caller, raw_string, **kwargs):
     text = "Is your answer yes or no?"
     options = (
         {"key": ("[Y]es!", "yes", "y"),
-         "desc": Answer yes.",
+         "desc": "Answer yes.",
          "goto": _handle_answer, {"answer": "yes"}},
         {"key": ("[N]o!", "no", "n"),
          "desc": "Answer no.",
@@ -45,44 +46,42 @@ def node_question(caller, raw_input, **kwargs):
     )
     return text, options
 
-def node_end(caller, raw_input, **kwargs):
-    text "Thanks for your answer. Goodbye!"
+def node_end(caller, raw_string, **kwargs):
+    text = "Thanks for your answer. Goodbye!"
     return text, None  # empty options ends the menu
 
 evmenu.EvMenu(caller, {"start": node_question, "end": node_end})
 
 ```
 
-Note the call to `EvMenu` at the end; this immediately creates the menu for the
-`caller`. It also assigns the two node-functions to menu node-names `start` and
-`end`, which is what the menu then uses to reference the nodes.
+Note the call to `EvMenu` at the end; this immediately creates the menu for the `caller`. It also
+assigns the two node-functions to menu node-names `start` and `end`, which is what the menu then
+uses to reference the nodes.
 
-Each node of the menu is a function that returns the text and a list of dicts
-describing the choices you can make on that node.
+Each node of the menu is a function that returns the text and a list of dicts describing the choices
+you can make on that node.
 
-Each option details what it should show (key/desc) as well as which node to go
-to (goto) next. The "goto" should be the name of the next node to go (if `None`,
-the same node will be rerun again).
+Each option details what it should show (key/desc) as well as which node to go to (goto) next. The
+"goto" should be the name of the next node to go (if `None`, the same node will be rerun again).
 
-Above, the `Abort` option gives the "end" node name just as a string whereas the
-yes/no options instead uses the callable `_handle_answer` but pass different
-arguments to it. `_handle_answer` then returns the name of the next node (this
-allows you to perform actions when making a choice before you move on to the
-next node the menu). Note that `_handle_answer` is _not_ a node in the menu,
-it's just a helper function.
+Above, the `Abort` option gives the "end" node name just as a string whereas the yes/no options
+instead uses the callable `_handle_answer` but pass different arguments to it. `_handle_answer` then
+returns the name of the next node (this allows you to perform actions when making a choice before
+you move on to the next node the menu). Note that `_handle_answer` is _not_ a node in the menu, it's
+just a helper function.
 
-When choosing 'yes' (or 'no') what happens here is that `_handle_answer` gets
-called and echoes your choice before directing to the "end" node, which exits
-the menu (since it doesn't return any options).
+When choosing 'yes' (or 'no') what happens here is that `_handle_answer` gets called and echoes your
+choice before directing to the "end" node, which exits the menu (since it doesn't return any
+options).
 
 You can also write menus using the [EvMenu templating language](#evmenu-templating-language). This
-allows you to use a text string to generate simpler menus with less boiler
-plate. Let's create exactly the same menu using the templating language:
+allows you to use a text string to generate simpler menus with less boiler plate. Let's create
+exactly the same menu using the templating language:
 
 ```python
 from evennia.utils import evmenu
 
-def _handle_answer(caller, raw_input, **kwargs):
+def _handle_answer(caller, raw_string, **kwargs):
     answer = kwargs.get("answer")
     caller.msg(f"You chose {answer}!")
     return "end"  # name of next node
@@ -95,8 +94,8 @@ Is your answer yes or no?
 
 ## options
 
-[Y]es!;yes;y: Answer yes. -> handle_answer(answer=yes)
-[N]o!;no;n: Answer no. -> handle_answer(answer=no)
+[Y]es!;yes;y: Answer yes. -> handle_answer(answer="yes")
+[N]o!;no;n: Answer no. -> handle_answer(answer="no")
 [A]bort;abort;a: Answer neither, and abort. -> end
 
 ## node end
@@ -109,14 +108,13 @@ evmenu.template2menu(caller, menu_template, {"handle_answer": _handle_answer})
 
 ```
 
-As seen, the `_handle_answer` is the same, but the menu structure is
-described in the `menu_template` string. The `template2menu` helper
-uses the template-string and a mapping of callables (we must add
-`_handle_answer` here) to build a full EvMenu for us.
+As seen, the `_handle_answer` is the same, but the menu structure is described in the
+`menu_template` string. The `template2menu` helper uses the template-string and a mapping of
+callables (we must add `_handle_answer` here) to build a full EvMenu for us.
 
 Here's another menu example, where we can choose how to interact with an NPC:
 
-```
+```py
 The guard looks at you suspiciously.
 "No one is supposed to be in here ..."
 he says, a hand on his weapon.
@@ -128,7 +126,7 @@ _______________________________________________
  5. Try to run away [Dex]
 ```
 
-```python
+```py
 
 def _skill_check(caller, raw_string, **kwargs):
     skills = kwargs.get("skills", [])
@@ -140,11 +138,12 @@ def _skill_check(caller, raw_string, **kwargs):
 
     return next_node_name
 
-def node_guard(caller, raw_string, **kwarg):
+def node_guard(caller, raw_string, **kwargs):
     text = (
         'The guard looks at you suspiciously.\n'
         '"No one is supposed to be in here ..."\n'
         'he says, a hand on his weapon.'
+    )
     options = (
         {"desc": "Try to bribe on [Cha + 10 gold]",
          "goto": (_skill_check, {"skills": ["Cha"], "gold": 10})},
@@ -153,28 +152,28 @@ def node_guard(caller, raw_string, **kwarg):
         {"desc": "Appeal to his vanity [Cha]",
          "goto": (_skill_check, {"skills": ["Cha"]})},
         {"desc": "Try to knock him out [Luck + Dex]",
-         "goto": (_skill_check, {"skills"" ["Luck", "Dex"]})},
+         "goto": (_skill_check, {"skills": ["Luck", "Dex"]})},
         {"desc": "Try to run away [Dex]",
          "goto": (_skill_check, {"skills": ["Dex"]})}
-    return text, options
     )
+
+    return text, options
 
 # EvMenu called below, with all the nodes ...
 
 ```
 
-Note that by skipping the `key` of the options, we instead get an
-(auto-generated) list of numbered options to choose from.
+Note that by skipping the `key` of the options, we instead get an (auto-generated) list of numbered
+options to choose from.
 
-Here the `_skill_check` helper will check (roll your stats, exactly what this
-means depends on your game) to decide if your approach succeeded. It may then
-choose to point you to nodes that continue the conversation or maybe dump you
-into combat!
-
+Here the `_skill_check` helper will check (roll your stats, exactly what this means depends on your
+game) to decide if your approach succeeded. It may then choose to point you to nodes that continue
+the conversation or maybe dump you into combat!
 
 ## Launching the menu
 
-Initializing the menu is done using a call to the `evennia.utils.evmenu.EvMenu` class. This is the most common way to do so - from inside a [Command](./Commands.md):
+Initializing the menu is done using a call to the `evennia.utils.evmenu.EvMenu` class. This is the
+most common way to do so - from inside a [Command](./Commands.md):
 
 ```python
 # in, for example gamedir/commands/command.py
@@ -187,7 +186,7 @@ class CmdTestMenu(Command):
 
     def func(self):
 
-	EvMenu(self.caller, "world.mymenu")
+ EvMenu(self.caller, "world.mymenu")
 
 ```
 
@@ -210,31 +209,54 @@ EvMenu(caller, menu_data,
 
 ```
 
- - `caller` (Object or Account): is a reference to the object using the menu. This object will get a new [CmdSet](./Command-Sets.md) assigned to it, for handling the menu.
- - `menu_data` (str, module or dict): is a module or python path to a module where the global-level functions will each be considered to be a menu node. Their names in the module will be the names by which they are referred to in the module. Importantly, function names starting with an underscore `_` will be ignored by the loader. Alternatively, this can be a direct mapping
-`{"nodename":function, ...}`.
- - `startnode` (str): is the name of the menu-node to start the menu at. Changing this means that you can jump into a menu tree at different positions depending on circumstance and thus possibly re-use menu entries.
- - `cmdset_mergetype` (str): This is usually one of "Replace" or "Union" (see [CmdSets](Command- Sets). The first means that the menu is exclusive - the user has no access to any other commands while in the menu. The Union mergetype means the menu co-exists with previous commands (and may overload them, so be careful as to what to name your menu entries in this case).
- - `cmdset_priority` (int): The priority with which to merge in the menu cmdset. This allows for advanced usage.
- - `auto_quit`, `auto_look`, `auto_help` (bool): If either of these are `True`, the menu automatically makes a `quit`, `look` or `help` command available to the user. The main reason why you'd want to turn this off is if  you want to use the aliases "q", "l" or "h" for something in your menu. The `auto_help` also activates the ability to have arbitrary "tool tips" in your menu node (see below), At least `quit` is highly recommend - if `False`, the menu *must* itself supply an "exit node" (a node without any options), or the user will be stuck in the menu until the server reloads (or eternally if the menu is `persistent`)!
- - `cmd_on_exit` (str): This command string will be executed right *after* the menu has closed down. From experience, it's useful to trigger a "look" command to make sure the user is aware of the change of state; but any command can be used. If set to `None`, no command will be triggered after exiting the menu.
- - `persistent` (bool) - if `True`, the menu will survive a reload (so the user will not be kicked
-   out by the reload - make sure they can exit on their own!)
- - `startnode_input` (str or (str, dict) tuple): Pass an input text or a input text + kwargs to the
-   start node as if it was entered on a fictional previous node. This can be very useful in order to
-   start a menu differently depending on the Command's arguments in which it was initialized.
- - `session` (Session): Useful when calling the menu from an [Account](./Accounts.md) in
-   `MULTISESSION_MODE` higher than 2, to make sure only the right Session sees the menu output.
- - `debug` (bool): If set, the `menudebug` command will be made available in the menu. Use it to
-   list the current state of the menu and use `menudebug <variable>` to inspect a specific state
-   variable from the list.
- - All other keyword arguments will be available as initial data for the nodes. They will be available in all nodes as properties on `caller.ndb._evmenu` (see below). These will also survive a `reload` if the menu is `persistent`.
+-   `caller` (Object or Account): is a reference to the object using the menu. This object will get
+    a new [CmdSet](./Command-Sets.md) assigned to it, for handling the menu.
+-   `menu_data` (str, module or dict): is a module or python path to a module where the global-level
+    functions will each be considered to be a menu node. Their names in the module will be the names
+    by which they are referred to in the module. Importantly, function names starting with an
+    underscore `_` will be ignored by the loader. Alternatively, this can be a direct mapping.
+    `{"nodename":function, ...}`.
+-   `startnode` (str): is the name of the menu-node to start the menu at. Changing this means that
+    you can jump into a menu tree at different positions depending on circumstance and thus possibly
+    re-use menu entries.
+-   `cmdset_mergetype` (str): This is usually one of "Replace" or "Union" (see
+    [CmdSets](https://www.evennia.com/docs/latest/api/evennia.commands.cmdset.html)). The first
+    means that the menu is exclusive - the user has no access to any other commands while in the
+    menu. The Union mergetype means the menu co-exists with previous commands (and may overload
+    them, so be careful as to what to name your menu entries in this case).
+-   `cmdset_priority` (int): The priority with which to merge in the menu cmdset. This allows for
+    advanced usage.
+-   `auto_quit`, `auto_look`, `auto_help` (bool): If either of these are `True`, the menu
+    automatically makes a `quit`, `look` or `help` command available to the user. The main reason
+    why you'd want to turn this off is if you want to use the aliases "q", "l" or "h" for something
+    in your menu. The `auto_help` also activates the ability to have arbitrary "tool tips" in your
+    menu node (see below), At least `quit` is highly recommend - if `False`, the menu _must_ itself
+    supply an "exit node" (a node without any options), or the user will be stuck in the menu until
+    the server reloads (or eternally if the menu is `persistent`)!
+-   `cmd_on_exit` (str): This command string will be executed right _after_ the menu has closed
+    down. From experience, it's useful to trigger a "look" command to make sure the user is aware of
+    the change of state; but any command can be used. If set to `None`, no command will be triggered
+    after exiting the menu.
+-   `persistent` (bool) - if `True`, the menu will survive a reload (so the user will not be kicked
+    out by the reload - make sure they can exit on their own!)
+-   `startnode_input` (str or (str, dict) tuple): Pass an input text or an input text + kwargs to
+    the start node as if it was entered on a fictional previous node. This can be very useful in
+    order to start a menu differently depending on the Command's arguments in which it was
+    initialized.
+-   `session` (Session): Useful when calling the menu from an [Account](./Accounts.md) in
+    `MULTISESSION_MODE` higher than 2, to make sure only the right Session sees the menu output.
+-   `debug` (bool): If set, the `menudebug` command will be made available in the menu. Use it to
+    list the current state of the menu and use `menudebug <variable>` to inspect a specific state
+    variable from the list.
+-   All other keyword arguments will be available as initial data for the nodes. They will be
+    available in all nodes as properties on `caller.ndb._evmenu` (see below). These will also
+    survive a `reload` if the menu is `persistent`.
 
 You don't need to store the EvMenu instance anywhere - the very act of initializing it will store it
-as `caller.ndb._evmenu` on the `caller`. This object will be deleted automatically when the menu
-is exited and you can also use it to store your own temporary variables for access throughout the
-menu. Temporary variables you store on a persistent `_evmenu` as it runs will
-*not* survive a `@reload`, only those you set as part of the original `EvMenu` call.
+as `caller.ndb._evmenu` on the `caller`. This object will be deleted automatically when the menu is
+exited and you can also use it to store your own temporary variables for access throughout the menu.
+Temporary variables you store on a persistent `_evmenu` as it runs will _not_ survive a `@reload`,
+only those you set as part of the original `EvMenu` call.
 
 ## The Menu nodes
 
@@ -255,48 +277,62 @@ def menunodename3(caller, raw_string, **kwargs):
 
 ```
 
-> While all of the above forms are okay, it's recommended to stick to the third and last form since it gives the most flexibility. The previous forms are mainly there for backwards compatibility with  existing menus from a time when EvMenu was less able and may become deprecated at some time in the future.
-
+> While all of the above forms are okay, it's recommended to stick to the third and last form since
+> it gives the most flexibility. The previous forms are mainly there for backwards compatibility
+> with existing menus from a time when EvMenu was less able and may become deprecated at some time
+> in the future.
 
 ### Input arguments to the node
 
- - `caller` (Object or Account): The object using the menu - usually a Character but could also be a Session or Account depending on where the menu is used.
- - `raw_string` (str): If this is given, it will be set to the exact text the user entered on the
-   *previous* node (that is, the command entered to get to this node). On the starting-node of the menu, this will be an empty string, unless `startnode_input` was set.
- - `kwargs` (dict): These extra keyword arguments are extra optional arguments passed to the node when the user makes a choice on the *previous* node. This may include things like status flags and details about which exact option was chosen (which can be impossible to determine from
-   `raw_string` alone). Just what is passed in `kwargs` is up to you when you create the previous node.
+-   `caller` (Object or Account): The object using the menu - usually a Character but could also be
+    a Session or Account depending on where the menu is used.
+-   `raw_string` (str): If this is given, it will be set to the exact text the user entered on the
+    _previous_ node (that is, the command entered to get to this node). On the starting-node of the
+    menu, this will be an empty string, unless `startnode_input` was set.
+-   `kwargs` (dict): These extra keyword arguments are extra optional arguments passed to the node
+    when the user makes a choice on the _previous_ node. This may include things like status flags
+    and details about which exact option was chosen (which can be impossible to determine from
+    `raw_string` alone). Just what is passed in `kwargs` is up to you when you create the previous
+    node.
 
 ### Return values from the node
 
 Each node function must return two variables, `text` and `options`.
 
-
 #### text
 
-The `text` variable is either a string or a tuple. This is the simplest form: 
+The `text` variable is either a string or a tuple. This is the simplest form:
 
 ```python
 text = "Node text"
 ```
 
-This is what will be displayed as text in the menu node when entering it. You can modify this dynamically in the node if you want. Returning a `None` node text text is allowed - this leads to a node with no text and only options.  
+This is what will be displayed as text in the menu node when entering it. You can modify this
+dynamically in the node if you want. Returning a `None` node text text is allowed - this leads to a
+node with no text and only options.
 
 ```python
 text = ("Node text", "help text to show with h|elp")
 ```
 
-In this form, we also add an optional help text. If `auto_help=True` when initializing the EvMenu, the user will be able to use `h` or `help` to see this text when viewing this node. If the user were to provide a custom option overriding `h` or `help`, that will be shown instead.
+In this form, we also add an optional help text. If `auto_help=True` when initializing the EvMenu,
+the user will be able to use `h` or `help` to see this text when viewing this node. If the user were
+to provide a custom option overriding `h` or `help`, that will be shown instead.
 
 If `auto_help=True` and no help text is provided, using `h|elp` will give a generic error message.
 
 ```python
-text = ("Node text", {"help topic 1": "Help 1", 
+text = ("Node text", {"help topic 1": "Help 1",
                       ("help topic 2", "alias1", ...): "Help 2", ...})
 ```
 
-This is 'tooltip' or 'multi-help category' mode. This also requires `auto_help=True` when initializing the EvMenu. By providing a `dict` as the second element of the `text` tuple, the user will be able to help about any of these topics. Use a tuple as key to add multiple aliases to the same help entry. This allows the user to get more detailed help text without leaving the given node. 
+This is 'tooltip' or 'multi-help category' mode. This also requires `auto_help=True` when
+initializing the EvMenu. By providing a `dict` as the second element of the `text` tuple, the user
+will be able to help about any of these topics. Use a tuple as key to add multiple aliases to the
+same help entry. This allows the user to get more detailed help text without leaving the given node.
 
-Note that in 'tooltip' mode, the normal `h|elp` command won't work. The `h|elp` entry must be added manually in the dict. As an example, this would reproduce the normal help functionality: 
+Note that in 'tooltip' mode, the normal `h|elp` command won't work. The `h|elp` entry must be added
+manually in the dict. As an example, this would reproduce the normal help functionality:
 
 ```python
 text = ("Node text", {("help", "h"): "Help entry...", ...})
@@ -304,10 +340,12 @@ text = ("Node text", {("help", "h"): "Help entry...", ...})
 
 #### options
 
-The `options` list describe all the choices available to the user when viewing this node. If `options` is returned as `None`, it means that this node is an *Exit node* - any text is displayed and then the menu immediately exits, running the `exit_cmd` if given.
+The `options` list describe all the choices available to the user when viewing this node. If
+`options` is returned as `None`, it means that this node is an _Exit node_ - any text is displayed
+and then the menu immediately exits, running the `exit_cmd` if given.
 
-Otherwise, `options` should be a list (or tuple) of dictionaries, one for each option. If only one option is available, a single dictionary can also be returned. This is how it could look:
-
+Otherwise, `options` should be a list (or tuple) of dictionaries, one for each option. If only one
+option is available, a single dictionary can also be returned. This is how it could look:
 
 ```python
 def node_test(caller, raw_string, **kwargs):
@@ -315,10 +353,10 @@ def node_test(caller, raw_string, **kwargs):
     text = "A goblin attacks you!"
 
     options = (
-	{"key": ("Attack", "a", "att"),
+ {"key": ("Attack", "a", "att"),
          "desc": "Strike the enemy with all your might",
          "goto": "node_attack"},
-	{"key": ("Defend", "d", "def"),
+ {"key": ("Defend", "d", "def"),
          "desc": "Hold back and defend yourself",
          "goto": (_defend, {"str": 10, "enemyname": "Goblin"})})
 
@@ -328,8 +366,7 @@ def node_test(caller, raw_string, **kwargs):
 
 This will produce a menu node looking like this:
 
-
-```
+```py
 A goblin attacks you!
 ________________________________
 
@@ -340,14 +377,19 @@ Defend: Hold back and defend yourself
 
 ##### option-key 'key'
 
-The option's `key` is what the user should enter in order to choose that option. If given as a tuple, the first string of that tuple will be what is shown on-screen while the rest are aliases for picking that option. In the above example, the user could enter "Attack" (or "attack", it's not case-sensitive), "a" or "att" in order to attack the goblin. Aliasing is useful for adding custom coloring to the choice. The first element of the aliasing tuple should then be the colored version, followed by a version without color - since otherwise the user would have to enter the color codes to select that choice.
+The option's `key` is what the user should enter in order to choose that option. If given as a
+tuple, the first string of that tuple will be what is shown on-screen while the rest are aliases for
+picking that option. In the above example, the user could enter "Attack" (or "attack", it's not
+case-sensitive), "a" or "att" in order to attack the goblin. Aliasing is useful for adding custom
+coloring to the choice. The first element of the aliasing tuple should then be the colored version,
+followed by a version without color - since otherwise the user would have to enter the color codes
+to select that choice.
 
-Note that the `key` is *optional*. If no key is given, it will instead automatically be replaced
+Note that the `key` is _optional_. If no key is given, it will instead automatically be replaced
 with a running number starting from `1`. If removing the `key` part of each option, the resulting
 menu node would look like this instead:
 
-
-```
+```py
 A goblin attacks you!
 ________________________________
 
@@ -358,7 +400,9 @@ ________________________________
 
 Whether you want to use a key or rely on numbers is mostly a matter of style and the type of menu.
 
-EvMenu accepts one important special `key` given only as `"_default"`. This key is used when a user enters something that does not match any other fixed keys. It is particularly useful for getting user input:
+EvMenu accepts one important special `key` given only as `"_default"`. This key is used when a user
+enters something that does not match any other fixed keys. It is particularly useful for getting
+user input:
 
 ```python
 def node_readuser(caller, raw_string, **kwargs):
@@ -374,15 +418,16 @@ def node_readuser(caller, raw_string, **kwargs):
 A `"_default"` option does not show up in the menu, so the above will just be a node saying
 `"Please enter your name"`. The name they entered will appear as `raw_string` in the next node.
 
-
 #### option-key 'desc'
 
-This simply contains the description as to what happens when selecting the menu option. For `"_default"` options or if the `key` is already long or descriptive, it is not strictly needed. But usually it's better to keep the `key` short and put more detail in `desc`.
-
+This simply contains the description as to what happens when selecting the menu option. For
+`"_default"` options or if the `key` is already long or descriptive, it is not strictly needed. But
+usually it's better to keep the `key` short and put more detail in `desc`.
 
 #### option-key 'goto'
 
-This is the operational part of the option and fires only when the user chooses said option. Here are three ways to write it
+This is the operational part of the option and fires only when the user chooses said option. Here
+are three ways to write it
 
 ```python
 
@@ -400,44 +445,65 @@ def node_select(caller, raw_string, **kwargs):
             "help - they all do different things ...")
 
     options = ({"desc": "Option one",
-		            "goto": "node_one"},
-	             {"desc": "Option two",
-		            "goto": _action_two},
-	             {"desc": "Option three",
-		            "goto": (_action_three, {"key": 1, "key2": 2})}
+              "goto": "node_one"},
+              {"desc": "Option two",
+              "goto": _action_two},
+              {"desc": "Option three",
+              "goto": (_action_three, {"key": 1, "key2": 2})}
               )
 
     return text, options
 
 ```
 
-As seen above, `goto` could just be pointing to a single `nodename` string - the name of the node to go to. When given like this, EvMenu will look for a node named like this and call its associated function as
+As seen above, `goto` could just be pointing to a single `nodename` string - the name of the node to
+go to. When given like this, EvMenu will look for a node named like this and call its associated
+function as
 
 ```python
     nodename(caller, raw_string, **kwargs)
 ```
 
-Here, `raw_string` is always the input the user entered to make that choice and `kwargs` are the same as those `kwargs` that already entered the *current* node (they are passed on).
+Here, `raw_string` is always the input the user entered to make that choice and `kwargs` are the
+same as those `kwargs` that already entered the _current_ node (they are passed on).
 
-Alternatively the `goto` could point to a "goto-callable". Such callables are usually defined in the same module as the menu nodes and given names starting with `_` (to avoid being parsed as nodes themselves). These callables will be called the same as a node function - `callable(caller, raw_string, **kwargs)`, where `raw_string` is what the user entered on this node and `**kwargs` is forwarded from the node's own input.
+Alternatively the `goto` could point to a "goto-callable". Such callables are usually defined in the
+same module as the menu nodes and given names starting with `_` (to avoid being parsed as nodes
+themselves). These callables will be called the same as a node function -
+`callable(caller, raw_string, **kwargs)`, where `raw_string` is what the user entered on this node
+and `**kwargs` is forwarded from the node's own input.
 
-The `goto` option key could also point to a tuple `(callable, kwargs)` - this allows for customizing the kwargs passed into the goto-callable, for example you could use the same callable but change the kwargs passed into it depending on which option was actually chosen.
+The `goto` option key could also point to a tuple `(callable, kwargs)` - this allows for customizing
+the kwargs passed into the goto-callable, for example you could use the same callable but change the
+kwargs passed into it depending on which option was actually chosen.
 
-The "goto callable" must either return a string `"nodename"` or a tuple `("nodename", mykwargs)`. This will lead to the next node being called as either `nodename(caller, raw_string, **kwargs)` or `nodename(caller, raw_string, **mykwargs)` - so this allows changing (or replacing) the options going into the next node depending on what option was chosen.
+The "goto callable" must either return a string `"nodename"` or a tuple `("nodename", mykwargs)`.
+This will lead to the next node being called as either `nodename(caller, raw_string, **kwargs)` or
+`nodename(caller, raw_string, **mykwargs)` - so this allows changing (or replacing) the options
+going into the next node depending on what option was chosen.
 
-There is one important case - if the goto-callable returns `None` for a `nodename`, *the current node will run again*, possibly with different kwargs. This makes it very easy to re-use a node over and over, for example allowing different options to update some text form being passed and manipulated for every iteration.
-
+There is one important case - if the goto-callable returns `None` for a `nodename`, _the current
+node will run again_, possibly with different kwargs. This makes it very easy to re-use a node over
+and over, for example allowing different options to update some text form being passed and
+manipulated for every iteration.
 
 ### Temporary storage
 
-When the menu starts, the EvMenu instance is stored on the caller as `caller.ndb._evmenu`. Through this object you can in principle reach the menu's internal state if you know what you are doing. This is also a good place to store temporary, more global variables that may be cumbersome to keep passing from node to node via the `**kwargs`. The `_evmnenu` will be deleted automatically when the menu closes, meaning you don't need to worry about cleaning anything up.
+When the menu starts, the EvMenu instance is stored on the caller as `caller.ndb._evmenu`. Through
+this object you can in principle reach the menu's internal state if you know what you are doing.
+This is also a good place to store temporary, more global variables that may be cumbersome to keep
+passing from node to node via the `**kwargs`. The `_evmenu` will be deleted automatically when the
+menu closes, meaning you don't need to worry about cleaning anything up.
 
-If you want *permanent* state storage, it's instead better to use an Attribute on `caller`. Remember that this will remain after the menu closes though, so you need to handle any needed cleanup yourself.
-
+If you want _permanent_ state storage, it's instead better to use an Attribute on `caller`. Remember
+that this will remain after the menu closes though, so you need to handle any needed cleanup
+yourself.
 
 ### Customizing Menu formatting
 
-The `EvMenu` display of nodes, options etc are controlled by a series of formatting methods on the `EvMenu` class. To customize these, simply create a new child class of `EvMenu` and override as needed. Here is an example:
+The `EvMenu` display of nodes, options etc are controlled by a series of formatting methods on the
+`EvMenu` class. To customize these, simply create a new child class of `EvMenu` and override as
+needed. Here is an example:
 
 ```python
 from evennia.utils.evmenu import EvMenu
@@ -497,27 +563,31 @@ class MyEvMenu(EvMenu):
         """
 
 ```
+
 See `evennia/utils/evmenu.py` for the details of their default implementations.
 
 ## EvMenu templating language
 
-In `evmenu.py` are two helper functions `parse_menu_template` and `template2menu` that is used to parse a _menu template_ string into an EvMenu:
+In `evmenu.py` are two helper functions `parse_menu_template` and `template2menu` that is used to
+parse a _menu template_ string into an EvMenu:
 
-    evmenu.template2menu(caller, menu_template, goto_callables)
+```py
+evmenu.template2menu(caller, menu_template, goto_callables)
+```
 
-One can also do it in two steps, by generate a menutree and using that to call
-EvMenu normally:
+One can also do it in two steps, by generating a menutree and using that to call EvMenu normally:
 
-    menutree = evmenu.parse_menu_template(caller, menu_template, goto_callables)
-    EvMenu(caller, menutree)
+```py
+menutree = evmenu.parse_menu_template(caller, menu_template, goto_callables)
+EvMenu(caller, menutree)
+```
 
-With this latter solution, one could mix and match normally created menu nodes
-with those generated by the template engine.
+With this latter solution, one could mix and match normally created menu nodes with those generated
+by the template engine.
 
-The `goto_callables` is a mapping `{"funcname": callable, ...}`, where each
-callable must be a module-global function on the form
-`funcname(caller, raw_string, **kwargs)` (like any goto-callable). The
-`menu_template` is a multi-line string on the following form:
+The `goto_callables` is a mapping `{"funcname": callable, ...}`, where each callable must be a
+module-global function on the form `funcname(caller, raw_string, **kwargs)` (like any
+goto-callable). The `menu_template` is a multi-line string on the following form:
 
 ```python
 menu_template = """
@@ -534,58 +604,67 @@ key3: desc3 -> node4
 """
 ```
 
-Each menu node is defined by a `## node <name>` containing the text of the node,
-followed by `## options` Also `## NODE` and `## OPTIONS` work. No python code
-logics is allowed in the template, this code is not evaluated but parsed. More
-advanced dynamic usage requires a full node-function.
+Each menu node is defined by a `## node <name>` containing the text of the node, followed by
+`## options` Also `## NODE` and `## OPTIONS` work. No python code logics is allowed in the template,
+this code is not evaluated but parsed. More advanced dynamic usage requires a full node-function.
 
-Except for defining the node/options, `#` act as comments - everything following
-will be ignored by the template parser.
+Except for defining the node/options, `#` act as comments - everything following will be ignored by
+the template parser.
 
 ### Template Options
 
 The option syntax is
 
-    <key>: [desc ->] nodename or function-call
+```text
+<key>: [desc ->] nodename or function-call
+```
 
-The 'desc' part is optional, and if that is not given, the `->` can be skipped
-too:
+The 'desc' part is optional, and if that is not given, the `->` can be skipped too:
 
+```text
     key: nodename
+```
 
 The key can both be strings and numbers. Separate the aliases with `;`.
 
-    key: node1
-    1: node2
-    key;k: node3
-    foobar;foo;bar;f;b: node4
+```text
+key: node1
+1: node2
+key;k: node3
+foobar;foo;bar;f;b: node4
+```
 
-Starting the key with the special letter `>` indicates that what follows is a
-glob/regex matcher.
+Starting the key with the special letter `>` indicates that what follows is a glob/regex matcher.
 
-    >: node1          - matches empty input
-    > foo*: node1     - everything starting with foo
-    > *foo: node3     - everything ending with foo
-    > [0-9]+?: node4  - regex (all numbers)
-    > *: node5        - catches everything else (put as last option)
+```text
+>: node1          - matches empty input
+> foo*: node1     - everything starting with foo
+> *foo: node3     - everything ending with foo
+> [0-9]+?: node4  - regex (all numbers)
+> *: node5        - catches everything else (put as last option)
+```
 
 Here's how to call a goto-function from an option:
 
-    key: desc -> myfunc(foo=bar)
+```text
+key: desc -> myfunc(foo=bar)
+```
 
-For this to work `template2menu` or `parse_menu_template` must be given a dict
-that includes `{"myfunc": _actual_myfunc_callable}`. All callables to be
-available in the template must be mapped this way. Goto callables act like
-normal EvMenu goto-callables and should have a callsign of
-`_actual_myfunc_callable(caller, raw_string, **kwargs)` and return the next node
-(passing dynamic kwargs into the next node does not work with the template
-- use the full EvMenu if you want advanced dynamic data passing).
+For this to work `template2menu` or `parse_menu_template` must be given a dict that includes
+`{"myfunc": _actual_myfunc_callable}`. All callables to be available in the template must be mapped
+this way. Goto callables act like normal EvMenu goto-callables and should have a callsign of
+`_actual_myfunc_callable(caller, raw_string, **kwargs)` and return the next node (passing dynamic
+kwargs into the next node does not work with the template
 
-Only no or named keywords are allowed in these callables. So
+-   use the full EvMenu if you want advanced dynamic data passing).
 
-    myfunc()         # OK
-    myfunc(foo=bar)  # OK
-    myfunc(foo)      # error!
+Only no or named keywords are allowed in these callables. So:
+
+```py
+myfunc()         # OK
+myfunc(foo=bar)  # OK
+myfunc(foo)      # error!
+```
 
 This is because these properties are passed as `**kwargs` into the goto callable.
 
@@ -651,9 +730,9 @@ evmenu.template2menu(caller, template_string, goto_callables)
 
 ## Asking for one-line input
 
-This describes two ways for asking for simple questions from the user. Using Python's `input`
-will *not* work in Evennia. `input` will *block* the entire server for *everyone* until that one
-player has entered their text, which is not what you want.
+This describes two ways for asking for simple questions from the user. Using Python's `input` will
+_not_ work in Evennia. `input` will _block_ the entire server for _everyone_ until that one player
+has entered their text, which is not what you want.
 
 ### The `yield` way
 
@@ -683,7 +762,7 @@ Using `yield` is simple and intuitive, but it will only access input from `self.
 cannot abort or time out the pause until the player has responded. Under the hood, it is actually
 just a wrapper calling `get_input` described in the following section.
 
-> Important Note: In Python you *cannot mix `yield` and `return <value>` in the same method*. It has
+> Important Note: In Python you _cannot mix `yield` and `return <value>` in the same method_. It has
 > to do with `yield` turning the method into a
 > [generator](https://www.learnpython.org/en/Generators). A `return` without an argument works, you
 > can just not do `return <value>`. This is usually not something you need to do in `func()` anyway,
@@ -703,7 +782,7 @@ get_input(caller, prompt, callback)
 
 Here `caller` is the entity that should receive the prompt for input given as `prompt`. The
 `callback` is a callable `function(caller, prompt, user_input)` that you define to handle the answer
-from the user. When run, the caller will see `prompt` appear on their screens and *any* text they
+from the user. When run, the caller will see `prompt` appear on their screens and _any_ text they
 enter will be sent into the callback for whatever processing you want.
 
 Below is a fully explained callback and example call:
@@ -735,23 +814,21 @@ get_input(caller, "Write something! ", callback)
 
 This will show as
 
-```
+```text
 Write something!
 > Hello
 When asked 'Write something!', you answered 'Hello'.
-
 ```
 
 Normally, the `get_input` function quits after any input, but as seen in the example docs, you could
 return True from the callback to repeat the prompt until you pass whatever check you want.
 
-> Note: You *cannot* link consecutive questions by putting a new `get_input` call inside the
-> callback If you want that you should use an EvMenu instead (see the [Repeating the same
-> node](./EvMenu.md#example-repeating-the-same-node) example above). Otherwise you can either peek at the
-> implementation of `get_input` and implement your own mechanism (it's just using cmdset nesting) or
-> you can look at [this extension suggested on the mailing
-> list](https://groups.google.com/forum/#!category-topic/evennia/evennia-questions/16pi0SfMO5U).
-
+> Note: You _cannot_ link consecutive questions by putting a new `get_input` call inside the
+> callback If you want that you should use an EvMenu instead (see the
+> [Repeating the same node](./EvMenu.md#example-repeating-the-same-node) example above). Otherwise
+> you can either peek at the implementation of `get_input` and implement your own mechanism (it's
+> just using cmdset nesting) or you can look at
+> [this extension suggested on the mailing list](https://groups.google.com/forum/#!category-topic/evennia/evennia-questions/16pi0SfMO5U).
 
 #### Example: Yes/No prompt
 
@@ -766,8 +843,8 @@ def yesno(caller, prompt, result):
         # will quit after this
     else:
         # the answer is not on the right yes/no form
-        caller.msg("Please answer Yes or No. \n{prompt}")
-@        # returning True will make sure the prompt state is not exited
+        caller.msg(f"Please answer Yes or No. \n{prompt}")
+        # returning True will make sure the prompt state is not exited
         return True
 
 # ask the question
@@ -779,14 +856,13 @@ get_input(caller, "Is Evennia great (Yes/No)?", yesno)
 The `evennia.utils.evmenu.list_node` is an advanced decorator for use with `EvMenu` node functions.
 It is used to quickly create menus for manipulating large numbers of items.
 
-
-```
+```text
 text here
 ______________________________________________
 
 1. option1     7. option7      13. option13
 2. option2     8. option8      14. option14
-3. option3     9. option9      [p]revius page
+3. option3     9. option9      [p]revious page
 4. option4    10. option10      page 2
 5. option5    11. option11     [n]ext page
 6. option6    12. option12
@@ -794,8 +870,7 @@ ______________________________________________
 ```
 
 The menu will automatically create an multi-page option listing that one can flip through. One can
-inpect each entry and then select them with prev/next. This is how it is used:
-
+inspect each entry and then select them with prev/next. This is how it is used:
 
 ```python
 from evennia.utils.evmenu import list_node
@@ -803,10 +878,10 @@ from evennia.utils.evmenu import list_node
 
 ...
 
-_options(caller):
+def _options(caller):
     return ['option1', 'option2', ... 'option100']
 
-_select(caller, menuchoice, available_choices):
+def _select(caller, menuchoice, available_choices):
     # analyze choice
     return "next_node"
 
@@ -833,9 +908,10 @@ auto-created by the `list_node` decorator.
 
 ## Example Menus
 
-Here is a diagram to help visualize the flow of data from node to node, including goto-callables in-between: 
+Here is a diagram to help visualize the flow of data from node to node, including goto-callables
+in-between:
 
-```
+```text
         ┌─
         │  def nodeA(caller, raw_string, **kwargs):
         │      text = "Choose how to operate on 2 and 3."
@@ -887,30 +963,36 @@ callable│                                          │                        
         └─
 ```
 
-Above we create a very simple/stupid menu (in the `EvMenu` call at the end) where we map the node identifier `"node_A"` to the Python function `nodeA` and `"node_B"` to the function `nodeB`. 
+Above we create a very simple/stupid menu (in the `EvMenu` call at the end) where we map the node
+identifier `"node_A"` to the Python function `nodeA` and `"node_B"` to the function `nodeB`.
 
-We start the menu in `"node_A"` where we get three options A, B and C.  Options A and B will route via a a goto-callable `_callback` that either multiples or adds the numbers 2 and 3 together before continuing to `"node_B"`. Option C routes directly to `"node_B"`, passing the number 5. 
+We start the menu in `"node_A"` where we get three options A, B and C. Options A and B will route
+via a a goto-callable `_callback` that either multiples or adds the numbers 2 and 3 together before
+continuing to `"node_B"`. Option C routes directly to `"node_B"`, passing the number 5.
 
-In every step, we pass a dict which becomes the ingoing `**kwargs` in the next step. If we didn't pass anything (it's optional), the next step's `**kwargs` would just be empty.
+In every step, we pass a dict which becomes the ingoing `**kwargs` in the next step. If we didn't
+pass anything (it's optional), the next step's `**kwargs` would just be empty.
 
 More examples:
 
-- **[Simple branching menu](./EvMenu.md#example-simple-branching-menu)** - choose from options
-- **[Dynamic goto](./EvMenu.md#example-dynamic-goto)** - jumping to different nodes based on response
-- **[Set caller properties](./EvMenu.md#example-set-caller-properties)** - a menu that changes things
-- **[Getting arbitrary input](./EvMenu.md#example-get-arbitrary-input)** - entering text
-- **[Storing data between nodes](./EvMenu.md#example-storing-data-between-nodes)** - keeping states and
-information while in the menu
-- **[Repeating the same node](./EvMenu.md#example-repeating-the-same-node)** - validating within the node
-before moving to the next
-- **[Yes/No prompt](#example-yesno-prompt)** - entering text with limited possible responses
-(this is *not* using EvMenu but the conceptually similar yet technically unrelated `get_input`
-helper function accessed as `evennia.utils.evmenu.get_input`).
-
+-   **[Simple branching menu](./EvMenu.md#example-simple-branching-menu)** - choose from options
+-   **[Dynamic goto](./EvMenu.md#example-dynamic-goto)** - jumping to different nodes based on
+    response
+-   **[Set caller properties](./EvMenu.md#example-set-caller-properties)** - a menu that changes
+    things
+-   **[Getting arbitrary input](./EvMenu.md#example-get-arbitrary-input)** - entering text
+-   **[Storing data between nodes](./EvMenu.md#example-storing-data-between-nodes)** - keeping
+    states and information while in the menu
+-   **[Repeating the same node](./EvMenu.md#example-repeating-the-same-node)** - validating within
+    the node before moving to the next
+-   **[Yes/No prompt](#example-yesno-prompt)** - entering text with limited possible responses (this
+    is _not_ using EvMenu but the conceptually similar yet technically unrelated `get_input` helper
+    function accessed as `evennia.utils.evmenu.get_input`).
 
 ### Example: Simple branching menu
 
-Below is an example of a simple branching menu node leading to different other nodes depending on choice:
+Below is an example of a simple branching menu node leading to different other nodes depending on
+choice:
 
 ```python
 # in mygame/world/mychargen.py
@@ -933,7 +1015,7 @@ EvMenu(caller, "world.mychargen", startnode="define_character")
 
 This will result in the following node display:
 
-```
+```text
 What aspect of your character do you want
 to change next?
 _________________________
@@ -961,25 +1043,25 @@ def _is_in_mage_guild(caller, raw_string, **kwargs):
     else:
         return "mage_guild_blocked"
 
-def enter_guild:
+def enter_guild():
     text = 'You say to the mage guard:'
-    options ({'desc': 'I need to get in there.',
+    options = ({'desc': 'I need to get in there.',
               'goto': _is_in_mage_guild},
              {'desc': 'Never mind',
               'goto': 'end_conversation'})
     return text, options
 ```
 
-This simple callable goto will analyse what happens depending on who the `caller` is.  The
+This simple callable goto will analyse what happens depending on who the `caller` is. The
 `enter_guild` node will give you a choice of what to say to the guard. If you try to enter, you will
-end up in different nodes depending on (in this example) if you have the right [Tag](./Tags.md) set on
-yourself or not. Note that since we don't include any 'key's in the option dictionary, you will just
-get to pick between numbers.
+end up in different nodes depending on (in this example) if you have the right [Tag](./Tags.md) set
+on yourself or not. Note that since we don't include any 'key's in the option dictionary, you will
+just get to pick between numbers.
 
 ### Example: Set caller properties
 
-Here is an example of passing arguments into the `goto` callable and use that to influence
-which node it should go to next:
+Here is an example of passing arguments into the `goto` callable and use that to influence which
+node it should go to next:
 
 ```python
 
@@ -989,7 +1071,7 @@ def _set_attribute(caller, raw_string, **kwargs):
     attrname, value = kwargs.get("attr", (None, None))
     next_node = kwargs.get("next_node")
 
-    caller.attributes.add(attrname, attrvalue)
+    caller.attributes.add(attrname, value)
 
     return next_node
 
@@ -1004,17 +1086,17 @@ def node_background(caller):
     options = ({"key": "death",
                 "desc": "A violent death in the family",
                 "goto": (_set_attribute, {"attr": ("experienced_violence", True),
-					  "next_node": "node_violent_background"})},
+       "next_node": "node_violent_background"})},
                {"key": "betrayal",
                 "desc": "The betrayal of a trusted grown-up",
                 "goto": (_set_attribute, {"attr": ("experienced_betrayal", True),
-					  "next_node": "node_betrayal_background"})})
+       "next_node": "node_betrayal_background"})})
     return text, options
 ```
 
 This will give the following output:
 
-```
+```text
 Kovash the magnificent experienced a traumatic event
 in their childhood. What was it?
 ____________________________________________________
@@ -1027,7 +1109,6 @@ Note above how we use the `_set_attribute` helper function to set the attribute 
 User's choice. In thie case the helper function doesn't know anything about what node called it - we
 even tell it which nodename it should return, so the choices leads to different paths in the menu.
 We could also imagine the helper function analyzing what other choices
-
 
 ### Example: Get arbitrary input
 
@@ -1048,8 +1129,8 @@ def _set_name(caller, raw_string, **kwargs):
             caller.msg(f"Set name to {prev_entry}.")
             return "node_background"
         else:
-	    caller.msg("Aborted.")
-	    return "node_exit"
+     caller.msg("Aborted.")
+     return "node_exit"
     else:
         # re-run old node, but pass in the name given
         return None, {"prev_entry": inp}
@@ -1061,12 +1142,12 @@ def enter_name(caller, raw_string, **kwargs):
     prev_entry = kwargs.get("prev_entry")
 
     if prev_entry:
-	text = "Current name: {}.\nEnter another name or <return> to accept."
+     text = f"Current name: {prev_entry}.\nEnter another name or <return> to accept."
     else:
-	text = "Enter your character's name or <return> to abort."
+        text = "Enter your character's name or <return> to abort."
 
-    options = {"key": "_default",
-               "goto": (_set_name, {"prev_entry": prev_entry})}
+        options = {"key": "_default",
+                "goto": (_set_name, {"prev_entry": prev_entry})}
 
     return text, options
 
@@ -1074,7 +1155,7 @@ def enter_name(caller, raw_string, **kwargs):
 
 This will display as
 
-```
+```text
 Enter your character's name or <return> to abort.
 
 > Gandalf
@@ -1094,8 +1175,6 @@ name we have entered before. This allows us to react correctly on an "empty" inp
 node named `"node_background"` if we accept the input or go to an exit node if we presses Return
 without entering anything. By returning `None` from the helper function we automatically re-run the
 previous node, but updating its ingoing kwargs to tell it to display a different text.
-
-
 
 ### Example: Storing data between nodes
 
@@ -1123,45 +1202,46 @@ def node_set_name(caller):
 
 
 def node_view_sheet(caller):
-    text = f"Character sheet:\n {self.ndb._evmenu.charactersheet}"
+    text = f"Character sheet:\n {caller.ndb._evmenu.charactersheet}"
 
-    options = ({"key": "Accept",
-                "goto": "finish_chargen"},
-	       {"key": "Decline",
-                "goto": "start_over"})
+    options = (
+        {"key": "Accept",
+         "goto": "finish_chargen"},
+        {"key": "Decline",
+         "goto": "start_over"}
+    )
 
     return text, options
 
 ```
 
-Instead of passing the character sheet along from node to node through the `kwargs` we instead
-set it up temporarily on `caller.ndb._evmenu.charactersheet`. This makes it easy to reach from
-all nodes. At the end we look at it and, if we accept the character the menu will likely save the
-result to permanent storage and exit.
+Instead of passing the character sheet along from node to node through the `kwargs` we instead set
+it up temporarily on `caller.ndb._evmenu.charactersheet`. This makes it easy to reach from all
+nodes. At the end we look at it and, if we accept the character the menu will likely save the result
+to permanent storage and exit.
 
 > One point to remember though is that storage on `caller.ndb._evmenu` is not persistent across
-> `@reloads`. If you are using a persistent menu (using `EvMenu(..., persistent=True)` you should
-use
-> `caller.db` to store in-menu data like this as well. You must then yourself make sure to clean it
-> when the user exits the menu.
-
+> `@reloads`. If you are using a persistent menu (using `EvMenu(..., persistent=True)`) you should
+> use `caller.db` to store in-menu data like this as well. You must then yourself make sure to clean
+> it when the user exits the menu.
 
 ### Example: Repeating the same node
 
-Sometimes you want to make a chain of menu nodes one after another, but you don't want the user to be able to continue to the next node until you have verified that what they input in the previous node is ok. A common example is a login menu:
-
+Sometimes you want to make a chain of menu nodes one after another, but you don't want the user to
+be able to continue to the next node until you have verified that what they input in the previous
+node is ok. A common example is a login menu:
 
 ```python
 
 def _check_username(caller, raw_string, **kwargs):
     # we assume lookup_username() exists
     if not lookup_username(raw_string):
-	# re-run current node by returning `None`
-	caller.msg("|rUsername not found. Try again.")
-	return None
+        # re-run current node by returning `None`
+        caller.msg("|rUsername not found. Try again.")
+        return None
     else:
-	# username ok - continue to next node
-	return "node_password"
+        # username ok - continue to next node
+        return "node_password"
 
 
 def node_username(caller):
@@ -1175,27 +1255,25 @@ def _check_password(caller, raw_string, **kwargs):
 
     nattempts = kwargs.get("nattempts", 0)
     if nattempts > 3:
-	caller.msg("Too many failed attempts. Logging out")
-	return "node_abort"
+        caller.msg("Too many failed attempts. Logging out")
+        return "node_abort"
     elif not validate_password(raw_string):
         caller.msg("Password error. Try again.")
-	return None, {"nattempts", nattempts + 1}
-    else:
-	# password accepted
-	return "node_login"
+     return None, {"nattempts": nattempts + 1}
+
+    return "node_login"
 
 def node_password(caller, raw_string, **kwargs):
     text = "Enter your password."
     options = {"key": "_default",
-	       "goto": _check_password}
+        "goto": _check_password}
     return text, options
 
 ```
 
 This will display something like
 
-
-```
+```text
 ---------------------------
 Please enter your username.
 ---------------------------
@@ -1227,7 +1305,6 @@ Here the goto-callables will return to the previous node if there is an error. I
 password attempts, this will tick up the `nattempts` argument that will get passed on from iteration
 to iteration until too many attempts have been made.
 
-
 ### Defining nodes in a dictionary
 
 You can also define your nodes directly in a dictionary to feed into the `EvMenu` creator.
@@ -1255,17 +1332,18 @@ EvMenu(caller, menu_data, startnode="node1")
 ```
 
 The keys of the dictionary become the node identifiers. You can use any callable on the right form
-to describe each node. If you use Python `lambda` expressions you can make nodes really on the fly.
+to describe each node. If you use Python `lambda` expressions, you can make nodes really on the fly.
 If you do, the lambda expression must accept one or two arguments and always return a tuple with two
 elements (the text of the node and its options), same as any menu node function.
 
 Creating menus like this is one way to present a menu that changes with the circumstances - you
 could for example remove or add nodes before launching the menu depending on some criteria. The
-drawback is that a `lambda` expression [is much more
-limited](https://docs.python.org/2/tutorial/controlflow.html#lambda-expressions) than a full
-function - for example you can't use other Python keywords like `if` inside the body of the
+drawback is that a `lambda` expression
+[is much more limited](https://docs.python.org/2/tutorial/controlflow.html#lambda-expressions) than
+a full function - for example you can't use other Python keywords like `if` inside the body of the
 `lambda`.
 
-Unless you are dealing with a relatively simple dynamic menu, defining menus with lambda's is
+Unless you are dealing with a relatively simple dynamic menu, defining menus with lambdas is
 probably more work than it's worth: You can create dynamic menus by instead making each node
-function more clever. See the [NPC shop tutorial](../Howtos/Tutorial-NPC-Merchants.md) for an example of this.
+function more clever. See the [NPC shop tutorial](../Howtos/Tutorial-NPC-Merchants.md) for an
+example of this.

--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -291,7 +291,6 @@ from evennia.utils.utils import (
     m_len,
     make_iter,
     mod_import,
-    pad,
     to_str,
 )
 
@@ -1161,13 +1160,21 @@ class EvMenu:
         Format the node's help text
 
         Args:
-            helptext (str): The unformatted help text for the node.
+            helptext (str or dict): The unformatted help text for the node.
+                If a dictionary, it's a mapping of help topics to help text.
 
         Returns:
-            helptext (str): The formatted help text.
+            helptext (str or dict): The formatted help text. If dictionary input,
+                returns a dictionary with formatted values.
 
         """
-        return dedent(helptext.strip("\n"), baseline_index=0).rstrip()
+        if isinstance(helptext, dict):
+            return {
+                key.strip().lower(): dedent(text.strip(), baseline_index=0).rstrip() 
+                for key, text in helptext.items()
+            }
+
+        return dedent(helptext.strip(), baseline_index=0).rstrip()
 
     def options_formatter(self, optionlist):
         """


### PR DESCRIPTION
- Updated the `format_helptext` method to accept both string and dictionary types for help text.
- If a dictionary is provided, it formats each entry, allowing for multiple help topics.
- Improved documentation to reflect the new behavior and return types.

#### Brief overview of PR changes/additions
This pull request includes changes to the `evennia/utils/evmenu.py` file to improve the formatting of help text and to clean up unused imports. The most important changes are:

Improvements to help text formatting:

* [`evennia/utils/evmenu.py`](diffhunk://#diff-f9b279f2f9f771cce3d22ee7348f2e015321ff9c2656609401e0816f308aced6L1164-R1177): Modified `helptext_formatter` to accept both strings and dictionaries as input, formatting the help text accordingly. This allows for more flexible and structured help text management.

Codebase cleanup:

* [`evennia/utils/evmenu.py`](diffhunk://#diff-f9b279f2f9f771cce3d22ee7348f2e015321ff9c2656609401e0816f308aced6L294): Removed the unused import `pad` to clean up the code.

#### Other info (issues closed, discussion etc)
Resolves #3755 