### PR TITLE
fix django version check

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -1313,7 +1313,6 @@ def check_main_evennia_dependencies():
             return False
         else:
             django_version = ".".join(str(num) for num in django.VERSION if isinstance(num, int))
-            # only the main version (1.5, not 1.5.4.0)
             django_version = ".".join(django_version.split("."))
             django_curr = LooseVersion(django_version)
             django_min = LooseVersion(DJANGO_MIN)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

django_curr == 5.2 due to truncation
django_min == 5.2.0

django_curr < django_min apparently succeeds. fix by leaving full version intact.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)

closes https://github.com/evennia/evennia/issues/3796