### PR TITLE
Add -> bool return annotations to override-intended hook methods

### DIFF
--- a/evennia/accounts/accounts.py
+++ b/evennia/accounts/accounts.py
@@ -1790,7 +1790,7 @@ class DefaultAccount(AccountDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_msg_receive(self, text=None, from_obj=None, **kwargs):
+    def at_msg_receive(self, text=None, from_obj=None, **kwargs) -> bool:
         """
         This hook is called whenever someone sends a message to this
         object using the `msg` method.

--- a/evennia/comms/comms.py
+++ b/evennia/comms/comms.py
@@ -686,7 +686,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
             message = f"{senders}{message}"
             logger.log_file(message, log_file)
 
-    def pre_join_channel(self, joiner, **kwargs):
+    def pre_join_channel(self, joiner, **kwargs) -> bool:
         """
         Hook method. Runs right before a channel is joined. If this
         returns a false value, channel joining is aborted.
@@ -719,7 +719,7 @@ class DefaultChannel(ChannelDB, metaclass=TypeclassBase):
         for key_or_alias in key_and_aliases:
             self.add_user_channel_alias(joiner, key_or_alias, **kwargs)
 
-    def pre_leave_channel(self, leaver, **kwargs):
+    def pre_leave_channel(self, leaver, **kwargs) -> bool:
         """
         Hook method. Runs right before a user leaves a channel. If this returns a false
         value, leaving the channel will be aborted.

--- a/evennia/objects/objects.py
+++ b/evennia/objects/objects.py
@@ -2056,7 +2056,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_object_delete(self):
+    def at_object_delete(self) -> bool:
         """
         Called just before the database object is persistently
         delete()d from the database. If this method returns False,
@@ -2218,7 +2218,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
 
     # hooks called when moving the object
 
-    def at_pre_move(self, destination, move_type="move", **kwargs):
+    def at_pre_move(self, destination, move_type="move", **kwargs) -> bool:
         """
         Called just before starting to move this object to
         destination. Return False to abort move.
@@ -2242,7 +2242,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         return True
 
-    def at_pre_object_leave(self, leaving_object, destination, **kwargs):
+    def at_pre_object_leave(self, leaving_object, destination, **kwargs) -> bool:
         """
         Called just before this object is about lose an object that was
         previously 'inside' it. Return False to abort move.
@@ -2263,7 +2263,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         return True
 
-    def at_pre_object_receive(self, arriving_object, source_location, **kwargs):
+    def at_pre_object_receive(self, arriving_object, source_location, **kwargs) -> bool:
         """
         Called just before this object received another object. If this
         method returns `False`, the move is aborted and the moved entity
@@ -2532,7 +2532,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_msg_receive(self, text=None, from_obj=None, **kwargs):
+    def at_msg_receive(self, text=None, from_obj=None, **kwargs) -> bool:
         """
         This hook is called whenever someone sends a message to this
         object using the `msg` method.
@@ -2701,7 +2701,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_pre_get(self, getter, **kwargs):
+    def at_pre_get(self, getter, **kwargs) -> bool:
         """
         Called by the default `get` command before this object has been
         picked up.
@@ -2740,7 +2740,7 @@ class DefaultObject(ObjectDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_pre_give(self, giver, getter, **kwargs):
+    def at_pre_give(self, giver, getter, **kwargs) -> bool:
         """
         Called by the default `give` command before this object has been
         given.

--- a/evennia/scripts/scripts.py
+++ b/evennia/scripts/scripts.py
@@ -511,7 +511,7 @@ class ScriptBase(ScriptDB, metaclass=TypeclassBase):
         """
         pass
 
-    def at_script_delete(self):
+    def at_script_delete(self) -> bool:
         """
         Called when script is deleted, before the script timer stops.
 
@@ -521,7 +521,7 @@ class ScriptBase(ScriptDB, metaclass=TypeclassBase):
         """
         return True
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """
         If returning False, `at_repeat` will not be called and timer will stop
         updating.
@@ -795,7 +795,7 @@ class DefaultScript(ScriptBase):
         """
         pass
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """
         Is called to check if the script's timer is valid to run at this time.
         Should return a boolean. If False, the timer will be stopped.
@@ -853,7 +853,7 @@ class DefaultScript(ScriptBase):
         """
         pass
 
-    def at_script_delete(self):
+    def at_script_delete(self) -> bool:
         """
         Called when the Script is deleted, before stopping the timer.
 

--- a/evennia/server/serversession.py
+++ b/evennia/server/serversession.py
@@ -481,7 +481,7 @@ class ServerSession(_BASE_SESSION_CLASS):
 
     # Mock access method for the session (there is no lock info
     # at this stage, so we just present a uniform API)
-    def access(self, *args, **kwargs):
+    def access(self, *args, **kwargs) -> bool:
         """
         Dummy method to mimic the logged-in API.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fourteen hook methods on DefaultObject, DefaultScript, ScriptBase, DefaultChannel, DefaultAccount, and ServerSession returned a bare `True` literal, causing type checkers to infer Literal[True] rather than bool. Userland subclasses that return False to abort behavior (the documented contract) would be flagged as incompatible overrides. Adds explicit `-> bool` annotations; no runtime behavior changes.

#### Motivation for adding to Evennia

Types are good, we like types :)

#### Other info (issues closed, discussion etc)
