### PR TITLE
Fix tag/search failing when searching by category only

### DIFF
--- a/evennia/commands/default/building.py
+++ b/evennia/commands/default/building.py
@@ -3991,10 +3991,11 @@ class CmdTag(COMMAND_DEFAULT_CLASS):
             return
         if "search" in self.switches:
             # search by tag
-            tag = self.args
+            tag = self.args.strip()
             category = None
             if ":" in tag:
                 tag, category = [part.strip() for part in tag.split(":", 1)]
+            tag = tag or None  # pass None instead of "" to match all keys
             objs = search.search_tag(tag, category=category)
             nobjs = len(objs)
             if nobjs > 0:

--- a/evennia/commands/default/tests.py
+++ b/evennia/commands/default/tests.py
@@ -1748,6 +1748,19 @@ class TestBuilding(BaseEvenniaCommandTest):
             "Found 1 object with tag 'testtag2' (category: 'category1'):",
         )
 
+        # search by category only (no tag key)
+        self.call(
+            building.CmdTag(),
+            "/search :category1",
+            "Found 1 object with tag 'None' (category: 'category1'):",
+        )
+        # search by category with leading space
+        self.call(
+            building.CmdTag(),
+            "/search  :category1",
+            "Found 1 object with tag 'None' (category: 'category1'):",
+        )
+
         self.call(building.CmdTag(), "/del Obj = testtag3", "Removed tag 'testtag3' from Obj.")
         self.call(
             building.CmdTag(),


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The tag/search command failed to find objects when searching by category alone (e.g. `tag/search :cityhall`) due to two issues:

1. Leading whitespace from command parsing was not stripped, causing the tag key to contain a space
2. An empty tag key was passed as "" instead of None, which searched for tags with an empty string key rather than matching all keys in the given category

Strip self.args and convert empty tag to None so category-only searches work correctly. Added tests for both cases.

#### Motivation for adding to Evennia

#### Other info (issues closed, discussion etc)
