### PR TITLE
Add AMP_CONNECT_TIMEOUT for portal probe

### DIFF
--- a/evennia/server/evennia_launcher.py
+++ b/evennia/server/evennia_launcher.py
@@ -81,6 +81,7 @@ NO_REACTOR_STOP = False
 AMP_PORT = None
 AMP_HOST = None
 AMP_INTERFACE = None
+AMP_CONNECT_TIMEOUT = None
 AMP_CONNECTION = None
 
 SRELOAD = chr(14)  # server reloading (have portal start a new server)
@@ -662,7 +663,9 @@ def send_instruction(operation, arguments, callback=None, errback=None):
         return _send()
     else:
         # we must connect first, send once connected
-        point = endpoints.TCP4ClientEndpoint(reactor, AMP_HOST, AMP_PORT)
+        point = endpoints.TCP4ClientEndpoint(
+            reactor, AMP_HOST, AMP_PORT, timeout=AMP_CONNECT_TIMEOUT
+        )
         deferred = endpoints.connectProtocol(point, AMPLauncherProtocol())
         deferred.addCallbacks(_on_connect, _on_connect_fail)
         REACTOR_RUN = True
@@ -1812,7 +1815,7 @@ def init_game_directory(path, check_db=True, need_gamedir=True):
         return
 
     # set up the Evennia executables and log file locations
-    global AMP_PORT, AMP_HOST, AMP_INTERFACE
+    global AMP_PORT, AMP_HOST, AMP_INTERFACE, AMP_CONNECT_TIMEOUT
     global SERVER_PY_FILE, PORTAL_PY_FILE
     global SERVER_LOGFILE, PORTAL_LOGFILE, HTTP_LOGFILE
     global SERVER_PIDFILE, PORTAL_PIDFILE
@@ -1822,6 +1825,7 @@ def init_game_directory(path, check_db=True, need_gamedir=True):
     AMP_PORT = settings.AMP_PORT
     AMP_HOST = settings.AMP_HOST
     AMP_INTERFACE = settings.AMP_INTERFACE
+    AMP_CONNECT_TIMEOUT = settings.AMP_CONNECT_TIMEOUT
 
     SERVER_PY_FILE = os.path.join(EVENNIA_LIB, "server", "server.py")
     PORTAL_PY_FILE = os.path.join(EVENNIA_LIB, "server", "portal", "portal.py")

--- a/evennia/settings_default.py
+++ b/evennia/settings_default.py
@@ -153,6 +153,10 @@ EVENNIA_ADMIN = True
 AMP_HOST = "localhost"
 AMP_PORT = 4006
 AMP_INTERFACE = "127.0.0.1"
+# Timeout (seconds) for the launcher's connection to the Portal's AMP port when
+# sending start/stop/status instructions. This is a loopback connection, so a
+# live Portal accepts in well under a millisecond.
+AMP_CONNECT_TIMEOUT = 2
 
 
 # Path to the lib directory containing the bulk of the codebase's code.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The launcher probes the AMP port to decide if the portal is running. `TCP4ClientEndpoint` defaults to 30s timeout. Usually, local port returns an instant response, but when OS doesn't fast-refuse (as is the case with WSL2 + Tailscale), the probe blocks for the full 30s before concluding the portal is down. Every launcher command probes at least once, so `start` and `stop` will each stall for 30s.

A short timeout is safe because it is only ever needed to bound the failure case. A live portal accepts connection in under a millisecond, so 2s is well above the expected threshold.

#### Other info (issues closed, discussion etc)

Closes #3941 
