### PR TITLE
Implement "cache buster"

### DIFF
--- a/evennia/web/templates/webclient/base.html
+++ b/evennia/web/templates/webclient/base.html
@@ -6,7 +6,7 @@ with evennia set up automatically and get the Evennia JS lib and
 JQuery available.
 -->
 
-{% load static %}
+{% load static cachebuster %}
 <html dir="ltr" lang="en">
   <head>
     <title> {{game_name}} </title>
@@ -17,13 +17,13 @@ JQuery available.
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-    <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/webclient.css" %}>
+    <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/webclient.css" as webclient_css %}{{ webclient_css|cachebust }}>
 
     {% comment %}
     Allows for loading custom styles without overriding the base site stylesheet
     {% endcomment %}
     <!-- Custom CSS -->
-    <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/custom.css" %}>
+    <link rel='stylesheet' type="text/css" media="screen" href={% static "webclient/css/custom.css" as custom_css %}{{ custom_css|cachebust }}>
 
     <link rel="icon" type="image/x-icon" href="/static/website/images/evennia_logo.png" />
 
@@ -76,7 +76,7 @@ JQuery available.
             var wsurl = "ws://" + this.location.hostname + ":{{websocket_port}}";
         {% endif %}
     </script>
-    <script src={% static "webclient/js/evennia.js" %} language="javascript" type="text/javascript" charset="utf-8"/></script>
+    <script src={% static "webclient/js/evennia.js" as webclient_js %}{{ webclient_js|cachebust }} language="javascript" type="text/javascript" charset="utf-8"/></script>
 
     <!-- set up splits before loading the GUI -->
 <!--

--- a/evennia/web/templates/website/base.html
+++ b/evennia/web/templates/website/base.html
@@ -1,4 +1,4 @@
-{% load static sekizai_tags %}
+{% load static sekizai_tags cachebuster %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -16,13 +16,13 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
 
     <!-- Base CSS -->
-    <link rel="stylesheet" type="text/css" href="{% static "website/css/website.css" %}">
+    <link rel="stylesheet" type="text/css" href="{% static "website/css/website.css" as css_url %}{{ css_url|cachebust }}">
 
     {% comment %}
     Allows for loading custom styles without overriding the base site styles
     {% endcomment %}
     <!-- Custom CSS -->
-    <link rel="stylesheet" type="text/css" href="{% static "website/css/custom.css" %}">
+    <link rel="stylesheet" type="text/css" href="{% static "website/css/custom.css" as custom_css %}{{ custom_css|cachebust }}">
 
     {% block header_ext %}
     {% endblock %}

--- a/evennia/web/templatetags/cachebuster.py
+++ b/evennia/web/templatetags/cachebuster.py
@@ -1,0 +1,16 @@
+from django import template
+from django.conf import settings
+from django.contrib.staticfiles import finders
+
+register = template.Library()
+
+@register.filter
+def cachebust(value, digest_size=5):
+    filepath = finders.find(value.removeprefix(settings.STATIC_URL))
+    if not filepath:
+        return value
+    
+    with open(filepath, "rb") as f:
+        import hashlib
+        filehash = hashlib.shake_256(f.read()).hexdigest(digest_size)
+        return f"{value}?{filehash}"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a new templatetag filter that adds a short query string to the end of static file paths. This is a common "cache-busting" technique to force browsers to redownload particular files if they've been updated, rather than waiting for the files to be cleared from the browser's cache on their own.

#### Motivation for adding to Evennia

Feature request: #3775

#### Other info (issues closed, discussion etc)

My original implementation linked in the feature request *works*, but uses the file's mtime, which is generally less desirable than a contents hash as it forces the file to be re-downloaded even if it's the same just by virtue of it being saved again. It also requires hard-coding the specific file paths into the context, which isn't great! This method is more widely and easily reusable.
