### PR TITLE
fix(admin): repair Link to Account button (pk→object_id mismatch)

### DIFF
--- a/evennia/web/admin/objects.py
+++ b/evennia/web/admin/objects.py
@@ -287,7 +287,7 @@ class ObjectAdmin(admin.ModelAdmin):
         urls = super().get_urls()
         custom_urls = [
             path(
-                "account-object-link/<int:pk>",
+                "account-object-link/<int:object_id>",
                 self.admin_site.admin_view(self.link_object_to_account),
                 name="object-account-link",
             )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
*Fixes the Django admin “Link to Account” button for Characters/Objects.
*URL pattern previously passed _<int:pk>_ while the view expected _object_id_, causing a TypeError

#### Motivation for adding to Evennia
* On Evennia 5.0.1 + Django 5.2.5 the button is currently broken and throws a 500 error.
* This prevents linking a Character to an Account via the admin UI.
* The patch restores expected behavior: clicking the button sets _last_puppet, adds the Character to the Account, and updates puppet locks.

#### Other info (issues closed, discussion etc)
* Closes #3808 
* Regression introduced in commit b76c5d2 (Feb 2022, Django 4 migration) when   `url()` was replaced with `path()`, switching from `object_id` to `pk` without  updating the view signature. Maintainer may  prefer to resolve the mismatch by updating the  view signature instead.
* Verified fix locally on clean evennia install with Debian Trixie, Python 3.13.5, Django 5.2.5.