### PR TITLE
Fix funcparser treating $" as malformed function call

### DIFF
--- a/evennia/utils/funcparser.py
+++ b/evennia/utils/funcparser.py
@@ -352,8 +352,16 @@ class FuncParser:
                 continue
 
             if char == start_char:
+                # peek ahead - if next char can't start a funcname, treat $ as literal
+                next_char = string[ichar + 1 : ichar + 2]
+                if next_char and not (next_char.isalpha() or next_char == "_"):
+                    # can't be a valid funcname, treat as literal
+                    if curr_func:
+                        infuncstr += char
+                    else:
+                        fullstr += char
+                    continue
                 # start a new function definition (not escaped as $$)
-
                 if curr_func:
                     # we are starting a nested funcdef
                     if len(callstack) >= _MAX_NESTING - 1:

--- a/evennia/utils/tests/test_funcparser.py
+++ b/evennia/utils/tests/test_funcparser.py
@@ -323,6 +323,14 @@ class TestFuncParser(TestCase):
         ret = self.parser.parse(string)
         self.assertEqual("The ('testing',){'bar': '$dum(b = \"test2\" , a)'} $pass(", ret)
 
+    def test_parse_malformed(self):
+        """
+        Test the parser ignoring non-funcs like $"x"
+        """
+        string = '$"x"'
+        ret = self.parser.parse(string)
+        self.assertEqual('$"x"', ret)
+
     def test_parse_escape(self):
         """
         Test the parser's escape functionality.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added test that $"x" gets parsed as a non-func
Added look-ahead in FuncParser.parse() to check viability of func

#### Motivation for adding to Evennia
Bug fix

#### Other info (issues closed, discussion etc)
Closes https://github.com/evennia/evennia/issues/3907

I don't think this is the best way, but it was the quick fix that worked for me. I do mildly wonder if regex would be better.