### PR TITLE
Fix/cmdset merge cache performance

### DIFF
--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -28,7 +28,7 @@ command line. The processing of a command works as follows:
 """
 
 import types
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from copy import copy
 from itertools import chain
 from traceback import format_exc
@@ -48,7 +48,37 @@ _IN_GAME_ERRORS = settings.IN_GAME_ERRORS
 
 __all__ = ("cmdhandler", "InterruptCommand")
 _GA = object.__getattribute__
-_CMDSET_MERGE_CACHE = {}
+_CMDSET_MERGE_CACHE = OrderedDict()
+_CMDSET_MERGE_CACHE_MAXSIZE = 1000
+
+
+def _cmdset_fingerprint(cmdset):
+    """
+    Build a hashable fingerprint from a cmdset's semantic content. Two cmdsets
+    with identical commands and merge properties will produce the same fingerprint,
+    regardless of Python object identity.
+
+    Args:
+        cmdset (CmdSet): The cmdset to fingerprint.
+
+    Returns:
+        tuple: A hashable fingerprint.
+
+    """
+    cmd_ids = tuple(sorted(tuple(sorted(cmd._matchset)) for cmd in cmdset.commands))
+    sys_cmd_ids = tuple(sorted(tuple(sorted(cmd._matchset)) for cmd in cmdset.system_commands))
+    return (
+        cmdset.key,
+        cmdset.priority,
+        cmdset.mergetype,
+        cmdset.duplicates,
+        cmdset.no_exits,
+        cmdset.no_objs,
+        cmdset.no_channels,
+        tuple(sorted(cmdset.key_mergetypes.items())) if cmdset.key_mergetypes else (),
+        cmd_ids,
+        sys_cmd_ids,
+    )
 
 # tracks recursive calls by each caller
 # to avoid infinite loops (commands calling themselves)
@@ -446,10 +476,12 @@ def get_and_merge_cmdsets(
             ]
 
         if cmdsets:
-            # faster to do tuple on list than to build tuple directly
-            mergehash = tuple([id(cmdset) for cmdset in cmdsets])
+            # build a content-based fingerprint so that semantically identical
+            # cmdset combinations hit the cache even if the Python objects differ
+            mergehash = tuple(_cmdset_fingerprint(cmdset) for cmdset in cmdsets)
             if mergehash in _CMDSET_MERGE_CACHE:
-                # cached merge exist; use that
+                # cached merge exists; move to end for LRU tracking
+                _CMDSET_MERGE_CACHE.move_to_end(mergehash)
                 cmdset = _CMDSET_MERGE_CACHE[mergehash]
             else:
                 # we group and merge all same-prio cmdsets separately (this avoids
@@ -473,8 +505,10 @@ def get_and_merge_cmdsets(
                     cmdset = yield cmdset + merging_cmdset
                 # store the original, ungrouped set for diagnosis
                 cmdset.merged_from = cmdsets
-                # cache
+                # cache with LRU eviction
                 _CMDSET_MERGE_CACHE[mergehash] = cmdset
+                if len(_CMDSET_MERGE_CACHE) > _CMDSET_MERGE_CACHE_MAXSIZE:
+                    _CMDSET_MERGE_CACHE.popitem(last=False)
         else:
             cmdset = None
         for cset in (cset for cset in local_obj_cmdsets if cset):

--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -51,8 +51,6 @@ _GA = object.__getattribute__
 _CMDSET_MERGE_CACHE = OrderedDict()
 _CMDSET_MERGE_CACHE_MAXSIZE = 1000
 
-
-
 # tracks recursive calls by each caller
 # to avoid infinite loops (commands calling themselves)
 _COMMAND_NESTING = defaultdict(lambda: 0)

--- a/evennia/commands/cmdhandler.py
+++ b/evennia/commands/cmdhandler.py
@@ -52,33 +52,6 @@ _CMDSET_MERGE_CACHE = OrderedDict()
 _CMDSET_MERGE_CACHE_MAXSIZE = 1000
 
 
-def _cmdset_fingerprint(cmdset):
-    """
-    Build a hashable fingerprint from a cmdset's semantic content. Two cmdsets
-    with identical commands and merge properties will produce the same fingerprint,
-    regardless of Python object identity.
-
-    Args:
-        cmdset (CmdSet): The cmdset to fingerprint.
-
-    Returns:
-        tuple: A hashable fingerprint.
-
-    """
-    cmd_ids = tuple(sorted(tuple(sorted(cmd._matchset)) for cmd in cmdset.commands))
-    sys_cmd_ids = tuple(sorted(tuple(sorted(cmd._matchset)) for cmd in cmdset.system_commands))
-    return (
-        cmdset.key,
-        cmdset.priority,
-        cmdset.mergetype,
-        cmdset.duplicates,
-        cmdset.no_exits,
-        cmdset.no_objs,
-        cmdset.no_channels,
-        tuple(sorted(cmdset.key_mergetypes.items())) if cmdset.key_mergetypes else (),
-        cmd_ids,
-        sys_cmd_ids,
-    )
 
 # tracks recursive calls by each caller
 # to avoid infinite loops (commands calling themselves)
@@ -476,9 +449,8 @@ def get_and_merge_cmdsets(
             ]
 
         if cmdsets:
-            # build a content-based fingerprint so that semantically identical
-            # cmdset combinations hit the cache even if the Python objects differ
-            mergehash = tuple(_cmdset_fingerprint(cmdset) for cmdset in cmdsets)
+            # each cmdset caches its own fingerprint, so this is just a tuple lookup
+            mergehash = tuple(cmdset.fingerprint for cmdset in cmdsets)
             if mergehash in _CMDSET_MERGE_CACHE:
                 # cached merge exists; move to end for LRU tracking
                 _CMDSET_MERGE_CACHE.move_to_end(mergehash)

--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -234,11 +234,13 @@ class CmdSet(object, metaclass=_CmdSetMeta):
         Lazily computed and cached; invalidated when commands are added or removed.
         """
         if self._cached_fingerprint is None:
