### PR TITLE
Fix #3716: Guard Discord member nick access and fall back to author name

### DIFF
--- a/evennia/server/portal/discord.py
+++ b/evennia/server/portal/discord.py
@@ -534,10 +534,17 @@ class DiscordClient(WebSocketClientProtocol, _BASE_SESSION_CLASS):
             if "guild_id" in data:
                 # message received to a Discord channel
                 keywords["type"] = "channel"
-                author = data["member"]["nick"] or data["author"]["username"]
-                author_id = data["author"]["id"]
+                member = data.get("member", {}) or {}
+                author_info = data.get("author", {}) or {}
+                # Prefer guild nickname; fall back to global_name, then username
+                author = (
+                    member.get("nick")
+                    or author_info.get("global_name")
+                    or author_info.get("username")
+                )
+                author_id = author_info.get("id") or data["author"]["id"]
                 keywords["sender"] = (author_id, author)
-                keywords["guild_id"] = data["guild_id"]
+                keywords["guild_id"] = data.get("guild_id")
 
             else:
                 # message sent directly to the bot account via DM


### PR DESCRIPTION
Fix #3716: Discord missing member.nick in certain events can raise KeyError

Summary
- Safely access Discord payload nick, guarding for missing member and missing nick.
- Fallbacks: author.global_name, then author.username.
- Prevents KeyError crashes when data.member or data.member.nick is absent (e.g., DMs or gateway variants).

Changes
- evennia/server/portal/discord.py: Wrap member nick extraction; compute a sender name with sensible fallbacks.

Reproduction
1. Send a Discord message where the payload lacks data.member or data.member.nick (e.g., DM or certain gateway events).
2. Prior behavior: portal raised KeyError on ['member']['nick'].
3. After patch: no exception; sender resolves to author.global_name or author.username.

Tests
- Targeted unit test will be added to validate DiscordClient.data_in() name resolution across payload shapes. Submitting as a draft PR to leverage CI while tests are finalized.

Compliance
- One-issue-per-branch; base=main.
- Black 100; minimal diff.
