### PR TITLE
Add configurable server lifecycle broadcast messages

### DIFF
--- a/evennia/commands/default/system.py
+++ b/evennia/commands/default/system.py
@@ -28,6 +28,8 @@ from evennia.utils.utils import class_from_module, iter_to_str
 COMMAND_DEFAULT_CLASS = class_from_module(settings.COMMAND_DEFAULT_CLASS)
 _TASK_HANDLER = None
 _BROADCAST_SERVER_RESTART_MESSAGES = settings.BROADCAST_SERVER_RESTART_MESSAGES
+_SERVER_RELOAD_INITIATE_MSG = settings.SERVER_RELOAD_INITIATE_MSG
+_SERVER_RESET_MSG = settings.SERVER_RESET_MSG
 
 # delayed imports
 _RESOURCE = None
@@ -79,7 +81,7 @@ class CmdReload(COMMAND_DEFAULT_CLASS):
         if self.args:
             reason = "(Reason: %s) " % self.args.rstrip(".")
         if _BROADCAST_SERVER_RESTART_MESSAGES:
-            evennia.SESSION_HANDLER.announce_all(f" Server restart initiated {reason}...")
+            evennia.SESSION_HANDLER.announce_all(_SERVER_RELOAD_INITIATE_MSG.format(reason=reason))
         evennia.SESSION_HANDLER.portal_restart_server()
 
 
@@ -112,7 +114,7 @@ class CmdReset(COMMAND_DEFAULT_CLASS):
         """
         Reload the system.
         """
-        evennia.SESSION_HANDLER.announce_all(" Server resetting/restarting ...")
+        evennia.SESSION_HANDLER.announce_all(_SERVER_RESET_MSG)
         evennia.SESSION_HANDLER.portal_reset_server()
 
 

--- a/evennia/server/sessionhandler.py
+++ b/evennia/server/sessionhandler.py
@@ -39,6 +39,7 @@ from evennia.utils.utils import (
 
 _FUNCPARSER_PARSE_OUTGOING_MESSAGES_ENABLED = settings.FUNCPARSER_PARSE_OUTGOING_MESSAGES_ENABLED
 _BROADCAST_SERVER_RESTART_MESSAGES = settings.BROADCAST_SERVER_RESTART_MESSAGES
+_SERVER_RESTART_MSG = settings.SERVER_RESTART_MSG
 
 # delayed imports
 _AccountDB = None
@@ -415,7 +416,7 @@ class ServerSessionHandler(SessionHandler):
         evennia.EVENNIA_SERVER_SERVICE.at_post_portal_sync(mode)
         # announce the reconnection
         if _BROADCAST_SERVER_RESTART_MESSAGES:
-            self.announce_all(_(" ... Server restarted."))
+            self.announce_all(_(_SERVER_RESTART_MSG))
 
     def portal_disconnect(self, session):
         """

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -314,6 +314,10 @@ AUDIT_MASKS = [
 ]
 # Broadcast "Server restart"-like messages to all sessions.
 BROADCAST_SERVER_RESTART_MESSAGES = True
+# Messages broadcast to all sessions on server lifecycle events.
+SERVER_RELOAD_INITIATE_MSG = " Server restart initiated {reason}..."
+SERVER_RESET_MSG = " Server resetting/restarting ..."
+SERVER_RESTART_MSG = " ... Server restarted."
 
 ######################################################################
 # Evennia Database config


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Introduces SERVER_RELOAD_INITIATE_MSG, SERVER_RESET_MSG, and SERVER_RESTART_MSG settings so games can override the hardcoded restart/reload strings without patching core. Defaults preserve the existing messages exactly.

#### Motivation for adding to Evennia

The reload message has always been easy to change, but the '... Server restarted' one has always been hard coded.

#### Other info (issues closed, discussion etc)