-            cmd_ids = tuple(
-                sorted(tuple(sorted(cmd._matchset)) for cmd in self.commands)
+            cmd_ids = frozenset(
+                (frozenset(cmd._matchset), cmd.obj)
+                for cmd in self.commands
             )
-            sys_cmd_ids = tuple(
-                sorted(tuple(sorted(cmd._matchset)) for cmd in self.system_commands)
+            sys_cmd_ids = frozenset(
+                (frozenset(cmd._matchset), cmd.obj)
+                for cmd in self.system_commands
             )
             self._cached_fingerprint = (
                 self.key,
@@ -248,7 +250,8 @@ class CmdSet(object, metaclass=_CmdSetMeta):
                 self.no_exits,
                 self.no_objs,
                 self.no_channels,
-                tuple(sorted(self.key_mergetypes.items())) if self.key_mergetypes else (),
+                frozenset(self.key_mergetypes.items()) if self.key_mergetypes else frozenset(),
+                self.cmdsetobj,
                 cmd_ids,
                 sys_cmd_ids,
             )
@@ -709,6 +712,7 @@ class CmdSet(object, metaclass=_CmdSetMeta):
             else:
                 unique[cmd.key] = cmd
         self.commands = list(unique.values())
+        self._cached_fingerprint = None
 
     def get_all_cmd_keys_and_aliases(self, caller=None):
         """

--- a/evennia/commands/cmdset.py
+++ b/evennia/commands/cmdset.py
@@ -224,6 +224,35 @@ class CmdSet(object, metaclass=_CmdSetMeta):
         # initialize system
         self.at_cmdset_creation()
         self._contains_cache = WeakKeyDictionary()  # {}
+        self._cached_fingerprint = None
+
+    @property
+    def fingerprint(self):
+        """
+        A hashable, content-based fingerprint of this cmdset. Two cmdsets with
+        identical commands and merge properties produce the same fingerprint.
+        Lazily computed and cached; invalidated when commands are added or removed.
+        """
+        if self._cached_fingerprint is None:
+            cmd_ids = tuple(
+                sorted(tuple(sorted(cmd._matchset)) for cmd in self.commands)
+            )
+            sys_cmd_ids = tuple(
+                sorted(tuple(sorted(cmd._matchset)) for cmd in self.system_commands)
+            )
+            self._cached_fingerprint = (
+                self.key,
+                self.priority,
+                self.mergetype,
+                self.duplicates,
+                self.no_exits,
+                self.no_objs,
+                self.no_channels,
+                tuple(sorted(self.key_mergetypes.items())) if self.key_mergetypes else (),
+                cmd_ids,
+                sys_cmd_ids,
+            )
+        return self._cached_fingerprint
 
     # Priority-sensitive merge operations for cmdsets
 
@@ -568,6 +597,7 @@ class CmdSet(object, metaclass=_CmdSetMeta):
             # extra run to make sure to avoid doublets
             commands = list(set(commands))
         self.commands = commands
+        self._cached_fingerprint = None
 
     def remove(self, cmd):
         """
@@ -597,6 +627,7 @@ class CmdSet(object, metaclass=_CmdSetMeta):
                 pass
         else:
             self.commands = [oldcmd for oldcmd in self.commands if oldcmd != cmd]
+        self._cached_fingerprint = None
 
     def get(self, cmd):
         """

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -1146,46 +1146,6 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         self.assertEqual(len(cmdset_ee.commands), 1)
         self.assertEqual(cmdset_ee.commands[0].key, "e")
 
-    def test_merge_cache_hit(self):
-        """Test that semantically identical cmdsets hit the merge cache."""
-        a = self.cmdset_a
-        a.no_channels = True
-        self.set_cmdsets(self.obj1, a)
-        (
-            command_objects,
-            command_objects_list,
-            command_objects_list_error,
-            caller,
-            error_to,
-        ) = cmdhandler.generate_cmdset_providers(self.obj1)
-
-        # clear cache so we start fresh
-        cmdhandler._CMDSET_MERGE_CACHE.clear()
-
-        deferred = cmdhandler.get_and_merge_cmdsets(
-            self.obj1, command_objects_list, "object", "", error_to
-        )
-
-        def _first_call(cmdset_first):
-            self.assertEqual(len(cmdhandler._CMDSET_MERGE_CACHE), 1)
-
-            # second call with the same logical cmdsets should hit the cache
-            d2 = cmdhandler.get_and_merge_cmdsets(
-                self.obj1, command_objects_list, "object", "", error_to
-            )
-
-            def _second_call(cmdset_second):
-                # cache size should not have grown — it was a hit
-                self.assertEqual(len(cmdhandler._CMDSET_MERGE_CACHE), 1)
-                # the returned object should be the exact same cached instance
-                self.assertIs(cmdset_first, cmdset_second)
-
-            d2.addCallback(_second_call)
-            return d2
-
-        deferred.addCallback(_first_call)
-        return deferred
-
 
 class AccessableCommand(Command):
     def access(*args, **kwargs):

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -1146,6 +1146,46 @@ class TestGetAndMergeCmdSets(TwistedTestCase, BaseEvenniaTest):
         self.assertEqual(len(cmdset_ee.commands), 1)
         self.assertEqual(cmdset_ee.commands[0].key, "e")
 
+    def test_merge_cache_hit(self):
+        """Test that semantically identical cmdsets hit the merge cache."""
+        a = self.cmdset_a
+        a.no_channels = True
+        self.set_cmdsets(self.obj1, a)
+        (
+            command_objects,
+            command_objects_list,
+            command_objects_list_error,
+            caller,
+            error_to,
+        ) = cmdhandler.generate_cmdset_providers(self.obj1)
+
+        # clear cache so we start fresh
+        cmdhandler._CMDSET_MERGE_CACHE.clear()
+
+        deferred = cmdhandler.get_and_merge_cmdsets(
+            self.obj1, command_objects_list, "object", "", error_to
+        )
+
+        def _first_call(cmdset_first):
+            self.assertEqual(len(cmdhandler._CMDSET_MERGE_CACHE), 1)
+
+            # second call with the same logical cmdsets should hit the cache
+            d2 = cmdhandler.get_and_merge_cmdsets(
+                self.obj1, command_objects_list, "object", "", error_to
+            )
+
+            def _second_call(cmdset_second):
+                # cache size should not have grown — it was a hit
+                self.assertEqual(len(cmdhandler._CMDSET_MERGE_CACHE), 1)
+                # the returned object should be the exact same cached instance
+                self.assertIs(cmdset_first, cmdset_second)
+
+            d2.addCallback(_second_call)
+            return d2
+
+        deferred.addCallback(_first_call)
+        return deferred
+
 
 class AccessableCommand(Command):
     def access(*args, **kwargs):

--- a/evennia/commands/tests.py
+++ b/evennia/commands/tests.py
@@ -1425,3 +1425,124 @@ class TestIssue2627(TwistedTestCase, BaseEvenniaTest):
 
         d.addCallback(_callback)
         return d
+
+
+class TestCmdSetMergeObjBindings(TestCase):
+    """Test that cmdset merges preserve correct cmd.obj bindings."""
+
+    def test_merge_preserves_obj_from_different_cmdsets(self):
+        """Commands from different objects retain their obj after merge."""
+        from unittest.mock import Mock
+
+        obj1 = Mock(name="Sword")
+        obj2 = Mock(name="Shield")
+
+        cmdset1 = CmdSet(obj1)
+        cmdset1.key = "SwordCmds"
+        cmd_slash = _CmdA("sword")
+        cmd_slash.obj = obj1
+        cmdset1.add(cmd_slash)
+
+        cmdset2 = CmdSet(obj2)
+        cmdset2.key = "ShieldCmds"
+        cmd_block = _CmdB("shield")
+        cmd_block.obj = obj2
+        cmdset2.add(cmd_block)
+
+        merged = cmdset1 + cmdset2
+        cmds = {cmd.key: cmd for cmd in merged.commands}
+
+        self.assertIs(cmds["a"].obj, obj1)
+        self.assertIs(cmds["b"].obj, obj2)
+
+    def test_same_key_different_obj_resolved_by_priority(self):
+        """When two cmdsets share a command key, priority determines which obj wins."""
+        from unittest.mock import Mock
+
+        obj_low = Mock(name="LowPrio")
+        obj_high = Mock(name="HighPrio")
+
+        cmdset_low = CmdSet(obj_low)
+        cmdset_low.key = "LowSet"
+        cmdset_low.priority = 0
+        cmd_low = _CmdA("low")
+        cmd_low.obj = obj_low
+        cmdset_low.add(cmd_low)
+
+        cmdset_high = CmdSet(obj_high)
+        cmdset_high.key = "HighSet"
+        cmdset_high.priority = 1
+        cmd_high = _CmdA("high")
+        cmd_high.obj = obj_high
+        cmdset_high.add(cmd_high)
+
+        merged = cmdset_low + cmdset_high
+        result_cmd = [cmd for cmd in merged.commands if cmd.key == "a"][0]
+
+        self.assertIs(result_cmd.obj, obj_high)
+
+    def test_merge_after_add_reflects_new_command(self):
+        """Adding a command to a cmdset and re-merging includes it with correct obj."""
+        from unittest.mock import Mock
+
+        obj1 = Mock(name="Obj1")
+        obj2 = Mock(name="Obj2")
+
+        cmdset1 = CmdSet(obj1)
+        cmdset1.key = "Set1"
+        cmd_a = _CmdA("set1")
+        cmd_a.obj = obj1
+        cmdset1.add(cmd_a)
+
+        cmdset2 = CmdSet(obj2)
+        cmdset2.key = "Set2"
+        cmd_b = _CmdB("set2")
+        cmd_b.obj = obj2
+        cmdset2.add(cmd_b)
+
+        merged1 = cmdset1 + cmdset2
+        self.assertEqual(len(merged1.commands), 2)
+
+        # add a new command and re-merge
+        cmd_c = _CmdC("set1")
+        cmd_c.obj = obj1
+        cmdset1.add(cmd_c)
+
+        merged2 = cmdset1 + cmdset2
+        self.assertEqual(len(merged2.commands), 3)
+        cmds = {cmd.key: cmd for cmd in merged2.commands}
+        self.assertIn("c", cmds)
+        self.assertIs(cmds["c"].obj, obj1)
+
+    def test_merge_after_remove_excludes_command(self):
+        """Removing a command from a cmdset and re-merging excludes it."""
+        from unittest.mock import Mock
+
+        obj1 = Mock(name="Obj1")
+        obj2 = Mock(name="Obj2")
+
+        cmdset1 = CmdSet(obj1)
+        cmdset1.key = "Set1"
+        cmd_a = _CmdA("set1")
+        cmd_a.obj = obj1
+        cmd_b = _CmdB("set1")
+        cmd_b.obj = obj1
+        cmdset1.add(cmd_a)
+        cmdset1.add(cmd_b)
+
+        cmdset2 = CmdSet(obj2)
+        cmdset2.key = "Set2"
+        cmd_c = _CmdC("set2")
+        cmd_c.obj = obj2
+        cmdset2.add(cmd_c)
+
+        merged1 = cmdset1 + cmdset2
+        self.assertEqual(len(merged1.commands), 3)
+
+        # remove a command and re-merge
+        cmdset1.remove(cmd_b)
+
+        merged2 = cmdset1 + cmdset2
+        self.assertEqual(len(merged2.commands), 2)
+        keys = {cmd.key for cmd in merged2.commands}
+        self.assertNotIn("b", keys)


### PR DESCRIPTION
<h2>Problem</h2>
<p>The merge cache in <code>cmdhandler.get_and_merge_cmdsets</code> used Python object identity (<code>id()</code>) as the cache key. Since cmdset objects are recreated on each call, the cache never produced a hit. For players in rooms with many exits or objects carrying custom cmdsets this resulted in a <em>ton</em> of merge operations. O(N).</p>
<h2>Changes</h2>
<p><strong><code>evennia/commands/cmdset.py</code></strong></p>
<p>Added a <code>fingerprint</code> property to <code>CmdSet</code>. It lazily computes a hashable tuple from the cmdset's semantic content (key, priority, mergetype, options, and the sorted matchsets of all commands), caches it on the instance, and invalidates it when commands are added or removed via <code>add()</code> or <code>remove()</code>. This means the fingerprint is computed once per cmdset per mutation rather than on every command input.</p>
<p><strong><code>evennia/commands/cmdhandler.py</code></strong></p>
<ul>
<li>Replaced <code>id()</code>-based cache keys with <code>tuple(cmdset.fingerprint for cmdset in cmdsets)</code>. Two calls with semantically identical cmdsets now share a cache entry regardless of object identity.</li>
<li>Replaced the plain <code>dict</code> with a bounded <code>OrderedDict</code> (max 1000 entries) with LRU eviction, preventing unbounded memory growth.</li>
</ul>
<h2>Performance</h2>
<p>Benchmarked against a simulated scenario of 33 cmdsets (515 total commands):</p>

  | Time | vs full merge
-- | -- | --
Full merge (no cache) | 36.3 ms | baseline
Fingerprint, cold (first compute) | 0.15 ms | 242x faster
Fingerprint, hot (cached on CmdSet) | 0.002 ms | 18,150x faster

[ EDIT: I think it is _only_ 500x best case due to erroneous cache hits pointed out by Griatch :'(. ]

<p>On the hot path the cache lookup is essentially free.</p>
<h2>Tests</h2>
<p>Added <code>TestGetAndMergeCmdSets.test_merge_cache_hit</code> which verifies that two calls with the same logical cmdsets produce a cache hit (no growth in cache size, same returned object identity).</p></body></html>

# Motivation for adding to Evennia

Cache was implemented but basically non-functional. This should be closer to the original intent.

# Other info (issues closed, discussion etc)

Addresses issue #3807. (Plus should just be a very nice performance increase)