### PR TITLE
Fix TypeError in telnet HTTP detection regex

### DIFF
--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -44,7 +44,7 @@ _IDLE_COMMAND = str.encode(settings.IDLE_COMMAND + "\n")
 
 # identify HTTP indata
 _HTTP_REGEX = re.compile(
-    r"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
+    rb"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
 )
 
 _HTTP_WARNING = bytes(


### PR DESCRIPTION
## Summary

- `_HTTP_REGEX` uses a string pattern (`r"..."`) but `applicationDataReceived` passes bytes data from `_RE_LINEBREAK.split()`, causing `TypeError: cannot use a string pattern on a bytes-like object` when a scanner/bot sends an HTTP request to the telnet port
- Fix restores the bytes prefix (`rb"..."`) that was present in earlier versions

## Steps to reproduce

1. Start Evennia with telnet port exposed
2. Send an HTTP request to the telnet port (e.g. `curl http://localhost:4000`)
3. Portal crashes with `TypeError` at `telnet.py:334`

## Test plan

- [ ] Verify telnet connections still work normally
- [ ] Verify HTTP requests to telnet port are rejected gracefully instead of crashing the portal