### PR TITLE
Fix portal and server docs typos

### DIFF
--- a/docs/source/Components/Portal-And-Server.md
+++ b/docs/source/Components/Portal-And-Server.md
@@ -19,8 +19,8 @@ The _Portal_ and _Server_ consitutes the two main halves of Evennia.
 These are two separate `twistd` processes and can be controlled from inside the game or from the command line as described [in the Running-Evennia doc](../Setup/Running-Evennia.md).
 
 - The Portal knows everything about internet protocols (telnet, websockets etc), but knows very little about the game. 
-- The Server knows everything about the game. It knows that a player has connected but now _how_ they connected. 
+- The Server knows everything about the game. It knows that a player has connected but not _how_ they connected.
 
-The effect of this is that you can fully `reload` the Server and have players still connected to the game. One the server comes back up, it will re-connect to the Portal and re-sync all players as if nothing happened. 
+The effect of this is that you can fully `reload` the Server and have players still connected to the game. Once the server comes back up, it will re-connect to the Portal and re-sync all players as if nothing happened.
 
-The Portal and Server are intended to always run on the same machine. They are glued together via an AMP (Asynchronous Messaging Protocol) connection. This allows the two programs to communicate seamlessly. 
+The Portal and Server are intended to always run on the same machine. They are glued together via an AMP (Asynchronous Messaging Protocol) connection. This allows the two programs to communicate seamlessly.


### PR DESCRIPTION
Fixes #3934.

Summary:
- Corrects "now _how_" to "not _how_".
- Corrects "One the server..." to "Once the server...".
- Removes trailing whitespace on the edited lines.

Validation:
- `git diff --check`
- `rg -n "now _how_|One the server|not _how_|Once the server" docs/source/Components/Portal-And-Server.md`
- Attempted the full Sphinx docs build with local requirements. The full build fails in unrelated autodoc/environment setup before completion, including missing optional `boto3` bindings for awsstorage and an existing `SignalsHandler` autodoc error, so I did not treat that as caused by this two-word docs fix.

This is a small direct microfix. If accepted and you are open to settling small docs fixes, I would appreciate $10 via the project funding route: https://www.paypal.me/GriatchEvennia