### PR TITLE
Fixes multimatch numbering display to be case insensitive

### DIFF
--- a/evennia/utils/tests/test_utils.py
+++ b/evennia/utils/tests/test_utils.py
@@ -891,6 +891,17 @@ More than one match for 'obj' (please narrow target):
  obj2-2"""
         caller.msg.assert_called_once_with(multimatch_msg)
 
+    def test_mixed_case_multimatch(self):
+        """multiple matches with different case should increment index by case-insensitive name"""
+        matches = [self.MockObject("obj1"), self.MockObject("Obj1")]
+        caller = mock.MagicMock()
+        self.assertIsNone(utils.at_search_result(matches, caller, "obj1"))
+        multimatch_msg = """\
+More than one match for 'obj1' (please narrow target):
+ obj1-1
+ Obj1-2"""
+        caller.msg.assert_called_once_with(multimatch_msg)
+
 
 class TestGroupObjectsByKeyAndDesc(TestCase):
     """

--- a/evennia/utils/utils.py
+++ b/evennia/utils/utils.py
@@ -2422,13 +2422,14 @@ def at_search_result(matches, caller, query="", quiet=False, **kwargs):
         # group results by display name to properly disambiguate
         grouped_matches = defaultdict(list)
         for item in matches:
-            group_key = (
+            item_key = (
                 item.get_display_name(caller) if hasattr(item, "get_display_name") else query
             )
-            grouped_matches[group_key].append(item)
+            # the actual searching is case-insensitive, so we force grouping keys to lower
+            grouped_matches[item_key.lower()].append( (item_key, item) )
 
         for key, match_list in grouped_matches.items():
-            for num, result in enumerate(match_list):
+            for num, (result_key, result) in enumerate(match_list):
                 # we need to consider that result could be a Command, where .aliases
                 # is a list of strings
                 if hasattr(result.aliases, "all"):
@@ -2444,7 +2445,7 @@ def at_search_result(matches, caller, query="", quiet=False, **kwargs):
 
                 error += _MULTIMATCH_TEMPLATE.format(
                     number=num + 1,
-                    name=key,
+                    name=result_key,
                     aliases=" [{alias}]".format(alias=";".join(aliases)) if aliases else "",
                     info=result.get_extra_info(caller),
                 )


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Modifies the core `at_search_result` handling to ensure matches are grouped by lowercase variants of the name, to match the case-insensitive groupings of the actual search function. Includes a new unit test to prevent regression.

#### Other info (issues closed, discussion etc)
Closes #3876