### PR TITLE
Update HAProxy Config Docs

### DIFF
--- a/docs/source/Setup/Config-HAProxy.md
+++ b/docs/source/Setup/Config-HAProxy.md
@@ -157,6 +157,8 @@ We use the `my.awesomegame.com` example here and here are the ports
 - `4001` is the standard Evennia webserver port (firewall closed!)
 - `4002` is the default Evennia websocket port (we use the same number for
   the outgoing wss port, so this should be open in firewall).
+- `4000` is the default Telnet port for Evennia, and we proxy through HAProxy
+  so `7000` can used for Secure Telnet connections instead.
 
 ```shell
 # base stuff to set up haproxy
@@ -183,6 +185,14 @@ listen evennia-https-website
 listen evennia-secure-websocket
     bind my.awesomegame.com:4002 ssl no-sslv3 no-tlsv10 crt /etc/letsencrypt/live/my.awesomegame.com/my.awesomegame.com.pem
     server localhost 127.0.0.1:4002
+    timeout client 10m
+    timeout server 10m
+    timeout connect 5m
+
+listen evennia-secure-telnet
+    bind my.awesomegame.com:7000 ssl no-sslv3 no-tlsv10 crt /etc/letsencrypt/live/my.awesomegame.com/my.awesomegame.com.pem
+    server localhost 127.0.0.1:4000
+    mode tcp
     timeout client 10m
     timeout server 10m
     timeout connect 5m


### PR DESCRIPTION
Add config example for HAProxy on how to proxy telnet through it, so secure telnet with SSL can be used instead of just regular telnet.

#### Brief overview of PR changes/additions

Just changed the HAProxy examples in the documentation to include SSL Telnet as well.

#### Motivation for adding to Evennia

This was not something that was covered for HAProxy at all- Only NGINX. I had to do some research on it and I figured it would be a nice to have since it's a question I've seen asked before a few times (and people were just directed to nginx, which is fine), but I feel like having a HAProxy example is also helpful.

#### Other info (issues closed, discussion etc)
