### PR TITLE
Normalize CRLF to LF

### DIFF
--- a/evennia/utils/batchprocessors.py
+++ b/evennia/utils/batchprocessors.py
@@ -235,6 +235,9 @@ def read_batchfile(pythonpath, file_ending=".py"):
     if not text and decoderr:
         raise UnicodeDecodeError("\n".join(decoderr), bytearray(), 0, 0, "")
 
+    if text:
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+
     return text
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes #3847 - CRLF breaks batch code #INSERT

Normalizes the batchcode input to change windows CRLF to just LF, or singular \r to \n. 

#### Other info (issues closed, discussion etc)
Close #3847 