### PR TITLE
Fix MXP parse to not escape surrounding text as HTML entities

### DIFF
--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -32,19 +32,48 @@ MXP_URL = MXP_TEMPSECURE + '<A HREF="\\1">' + "\\2" + MXP_TEMPSECURE + "</A>"
 
 def mxp_parse(text):
     """
-    Replaces links to the correct format for MXP.
+    Parse Evennia's MXP link markup into MXP escape sequences suitable for
+    sending to MXP-enabled clients.
+
+    Converts ``|lc<cmd>|lt<label>|le`` to a clickable SEND tag and
+    ``|lu<url>|lt<label>|le`` to a clickable URL tag. Non-MXP content
+    has ``&``, ``<``, and ``>`` HTML-escaped to prevent them from being
+    interpreted as MXP tags by the client.
+
+    Messages containing no MXP markup are returned unchanged.
 
     Args:
         text (str): The text to parse.
 
     Returns:
-        parsed (str): The parsed text.
+        str: The parsed text with MXP sequences substituted and non-MXP
+            angle brackets escaped, or the original text if no MXP markup
+            was found.
 
+    Examples:
+        ``|lchelp overview|lthelp overview|le`` becomes
+        ``\\x1b[4z<SEND HREF="help overview">help overview\\x1b[4z</SEND>``
     """
-    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-    text = LINKS_SUB.sub(MXP_SEND, text)
-    text = URL_SUB.sub(MXP_URL, text)
+    if "|lc" not in text and "|lu" not in text:
+        return text
+
+    def replace_with_escape(pattern, template, text):
+        result = ""
+        last = 0
+        found = False
+        for match in pattern.finditer(text):
+            found = True
+            result += text[last : match.start()]
+            result += template.replace("\\1", match.group(1)).replace("\\2", match.group(2))
+            last = match.end()
+        if not found:
+            return text
+        result += text[last:]
+        return result
+
+    text = replace_with_escape(LINKS_SUB, MXP_SEND, text)
+    text = replace_with_escape(URL_SUB, MXP_URL, text)
     return text
 
 

--- a/evennia/server/portal/tests.py
+++ b/evennia/server/portal/tests.py
@@ -290,6 +290,41 @@ class TestTelnet(TwistedTestCase):
         self.proto._handshake_delay.cancel()
         return d
 
+    def test_mxp_parse(self):
+        """
+        Test that mxp_parse correctly converts Evennia MXP markup to MXP escape sequences,
+        and leaves messages without MXP markup untouched.
+        """
+        from evennia.server.portal.mxp import mxp_parse, MXP_TEMPSECURE
+
+        # no MXP markup - should be returned unchanged
+        self.assertEqual(mxp_parse("hello world"), "hello world")
+
+        # angle brackets without MXP markup - should be returned unchanged
+        self.assertEqual(mxp_parse("<name>"), "<name>")
+
+        # basic link substitution
+        result = mxp_parse("|lchelp overview|lthelp overview|le")
+        self.assertIn('<SEND HREF="help overview">', result)
+        self.assertIn("help overview", result)
+        self.assertIn(MXP_TEMPSECURE, result)
+        self.assertNotIn("|lc", result)
+        self.assertNotIn("|lt", result)
+        self.assertNotIn("|le", result)
+
+        # surrounding text should pass through unchanged
+        result = mxp_parse("<|lchelp eat|lthelp eat|le>")
+        self.assertIn("<", result)
+        self.assertIn(">", result)
+        self.assertNotIn("&lt;", result)
+        self.assertNotIn("&gt;", result)
+        self.assertIn('<SEND HREF="help eat">', result)
+
+        # non-MXP ampersands should pass through unchanged
+        result = mxp_parse("fish & chips |lchelp eat|lthelp eat|le")
+        self.assertIn("fish & chips", result)
+        self.assertNotIn("&amp;", result)
+
 
 class TestWebSocket(BaseEvenniaTest):
     def setUp(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
THIS WAS A FUN ONE.

mxp_parse previously HTML-escaped all &, <, and > characters in non-MXP text portions of a message.

This caused literal angle brackets surrounding MXP tags (e.g. `<|lchelp eat|lthelp eat|le>`) to be sent to the client as `&lt;` and `&gt;` ~~(funny story, originally this PR said < and > instead of < and >, I'm sure you can guess how that happened)~~ instead of `<` and `>`, since MXP-enabled clients do not decode HTML entities outside of MXP tag contexts.

The fix removes the HTML escaping of non-MXP content entirely. MXP clients only process tags within \x1b[4z secure mode markers, so surrounding plain text is treated as literal text regardless of angle brackets.

A test is added to TestTelnet covering correct link substitution, passthrough of surrounding angle brackets, and the early-return path for messages containing no MXP markup.

#### Motivation for adding to Evennia
<img width="544" height="304" alt="image" src="https://github.com/user-attachments/assets/3bbc5cd4-42f4-449d-9dfe-e63770c48cf7" />
->
<img width="496" height="320" alt="image" src="https://github.com/user-attachments/assets/2d3c4a5c-b30f-45e3-9db7-bccf38f58ceb" />


#### Other info (issues closed, discussion etc)
Fixes https://github.com/evennia/evennia/issues/3860#issue-3898585173
