### PR TITLE
Telnet - _HTTP_REGEX gets bytes flag. Fixes disconnect on multiline input.

### DIFF
--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -44,7 +44,7 @@ _IDLE_COMMAND = str.encode(settings.IDLE_COMMAND + "\n")
 
 # identify HTTP indata
 _HTTP_REGEX = re.compile(
-    r"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
+    rb"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
 )
 
 _HTTP_WARNING = bytes(


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds the `b` flag to `_HTTP_REGEX` at the top of `evennia/server/portal/telnet.py`.

#### Motivation for adding to Evennia

Fixes a bug where the regex's use on line 334 of the same file throws an exception about not being able to work on a bytes object into the portal log and disconnects the user upon receiving incoming data with one or more linebreaks in it.

#### Other info (issues closed, discussion etc)

It's such a small fix I didn't make an issue for it.