### PR TITLE
Fix distutils error for new Python3.12+ projects, Fix Django versioning

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -20,7 +20,7 @@ import shutil
 import signal
 import sys
 from argparse import ArgumentParser
-from distutils.version import LooseVersion
+from packaging.version import Version
 from subprocess import STDOUT, CalledProcessError, Popen, call, check_output
 
 import django
@@ -1265,9 +1265,9 @@ def check_main_evennia_dependencies():
     def _test_python_version():
         """Test Python version"""
         python_version = ".".join(str(num) for num in sys.version_info if isinstance(num, int))
-        python_curr = LooseVersion(python_version)
-        python_min = LooseVersion(PYTHON_MIN)
-        python_max = LooseVersion(PYTHON_MAX_TESTED)
+        python_curr = Version(python_version)
+        python_min = Version(PYTHON_MIN)
+        python_max = Version(PYTHON_MAX_TESTED)
 
         if python_curr < python_min:
             print(ERROR_PYTHON_VERSION.format(python_version=python_version, python_min=PYTHON_MIN))
@@ -1291,8 +1291,8 @@ def check_main_evennia_dependencies():
             return False
         else:
             twisted_version = twisted.version.short()
-            twisted_curr = LooseVersion(twisted_version)
-            twisted_min = LooseVersion(TWISTED_MIN)
+            twisted_curr = Version(twisted_version)
+            twisted_min = Version(TWISTED_MIN)
 
             if twisted_curr < twisted_min:
                 print(
@@ -1313,11 +1313,9 @@ def check_main_evennia_dependencies():
             return False
         else:
             django_version = ".".join(str(num) for num in django.VERSION if isinstance(num, int))
-            # only the main version (1.5, not 1.5.4.0)
-            django_version = ".".join(django_version.split(".")[:2])
-            django_curr = LooseVersion(django_version)
-            django_min = LooseVersion(DJANGO_MIN)
-            django_max = LooseVersion(DJANGO_MAX_TESTED)
+            django_curr = Version(django_version)
+            django_min = Version(DJANGO_MIN)
+            django_max = Version(DJANGO_MAX_TESTED)
 
             if django_curr < django_min:
                 print(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes #3851 - distutils was deprecated in 3.10 and removed in 3.12, the replacement for `distutils.LooseVersion` is `packaging.Version`.  `packaging` is also in 3.11 so backwards compatible change.  

Fixes #3844 - Warning that Django version is not high enough when it actually is.

This removes the code that stripped the user Django version to just major.minor, i.e. from "5.2.8" to "5.2".  
I think it's slightly cleaner to treat that as "read-only" from the user and adjust DJANGO_MIN if necessary.   

#### Other info (issues closed, discussion etc)
Closes #3851
Closes #3844
