### PR TITLE
Fix TypeError in MSDP encode when args contain non-string values

### DIFF
--- a/evennia/server/portal/telnet_oob.py
+++ b/evennia/server/portal/telnet_oob.py
@@ -183,7 +183,7 @@ class TelnetOOB:
         if args:
             msdp_args = msdp_cmdname
             if len(args) == 1:
-                msdp_args += args[0]
+                msdp_args += str(args[0])
             else:
                 msdp_args += (
                     "{msdp_array_open}"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Wraps args[0] in str() before string concatenation in encode_msdp. Without this, MSDP clients sending numeric values cause a TypeError on the += operation.

#### Motivation for adding to Evennia

Avoids a crash when MDSP clients send numeric values

#### Other info (issues closed, discussion etc)
