### PR TITLE
xyzgrid: Return Dijkstra solution

### DIFF
--- a/evennia/contrib/grid/xyzgrid/xymap.py
+++ b/evennia/contrib/grid/xyzgrid/xymap.py
@@ -624,6 +624,7 @@ class XYMap:
                 # we can re-use the stored data!
                 self.dist_matrix = dist_matrix
                 self.pathfinding_routes = pathfinding_routes
+                return
 
         # build a matrix representing the map graph, with 0s as impassable areas
 


### PR DESCRIPTION
When loading the Dijkstra solution, results are stored but recalculated anyway. This should be returned instead.
