### PR TITLE
Fix ReferenceError in notifications plugin when window unfocused

### DIFF
--- a/evennia/web/static/webclient/js/plugins/notifications.js
+++ b/evennia/web/static/webclient/js/plugins/notifications.js
@@ -40,7 +40,7 @@ let notifications_plugin = (function () {
                         if(result === "granted") {
                             var title = originalTitle === "" ? "Evennia" : originalTitle;
                             var options = {
-                                body: text.replace(/(<([^>]+)>)/ig,""),
+                                body: args[0].replace(/(<([^>]+)>)/ig,""),
                                 icon: "/static/website/images/evennia_logo.png"
                             }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The desktop notifications plugin's onText handler takes (args, kwargs) but the requestPermission callback references a bare `text` identifier that isn't defined anywhere in scope, throwing:

```
    Uncaught ReferenceError: text is not defined
        at notifications.js:43
```

This fires when a message arrives while the webclient window is unfocused, but only for users who have notification_popup enabled and have granted notification permission.

Read the message body from args[0] to match the convention every other text-handling plugin uses (default_out.js, text2html.js, html.js, goldenlayout.js).

#### Motivation for adding to Evennia

This seems to be a rather old issue with a straightforward fix.

#### Other info (issues closed, discussion etc)
