### PR TITLE
fix: close stale DB connections before first query

### DIFF
--- a/evennia/server/service.py
+++ b/evennia/server/service.py
@@ -9,6 +9,7 @@ import traceback
 
 import django
 from django.conf import settings
+import django.db
 from django.db import connection
 from django.db.utils import OperationalError
 from django.utils.translation import gettext as _
@@ -187,6 +188,10 @@ class EvenniaServerService(MultiService):
 
         # clear server startup mode
         try:
+            # Close stale DB connections inherited from the pre-fork parent
+            # process. Python 3.14's sqlite3 module is not fork-safe and will
+            # raise MemoryError if a pre-fork connection is reused.
+            django.db.connections.close_all()
             evennia.ServerConfig.objects.conf("server_starting_mode", delete=True)
         except OperationalError:
             print("Server server_starting_mode couldn't unset - db not set up.")


### PR DESCRIPTION
When twisted daemonizes via fork, the child process inherits SQLite connections from the parent. Python 3.14's sqlite3 module is not fork-safe and raises MemoryError when these inherited connections are reused.

Closes #3887 
