### PR TITLE
Add exclusions and line-length for ruff lint support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,3 +170,20 @@ omit = [
   "*.pyc",
   "*.service",
 ]
+
+[tool.ruff]
+exclude = [
+  "/.eggs/",
+  "/.git/",
+  "/.hg/",
+  "/.mypy_cache/",
+  "/.tox/",
+  "/.venv/",
+  "/_build/",
+  "/buck-out/",
+  "/build/",
+  "/dist/",
+  "migrations",
+  "docs",
+]
+line-length = 100


### PR DESCRIPTION
Updates to the `pyproject.toml` file to configure the `ruff` tool for linting and code formatting. The changes mirror current `black` tool configuration.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R173-R189): Added `ruff` tool configuration, including exclusions for directories such as `/.eggs/`, `/.git/`, `/.tox/`, and others, and set the line length to 100 characters.

#### Other info (issues closed, discussion etc)
Resolves #3782 