### PR TITLE
Fix telnet disconnect when multiple commands arrive in one packet

### DIFF
--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -44,7 +44,7 @@ _IDLE_COMMAND = str.encode(settings.IDLE_COMMAND + "\n")
 
 # identify HTTP indata
 _HTTP_REGEX = re.compile(
-    r"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
+    rb"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
 )
 
 _HTTP_WARNING = bytes(


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The HTTP detection regex in applicationDataReceived uses a string pattern (r"...") but the data it matches against is bytes. When 3+ commands arrive in a single TCP packet (e.g. rapid input or semicolon-separated commands from a MUD client), the data splits into 3+ parts, triggering the len(data) > 2 guard. The subsequent _HTTP_REGEX.match(data[0]) then crashes with:

    TypeError: cannot use a string pattern on a bytes-like object

This unhandled exception kills the telnet connection.

Fix: change the regex from a string pattern (r"...") to a bytes pattern (rb"...") to match the bytes data it receives.

#### Motivation for adding to Evennia

Fix a crash bug

#### Other info (issues closed, discussion etc)
