### PR TITLE
website: fix login banner showing before any attempt (fixes #3810)

### DIFF
--- a/evennia/web/templates/website/registration/login.html
+++ b/evennia/web/templates/website/registration/login.html
@@ -16,7 +16,7 @@
           {% if user.is_authenticated %}
           <div class="alert alert-info" role="alert">You are already logged in!</div>
           {% else %}
-            {% if form.errors %}
+            {% if form.is_bound and form.non_field_errors %}
             <div class="alert alert-danger" role="alert">Your username and password are incorrect. Please try again.</div>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Fix login page template to avoid showing the "Your username and password are incorrect" banner on initial GET requests.
- Change banner condition from `{% if form.errors %}` to `{% if form.is_bound and form.non_field_errors %}`.
- Preserves the original banner text.

#### Motivation for adding to Evennia
Currently, users see an error banner before they have attempted to log in, which is confusing. This change makes the login page behave as expected: the banner only appears after a failed login attempt.

#### Other info (issues closed, discussion etc)
Closes #3810


This PR takes the minimal-change approach by keeping the existing static error text.  An alternative would be to render `{{ form.non_field_errors|striptags }}`, which would display the actual message generated by Django’s `AuthenticationForm`. That has the advantage of relying directly on Django’s own validation messages (e.g. if wording changes upstream); but might cause disruption to existing evennia installs if any over-rides depend on the current wording.
