### PR TITLE
postgresql: Formally support postgresql

### DIFF
--- a/docs/source/Setup/Choosing-a-Database.md
+++ b/docs/source/Setup/Choosing-a-Database.md
@@ -51,8 +51,7 @@ If you want to reset your SQLite3 database, see [here](./Updating-Evennia.md#sql
 
 First, install the posgresql server. Version `9.6` is tested with Evennia. Packages are readily available for all distributions. You need to also get the `psql` client (this is called `postgresql- client` on debian-derived systems). Windows/Mac users can [find what they need on the postgresql download page](https://www.postgresql.org/download/). You should be setting up a password for your database-superuser (always called `postgres`) when you install. 
 
-For interaction with Evennia you need to also install `psycopg2` to your Evennia install 
-(`pip install psycopg2-binary` in your virtualenv). This acts as the python bridge to the database server.
+For interaction with Evennia you need to also install `psycopg` (psycopg3) to your Evennia install (`pip install psycopg[binary]` in your virtualenv). This acts as the python bridge to the database server.
 
 Next, start the postgres client:
 
@@ -102,7 +101,7 @@ Edit `mygame/server/conf/secret_settings.py` and add the following section:
 #
 DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'evennia',
             'USER': 'evennia',
             'PASSWORD': 'somepassword',

--- a/evennia/server/deprecations.py
+++ b/evennia/server/deprecations.py
@@ -179,9 +179,9 @@ def check_warnings(settings):
         )
 
     for dbentry in settings.DATABASES.values():
-        if "psycopg" in dbentry.get("ENGINE", ""):
+        if "psycopg2" in dbentry.get("ENGINE", ""):
             print(
-                'Deprecation: postgresql_psycopg2 backend is deprecated". '
+                "Deprecation: postgresql_psycopg2 backend is deprecated. "
                 "Switch settings.DATABASES to use "
-                '"ENGINE": "django.db.backends.postgresql instead"'
+                '"ENGINE": "django.db.backends.postgresql" instead.'
             )

--- a/evennia/server/initial_setup.py
+++ b/evennia/server/initial_setup.py
@@ -38,14 +38,6 @@ play the demo game.
 )
 
 
-WARNING_POSTGRESQL_FIX = """
-    PostgreSQL-psycopg2 compatibility fix:
-    The in-game channels {chan1}, {chan2} and {chan3} were created,
-    but the superuser was not yet connected to them. Please use in
-    game commands to connect Account #1 to those channels when first
-    logging in.
-"""
-
 
 def _get_superuser_account():
     """

--- a/evennia/typeclasses/migrations/0010_delete_old_player_tables.py
+++ b/evennia/typeclasses/migrations/0010_delete_old_player_tables.py
@@ -27,7 +27,7 @@ def _drop_table(db_cursor, table_name):
             db_cursor.execute("SET FOREIGN_KEY_CHECKS=0;")
             db_cursor.execute("DROP TABLE {table};".format(table=table_name))
             db_cursor.execute("SET FOREIGN_KEY_CHECKS=1;")
-        elif _ENGINE == "postgresql":
+        elif _ENGINE == "django.db.backends.postgresql":
             db_cursor.execute("ALTER TABLE {table} DISABLE TRIGGER ALL;".format(table=table_name))
             db_cursor.execute("DROP TABLE {table};".format(table=table_name))
             db_cursor.execute("ALTER TABLE {table} ENABLE TRIGGER ALL;".format(table=table_name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ extra = [
 
   # Git contrib
   "gitpython >= 3.1.27",
+
+  # PostgreSQL support
+  "psycopg[binary] >= 3.1.12",
 ]
 
 [project.urls]


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Updated PostgreSQL docs to recommend `psycopg[binary]` instead of `psycopg2-binary` and use `django.db.backends.postgresql`
- Added `psycopg[binary]>=3.1.12` to `[extra]` optional dependencies in `pyproject.toml`
- Fixed bug in `0010_delete_old_player_tables.py` where the PostgreSQL check compared against `postgresql` instead of the full path
- Removed unused warning from initial_setup
- Fixed deprecation warning typo

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
No unit tests exist for the migrations.

Closes #3802