### PR TITLE
Fix MXP OPEN mode eating unknown tags like <username> in plain text

### DIFF
--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -103,6 +103,10 @@ class Mxp:
         if settings.MXP_ENABLED:
             self.protocol().protocol_flags["MXP"] = True
             self.protocol().requestNegotiation(MXP, b"")
+            # Switch client to permanently-locked mode so plain text containing
+            # '<' is never parsed as MXP. Actual clickable links use \x1b[4z
+            # (TEMP_SECURE) wrappers from mxp_parse(), which work fine from here.
+            self.protocol().sendLine(b"\x1b[7z")
         else:
             self.protocol().wont(MXP)
         self.protocol().handshake_done()

--- a/evennia/server/portal/mxp.py
+++ b/evennia/server/portal/mxp.py
@@ -26,6 +26,7 @@ URL_SUB = re.compile(r"\|lu(.*?)\|lt(.*?)\|le", re.DOTALL)
 MXP = bytes([91])  # b"\x5b"
 
 MXP_TEMPSECURE = "\x1b[4z"
+MXP_LOCK_LOCKED = b"\x1b[7z"
 MXP_SEND = MXP_TEMPSECURE + '<SEND HREF="\\1">' + "\\2" + MXP_TEMPSECURE + "</SEND>"
 MXP_URL = MXP_TEMPSECURE + '<A HREF="\\1">' + "\\2" + MXP_TEMPSECURE + "</A>"
 
@@ -106,7 +107,7 @@ class Mxp:
             # Switch client to permanently-locked mode so plain text containing
             # '<' is never parsed as MXP. Actual clickable links use \x1b[4z
             # (TEMP_SECURE) wrappers from mxp_parse(), which work fine from here.
-            self.protocol().sendLine(b"\x1b[7z")
+            self.protocol().sendLine(MXP_LOCK_LOCKED)
         else:
             self.protocol().wont(MXP)
         self.protocol().handshake_done()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

After MXP negotiation, clients default to OPEN mode and attempt to parse all <word> text as MXP elements. This silently removes unknown tags such as <username> and <password> from server output.

Send \x1b[7z (LOCK_LOCKED) immediately after the MXP handshake to put clients into permanently-locked mode. Explicit clickable links created by mxp_parse() already use \x1b[4z (TEMP_SECURE) wrappers, which work correctly from a locked baseline and return to locked mode afterwards.

#### Motivation for adding to Evennia

I think this was the intended way for it to work since it correctly send the TEMP_SECURE escape string when links are used with the pipe commands. It also fixes an issue for us that cropped up which was one of those 'how did this ever work' sort of scenarios.

#### Other info (issues closed, discussion etc)

May help with #2790 but don't quote me on that!