### PR TITLE
nit: Remove 'None' print in LogObserver

### DIFF
--- a/evennia/utils/logger.py
+++ b/evennia/utils/logger.py
@@ -281,6 +281,8 @@ class GetLogObserver:
         log_msg = twisted_logger.formatEventAsClassicLogText(
             event, formatTime=lambda e: twisted_logger.formatTime(e, _TIME_FORMAT)
         )
+        if log_msg is None:
+            return None
         return f"{component_prefix}{log_msg}"
 
     def __call__(self, outfile):


### PR DESCRIPTION
Fixes:

```
2026-02-15 17:57:06 [..] Initial setup: Gathering static resources using 'collectstatic'
None2026-02-15 17:57:06 [..] 0 static files copied to '/home/jake/evennia/aystra/server/.static', 212 unmodified.
2026-02-15 17:57:06 [..] Initial setup complete. Restarting Server once.
2026-02-15 17:57:06 [..] Evennia Server successfully started.
|Portal| 2026-02-15 17:57:07 [..] Portal starting server ... 
```