### PR TITLE
docs: clarify Windows py launcher usage during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ with [discussion forums][group] and a [discord server][chat] to help and support
 
     pip install evennia
         (windows users once: py -m evennia)
+        (note: Windows users with multiple Python versions should prefer `py -3.11` instead of `python` when creating virtual environments)
     evennia --init mygame
     cd mygame
     evennia migrate


### PR DESCRIPTION
This PR adds a small clarification to the Windows installation notes in the README.

Some Windows users have multiple Python versions installed, and using `py -3.11` is the recommended approach for creating virtual environments to ensure the correct interpreter is used. This addition does not change functionality, but improves clarity for new users following the installation steps.
