### PR TITLE
fix: pass caller to purge_processor in CmdStateCC cc command

### DIFF
--- a/evennia/commands/default/batchprocess.py
+++ b/evennia/commands/default/batchprocess.py
@@ -662,7 +662,7 @@ class CmdStateCC(_COMMAND_DEFAULT_CLASS):
             step_pointer(caller, 1)
             show_curr(caller)
 
-        purge_processor(self)
+        purge_processor(caller)
         caller.msg(format_code("Finished processing batch file."))
 
 


### PR DESCRIPTION
## Bug
[#3891](https://github.com/evennia/evennia/issues/3891) — Running `cc` (continue-to-end) in the interactive batch processor raises `AttributeError: 'CmdStateCC' object has no attribute 'ndb'`.

## Cause
`CmdStateCC.func()` passes `self` (the command instance) to `purge_processor()` instead of `caller`. The function expects an object with `.ndb` attributes (the caller/account object), not the command itself.

Every other call site passes `caller` or `self.caller`:
- Line 283: `purge_processor(caller)`
- Line 376: `purge_processor(caller)`
- Line 400: `purge_processor(self.caller)`
- Line 731: `purge_processor(self.caller)`

Line 665 was the only one passing `self`.

## Fix
Change `purge_processor(self)` → `purge_processor(caller)` to match the local variable already used throughout the method.

## Testing
Reproduced per the issue steps (`batchcmd/i tutorial_world.build` then `cc`). The AttributeError no longer occurs and the batch processor purges correctly.

Happy to address any feedback.

Greetings, saschabuehrle