### PR TITLE
Add alias "look at" to look command.

### DIFF
--- a/evennia/commands/default/general.py
+++ b/evennia/commands/default/general.py
@@ -69,7 +69,7 @@ class CmdLook(COMMAND_DEFAULT_CLASS):
     """
 
     key = "look"
-    aliases = ["l", "ls"]
+    aliases = ["l", "ls", "look at"]
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added alias to look command of "look at"

#### Motivation for adding to Evennia
Motivation for doing this is twofold.  I have years of playing a mud where the command "look at" was required to look at something.  I am constantly correcting my own usage of "look at" to "look" on two different MUDs now, one of which I am not a developer on.

#### Other info (issues closed, discussion etc)
