### PR TITLE
Improve performance on larger cmdsets

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -32,7 +32,6 @@ from collections import defaultdict
 from copy import copy
 from itertools import chain
 from traceback import format_exc
-from weakref import WeakValueDictionary
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -49,7 +48,7 @@ _IN_GAME_ERRORS = settings.IN_GAME_ERRORS
 
 __all__ = ("cmdhandler", "InterruptCommand")
 _GA = object.__getattribute__
-_CMDSET_MERGE_CACHE = WeakValueDictionary()
+_CMDSET_MERGE_CACHE = {}
 
 # tracks recursive calls by each caller
 # to avoid infinite loops (commands calling themselves)

--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -248,7 +248,8 @@ class CmdSet(object, metaclass=_CmdSetMeta):
         if cmdset_a.duplicates and cmdset_a.priority == cmdset_b.priority:
             cmdset_c.commands.extend(cmdset_b.commands)
         else:
-            cmdset_c.commands.extend([cmd for cmd in cmdset_b if cmd not in cmdset_a])
+            existing_commands = set(cmdset_a.commands)
+            cmdset_c.commands.extend([cmd for cmd in cmdset_b if cmd not in existing_commands])
         return cmdset_c
 
     def _intersect(self, cmdset_a, cmdset_b):


### PR DESCRIPTION
Don't store cmdset cache as weakrefs to avoid GC hits.

#### Brief overview of PR changes/additions

I don't think WeakValueDictionary is a good choice here for the cmdset cache, as it's the result of a merge of all the cmdsets on a character, location and objects within. As such, the only reference to the object will be this weakref (it doesn't exist as a merged cmdset on the character as it is unique to the location), and it will get immediatley garbage collected.

Second, comparing the presence of a command in a set is more performant than a list, and is a noticeable improvement over the same action in a list.

#### Motivation for adding to Evennia

Performance for worlds with a high number of Commands and CmdSets

#### Other info (issues closed, discussion etc)
