### PR TITLE
Funcparser fix

### DIFF
--- a/evennia/server/portal/telnet.py
+++ b/evennia/server/portal/telnet.py
@@ -44,7 +44,7 @@ _IDLE_COMMAND = str.encode(settings.IDLE_COMMAND + "\n")
 
 # identify HTTP indata
 _HTTP_REGEX = re.compile(
-    r"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
+    rb"(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH) (.*? HTTP/[0-9]\.[0-9])", re.I
 )
 
 _HTTP_WARNING = bytes(
@@ -330,8 +330,10 @@ class TelnetProtocol(Telnet, StatefulTelnetProtocol, _BASE_SESSION_CLASS):
             data = [_IDLE_COMMAND]
         else:
             data = _RE_LINEBREAK.split(data)
-
-            if len(data) > 2 and _HTTP_REGEX.match(data[0]):
+            # Normalize to bytes for regex match if needed.
+            if len(data) > 2 and _HTTP_REGEX.match(
+                data[0].encode("utf-8", errors="replace") if isinstance(data[0], str) else data[0]
+            ):
                 # guard against HTTP request on the Telnet port; we
                 # block and kill the connection.
                 self.transport.write(_HTTP_WARNING)

--- a/evennia/server/portal/tests.py
+++ b/evennia/server/portal/tests.py
@@ -237,6 +237,22 @@ class TestTelnet(TwistedTestCase):
         self.addCleanup(factory.sessionhandler.disconnect_all)
 
     @mock.patch("evennia.server.portal.portalsessionhandler.reactor", new=MagicMock())
+    def test_command_stacking_no_type_error(self):
+        self.transport.client = ["localhost"]
+        self.transport.setTcpKeepAlive = Mock()
+        d = self.proto.makeConnection(self.transport)
+        # Mudlet sends multiple commands in one packet when command stacking
+        data = b"wave\r\nsay hi\r\n"
+        try:
+            self.proto.dataReceived(data)
+        except TypeError:
+            self.fail("dataReceived raised TypeError on stacked commands")
+        # clean up to prevent Unclean reactor
+        self.proto.nop_keep_alive.stop()
+        self.proto._handshake_delay.cancel()
+        return d
+
+    @mock.patch("evennia.server.portal.portalsessionhandler.reactor", new=MagicMock())
     def test_mudlet_ttype(self):
         self.transport.client = ["localhost"]
         self.transport.setTcpKeepAlive = Mock()

--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -353,6 +353,15 @@ class FuncParser:
 
             if char == start_char:
                 # start a new function definition (not escaped as $$)
+                # peek ahead - if next char can't start a funcname, treat $ as literal
+                next_char = string[ichar + 1 : ichar + 2]
+                if next_char and not (next_char.isalpha() or next_char == "_"):
+                    # can't be a valid funcname, treat as literal
+                    if curr_func:
+                        infuncstr += char
+                    else:
+                        fullstr += char
+                    continue
 
                 if curr_func:
                     # we are starting a nested funcdef

--- a/evennia/utils/tests/test_funcparser.py
+++ b/evennia/utils/tests/test_funcparser.py
@@ -323,6 +323,14 @@ class TestFuncParser(TestCase):
         ret = self.parser.parse(string)
         self.assertEqual("The ('testing',){'bar': '$dum(b = \"test2\" , a)'} $pass(", ret)
 
+    def test_parse_malformed(self):
+        """
+        Test the parser ignoring non-funcs like $"x"
+        """
+        string = '$"x"'
+        ret = self.parser.parse(string)
+        self.assertEqual('$"x"', ret)
+
     def test_parse_escape(self):
         """
         Test the parser's escape functionality.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added test that $"x" gets parsed as a non-func
Added look-ahead in FuncParser.parse() to check viability of func

#### Motivation for adding to Evennia
Bug fix

#### Other info (issues closed, discussion etc)
Closes https://github.com/evennia/evennia/issues/3907

I don't think this is the best way, but it was the quick fix that worked for me. I do mildly wonder if regex would be better.