### PR TITLE
Add evennia launcher to scripts for uv installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,10 @@ extra = [
 "Issue tracker" = "https://github.com/evennia/evennia/issues"
 "Patreon" = "https://www.patreon.com/griatch"
 
+[project.scripts]
+evennia = "evennia.server.evennia_launcher:main"
+
+
 [tool.black]
 line-length = 100
 target-version = ['py310', 'py311']


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Recently I've started playing around with [uv](https://docs.astral.sh/uv/), a dependency management system for python that's written in Rust and has a few neat features, such as support [running scripts with inline dependencies](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) as detailed [here](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata), originally from PEP0723. The first real snag I ran into with installing with uv is Evennia's setup process on python wouldn't run. From what I gathered, there's a specification where `uv` and other tools use a section of the pyproject.toml and will generate an executable in Windows based on it, largely replacing the old batch file that was generated. Near as I can tell, this seems to work just fine so far, though it's possible there could be issues I'm missing. At least for local dev uv seems shockingly fast, but I haven't set up any full deployment workflows with it yet, so I'm unsure if I'll hit any roadblocks.

#### Motivation for adding to Evennia

Allows for installing Evennia using `uv` by adding Evennia to a project's pyproject.toml and generating a windows binary executable.

#### Other info (issues closed, discussion etc)
I apologize if I'm totally out of the loop and this is a duplicate of an existing issue. I didn't see anything with a quick glance, though.
