### PR TITLE
Update spawn hook to use `new_prototype`

### DIFF
--- a/evennia/prototypes/spawner.py
+++ b/evennia/prototypes/spawner.py
@@ -804,7 +804,7 @@ def batch_update_objects_with_prototype(
             changed += 1
             obj.save()
             if spawn_hook := getattr(obj, "at_object_post_spawn", None):
-                spawn_hook(prototype=prototype)
+                spawn_hook(prototype=new_prototype)
 
     return changed
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The initial implementation of the `at_object_post_spawn` hook erroneously used the `prototype` variable in the spawn-update logic, which could be a prototype key rather than the prototype itself, resulting in an unexpected input of a string. This corrects that to `new_prototype` which should be guaranteed to contain the actual homogenized prototype dict.

#### Motivation for adding to Evennia
Resolving edge-case issues.