### PR TITLE
Fix error when creating object with None key

### DIFF
--- a/evennia/objects/manager.py
+++ b/evennia/objects/manager.py
@@ -685,6 +685,11 @@ class ObjectDBManager(TypedObjectManager):
                     "or the setting is malformed."
                 )
 
+        # db_key has NOT NULL constraint, convert None to empty string.
+        # at_first_save() will convert empty string to #dbref
+        if key is None:
+            key = ""
+
         # create new instance
         new_object = typeclass(
             db_key=key,

--- a/evennia/objects/tests.py
+++ b/evennia/objects/tests.py
@@ -244,6 +244,20 @@ class DefaultObjectTest(BaseEvenniaTest):
 class TestObjectManager(BaseEvenniaTest):
     "Test object manager methods"
 
+    def test_create_object_with_none_key(self):
+        """Test that create_object() handles key=None and key="" correctly."""
+        # Test with key=None - should convert to "" and then to #dbref
+        obj_none = ObjectDB.objects.create_object(key=None, location=self.room1)
+        self.assertIsNotNone(obj_none)
+        self.assertEqual(obj_none.key, f"#{obj_none.id}")
+        obj_none.delete()
+
+        # Test with key="" - should convert to #dbref
+        obj_empty = ObjectDB.objects.create_object(key="", location=self.room1)
+        self.assertIsNotNone(obj_empty)
+        self.assertEqual(obj_empty.key, f"#{obj_empty.id}")
+        obj_empty.delete()
+
     def test_get_object_with_account(self):
         query = ObjectDB.objects.get_object_with_account("TestAccount").first()
         self.assertEqual(query, self.char1)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Added None-to-empty-string conversion for `key` parameter in `create_object()` to fix database error and enable proper #dbref default naming.

#### Motivation for adding to Evennia

Fixes bug where create_object(key=None) causes error:
`django.db.utils.IntegrityError: null value in column "db_key" of relation "objects_objectdb" violates not-null constraint`

The class documentation indicates the object should still be created with a "#dbref" name.

#### Other info (issues closed, discussion etc)
Fixes #3822

I don't believe this to be a documentation issue moreso than a bug as an empty string `""` does actually work as described, changing the object name to `#dbref`.

Additionally, propagating None all the way to the database layer to only then find out you can't do that is probably not intentional. 