### PR TITLE
Fix system commands duplicated in merged CmdSets

### DIFF
--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -243,13 +243,17 @@ class CmdSet(object, metaclass=_CmdSetMeta):
 
         """
         cmdset_c = cmdset_a._duplicate()
-        # we make copies, not refs by use of [:]
-        cmdset_c.commands = cmdset_a.commands[:]
+        # Exclude system commands; __add__ re-adds them after merging.
+        cmdset_c.commands = [c for c in cmdset_a.commands if not c.key.startswith("__")]
         if cmdset_a.duplicates and cmdset_a.priority == cmdset_b.priority:
-            cmdset_c.commands.extend(cmdset_b.commands)
+            cmdset_c.commands.extend(
+                [c for c in cmdset_b.commands if not c.key.startswith("__")]
+            )
         else:
             existing_commands = set(cmdset_a.commands)
-            cmdset_c.commands.extend([cmd for cmd in cmdset_b if cmd not in existing_commands])
+            cmdset_c.commands.extend(
+                [cmd for cmd in cmdset_b if cmd not in existing_commands and not cmd.key.startswith("__")]
+            )
         return cmdset_c
 
     def _intersect(self, cmdset_a, cmdset_b):
@@ -295,7 +299,8 @@ class CmdSet(object, metaclass=_CmdSetMeta):
 
         """
         cmdset_c = cmdset_a._duplicate()
-        cmdset_c.commands = cmdset_a.commands[:]
+        # Exclude system commands; __add__ re-adds them after merging.
+        cmdset_c.commands = [c for c in cmdset_a.commands if not c.key.startswith("__")]
         return cmdset_c
 
     def _remove(self, cmdset_a, cmdset_b):

--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -243,17 +243,13 @@ class CmdSet(object, metaclass=_CmdSetMeta):
 
         """
         cmdset_c = cmdset_a._duplicate()
-        # Exclude system commands; __add__ re-adds them after merging.
-        cmdset_c.commands = [c for c in cmdset_a.commands if not c.key.startswith("__")]
+        # we make copies, not refs by use of [:]
+        cmdset_c.commands = cmdset_a.commands[:]
         if cmdset_a.duplicates and cmdset_a.priority == cmdset_b.priority:
-            cmdset_c.commands.extend(
-                [c for c in cmdset_b.commands if not c.key.startswith("__")]
-            )
+            cmdset_c.commands.extend(cmdset_b.commands)
         else:
             existing_commands = set(cmdset_a.commands)
-            cmdset_c.commands.extend(
-                [cmd for cmd in cmdset_b if cmd not in existing_commands and not cmd.key.startswith("__")]
-            )
+            cmdset_c.commands.extend([cmd for cmd in cmdset_b if cmd not in existing_commands])
         return cmdset_c
 
     def _intersect(self, cmdset_a, cmdset_b):
@@ -299,8 +295,7 @@ class CmdSet(object, metaclass=_CmdSetMeta):
 
         """
         cmdset_c = cmdset_a._duplicate()
-        # Exclude system commands; __add__ re-adds them after merging.
-        cmdset_c.commands = [c for c in cmdset_a.commands if not c.key.startswith("__")]
+        cmdset_c.commands = cmdset_a.commands[:]
         return cmdset_c
 
     def _remove(self, cmdset_a, cmdset_b):
@@ -493,7 +488,11 @@ class CmdSet(object, metaclass=_CmdSetMeta):
         # print "__add__ for %s (prio %i)  called with %s (prio %i)." % (self.key, self.priority,
         # cmdset_a.key, cmdset_a.priority)
 
-        # return the system commands to the cmdset
+        # Re-add the merged system commands. First strip any that were carried
+        # through via the raw commands[:] copy in the merge methods, so they
+        # don't appear twice.
+        sys_set = set(sys_commands)
+        cmdset_c.commands = [c for c in cmdset_c.commands if c not in sys_set]
         cmdset_c.add(sys_commands, allow_duplicates=True)
         return cmdset_c
 

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -172,6 +172,45 @@ class TestCmdSetMergers(TestCase):
         self.assertEqual(sum(1 for cmd in cmdset_f.commands if cmd.from_cmdset == "A"), 2)
         self.assertEqual(sum(1 for cmd in cmdset_f.commands if cmd.from_cmdset == "C"), 0)
 
