### PR TITLE
Replace `unique_together` and `indexes` Tag options with UniqueConstraint

### DIFF
--- a/evennia/typeclasses/tags.py
+++ b/evennia/typeclasses/tags.py
@@ -81,8 +81,12 @@ class Tag(models.Model):
         "Define Django meta options"
 
         verbose_name = "Tag"
-        unique_together = (("db_key", "db_category", "db_tagtype", "db_model"),)
-        indexes = [models.Index(fields=["db_key", "db_category", "db_tagtype", "db_model"])]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["db_key", "db_category", "db_tagtype", "db_model"],
+                name="tag_unique_key_category_tagtype_model",
+            )
+        ]
 
     def __lt__(self, other):
         return str(self) < str(other)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Replaces the `unique_together` and `indexes` properties of the Tag meta with `UniqueConstraint`

#### Motivation for adding to Evennia

Seems to resolve https://github.com/evennia/evennia/issues/3897 in a Django-idiomatic way.

Another thing that seemed to work for me was to just delete the `indexes` property alone, but that left `unique_together` which is [considered obsolete](https://docs.djangoproject.com/en/6.0/ref/models/options/#django.db.models.Options.unique_together), so I went ahead and upgraded that.

#### Other info (issues closed, discussion etc)

My understanding is that this change is functionally sound (the old "indexes" property, as I understand it, is redundant with the "unique_together" property given that it only contained the full set of "unique_together" fields, so the index of that unique set is effectively just the tag's PK, and this change retains that set of unique fields), but has one wrinkle which is that any existing databases that migrate using this change will retain an orphaned `typeclasses_db_key_be0c81_idx` index created in migration 0017.