### PR TITLE
Fix `containining` -> `containing` typo in Settings-Default.md

### DIFF
--- a/docs/source/Setup/Settings-Default.md
+++ b/docs/source/Setup/Settings-Default.md
@@ -503,7 +503,7 @@ LOCK_FUNC_MODULES = ("evennia.locks.lockfuncs", "server.conf.lockfuncs")
 INPUT_FUNC_MODULES = ["evennia.server.inputfuncs", "server.conf.inputfuncs"]
 # Modules that contain prototypes for use with the spawner mechanism.
 PROTOTYPE_MODULES = ["world.prototypes"]
-# Modules containining Prototype functions able to be embedded in prototype
+# Modules containing Prototype functions able to be embedded in prototype
 # definitions from in-game.
 PROT_FUNC_MODULES = ["evennia.prototypes.protfuncs"]
 # Module holding settings/actions for the dummyrunner program (see the


### PR DESCRIPTION
Line 506 of `docs/source/Setup/Settings-Default.md` has `containining` (extra letters) in the comment for the Prototype-functions module list.