### PR TITLE
Update intro_menu to match the history.js webclient plugin

### DIFF
--- a/evennia/contrib/tutorials/tutorial_world/intro_menu.py
+++ b/evennia/contrib/tutorials/tutorial_world/intro_menu.py
@@ -434,9 +434,8 @@ The web client starts out having two panes - the input-pane for entering command
 and the main window.
 
 - Use |y<Return>|n (or click the arrow on the right) to send your input.
-- Use |yCtrl + <up/down-arrow>|n to step back and forth in your command-history.
-- Use |yCtrl + <Return>|n to add a new line to your input without sending.
-(Cmd instead of Ctrl-key on Macs)
+- Use |yShift + <up/down-arrow>|n to step back and forth in your command-history.
+- Use |yShift + <Return>|n to add a new line to your input without sending.
 
 There is also some |wextra|n info to learn about customizing the webclient.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The text in `contrib.tutorials.tutorial_world.intro_menu` says the key combination to scroll up/down through the history is Ctrl+up/down, but `web/static/webclient/js/plugins/history.js` uses Shift instead of Ctrl. This just updates the text in intro_menu to match what history does. Likewise with adding a new line to input.

Thanks all for putting so much effort into this library, it's been a joy to poke around in!
