### PR TITLE
Fix @teleport showing double error message on failed search

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3856,13 +3856,18 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
         self.obj_to_teleport = self.caller
         self.destination = None
         if self.rhs:
-            self.obj_to_teleport = self.caller.search(self.lhs, global_search=True)
+            self.obj_to_teleport = self.caller.search(self.lhs, global_search=True, quiet=True)
             if not self.obj_to_teleport:
                 self.msg("Did not find object to teleport.")
                 raise InterruptCommand
-            self.destination = self.caller.search(self.rhs, global_search=True)
+            self.obj_to_teleport = self.obj_to_teleport[0]
+            self.destination = self.caller.search(self.rhs, global_search=True, quiet=True)
+            if self.destination:
+                self.destination = self.destination[0]
         elif self.lhs:
-            self.destination = self.caller.search(self.lhs, global_search=True)
+            self.destination = self.caller.search(self.lhs, global_search=True, quiet=True)
+            if self.destination:
+                self.destination = self.destination[0]
 
     def func(self):
         """Performs the teleport"""

--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3856,18 +3856,13 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
         self.obj_to_teleport = self.caller
         self.destination = None
         if self.rhs:
-            self.obj_to_teleport = self.caller.search(self.lhs, global_search=True, quiet=True)
+            self.obj_to_teleport = self.caller.search(self.lhs, global_search=True)
             if not self.obj_to_teleport:
                 self.msg("Did not find object to teleport.")
                 raise InterruptCommand
-            self.obj_to_teleport = self.obj_to_teleport[0]
-            self.destination = self.caller.search(self.rhs, global_search=True, quiet=True)
-            if self.destination:
-                self.destination = self.destination[0]
+            self.destination = self.caller.search(self.rhs, global_search=True)
         elif self.lhs:
-            self.destination = self.caller.search(self.lhs, global_search=True, quiet=True)
-            if self.destination:
-                self.destination = self.destination[0]
+            self.destination = self.caller.search(self.lhs, global_search=True)
 
     def func(self):
         """Performs the teleport"""
@@ -3902,7 +3897,7 @@ class CmdTeleport(COMMAND_DEFAULT_CLASS):
             return
 
         if not destination:
-            caller.msg("Destination not found.")
+            # Search already reported the error to the caller in parse().
             return
 
         if "loc" in self.switches:

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -1695,7 +1695,7 @@ class TestBuilding(BaseEvenniaCommandTest):
         self.call(
             building.CmdTeleport(),
             "Obj = NotFound",
-            "Could not find 'NotFound'.|Destination not found.",
+            "Could not find 'NotFound'.",
         )
         self.call(
             building.CmdTeleport(),


### PR DESCRIPTION
#### Brief overview of PR changes/additions

CmdTeleport.parse() called caller.search() without quiet=True, so a failed search would show Evennia's default "Could not find X" message. Then func() would show a second "Destination not found." message.

Now uses quiet=True and extracts [0] from the results list, giving a single clean error message from func().

#### Motivation for adding to Evennia

No double error message

#### Other info (issues closed, discussion etc)