+    def test_system_cmds_not_duplicated_after_replace(self):
+        """System commands must appear exactly once after a Replace merge."""
+        a, c = self.cmdset_a, self.cmdset_c
+
+        class _SysCmd(_BaseCmd):
+            key = "__sys"
+
+        sys_cmd = _SysCmd("A")
+        a.add(sys_cmd)
+
+        c.mergetype = "Replace"
+        c.priority = 1
+        cmdset_f = c + a  # c higher prio, Replace kicks in
+
+        sys_cmds_in_commands = [cmd for cmd in cmdset_f.commands if cmd.key.startswith("__")]
+        self.assertEqual(len(sys_cmds_in_commands), 1)
+
+    def test_system_cmds_not_duplicated_after_union(self):
+        """System commands must appear exactly once after a Union merge, from either side."""
+        a, c = self.cmdset_a, self.cmdset_c
+
+        class _SysCmd(_BaseCmd):
+            key = "__sys"
+
+        # System command on the higher-priority side (cmdset_a)
+        a.add(_SysCmd("A"))
+        a.priority = 1
+        cmdset_f = a + c
+        sys_in_commands = [cmd for cmd in cmdset_f.commands if cmd.key.startswith("__")]
+        self.assertEqual(len(sys_in_commands), 1)
+
+        # System command on the lower-priority side (cmdset_c)
+        a2, c2 = self.cmdset_a, _CmdSetC()
+        c2.add(_SysCmd("C"))
+        a2.priority = 1
+        cmdset_f2 = a2 + c2
+        sys_in_commands2 = [cmd for cmd in cmdset_f2.commands if cmd.key.startswith("__")]
+        self.assertEqual(len(sys_in_commands2), 1)
+
     def test_order(self):
         "Merge in reverse- and forward orders, same priorities"
         a, b, c, d = self.cmdset_a, self.cmdset_b, self.cmdset_c, self.cmdset_d


### PR DESCRIPTION
I was encountering an issue with EvMore where the pager would consistently wind up having duplicates of all of its commands. After a bunch of poking around I determined this is because CmdSets merge was picking up system commands from multiple locations and duplicating them. 

First commit worked but I didn't like that it was using a string compare so I refactored it to a more elegant fix. 

---

## Problem

When a CmdSet using `mergetype = "Replace"` or `"Union"` is merged onto another set that contains system commands (keys starting with `__`), those system commands appear twice in the result. The most visible symptom is with EvMore: after the pager is displayed, any input produces:

```
More than one match for 'q' (please narrow target):
 q-1 [n;end;a;next;p;abort;previous;quit;t;top;q;e]
 q-2 [n;end;a;next;p;abort;previous;quit;t;top;q;e]
```

## Root cause

`_replace` and `_union` both copy `cmdset_a.commands[:]` verbatim into `cmdset_c.commands`. Because `CmdSet.add()` appends system commands to both `self.commands` and `self.system_commands`, that raw slice includes them. `CmdSet.__add__` then unconditionally calls `cmdset_c.add(sys_commands, allow_duplicates=True)` to re-add the correctly-merged system commands so they end up in `cmdset_c.commands` twice. `cmdparser.build_matches` then finds two identical matches and reports the ambiguity error.

`_intersect` and `_remove` build their results differently and are not affected.

## Fix

Rather than filtering in each merge method, the deduplication is applied in `__add__` at the exact point of re-adding. Strip any system commands already present in `cmdset_c.commands` before calling `add(sys_commands, allow_duplicates=True)`. This uses `Command.__eq__`/`__hash__` rather than string prefix matching, keeps the merge methods untouched, and automatically covers any future merge type.

## Tests

Added two regression tests to `TestCmdSetMergers` covering system command deduplication after both Replace and Union merges, with system commands present on either side.