### PR TITLE
fix: EvMore pager re-reads terminal size per page so mid-pagination resize is not stale

### DIFF
--- a/evennia/utils/evmore.py
+++ b/evennia/utils/evmore.py
@@ -257,11 +257,12 @@ class EvMore(object):
         self._paginator = self.paginator_index
         self._page_formatter = str
 
-        # set up individual pages for different sessions
-        height = max(4, session.protocol_flags.get("SCREENHEIGHT", {0: _SCREEN_HEIGHT})[0] - 4)
-        self.width = session.protocol_flags.get("SCREENWIDTH", {0: _SCREEN_WIDTH})[0]
-        # always limit number of chars to 10 000 per page
-        self.height = min(10000 // max(1, self.width), height)
+        # keep the original input so we can re-paginate on a terminal resize
+        self._inp = inp
+
+        # set up individual pages based on the current screen size
+        self.width, self.height = self._calc_size()
+        self._last_size = (self.width, self.height)
 
         # does initial parsing of input
         self.init_pages(inp)
@@ -271,10 +272,50 @@ class EvMore(object):
 
     # EvMore functional methods
 
+    def _calc_size(self):
+        """
+        Read the current screen size from the session's protocol flags.
+
+        These flags are updated dynamically by NAWS when the client's terminal
+        is resized, so this is re-read rather than cached to keep pagination in
+        sync with the current terminal dimensions.
+
+        Returns:
+            tuple: The `(width, height)` to use for pagination, where `height`
+                is capped so that a page never exceeds 10 000 characters.
+
+        """
+        protocol_flags = self._session.protocol_flags
+        height = max(4, protocol_flags.get("SCREENHEIGHT", {0: _SCREEN_HEIGHT})[0] - 4)
+        width = protocol_flags.get("SCREENWIDTH", {0: _SCREEN_WIDTH})[0]
+        # always limit number of chars to 10 000 per page
+        height = min(10000 // max(1, width), height)
+        return width, height
+
+    def _check_resize(self):
+        """
+        Re-read the current screen size and re-paginate if it has changed.
+
+        This handles the client resizing their terminal mid-pagination: the
+        pages are re-sliced at the new size and the current position is clamped
+        so it stays within the (possibly smaller) new page count.
+
+        """
+        new_size = self._calc_size()
+        if new_size != self._last_size:
+            self.width, self.height = new_size
+            self._last_size = new_size
+            # re-paginate the original input at the new size
+            self.init_pages(self._inp)
+            # keep the current position valid for the new page count
+            self._npos = max(0, min(self._npos, self._npages - 1))
+
     def display(self, show_footer=True):
         """
         Pretty-print the page.
         """
+        # re-read the terminal size in case it changed mid-pagination
+        self._check_resize()
         pos = 0
         text = "[no content]"
         if self._npages > 0:

--- a/evennia/utils/tests/test_evmore.py
+++ b/evennia/utils/tests/test_evmore.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the EvMore pager (evennia.utils.evmore).
+
+These focus on the pager re-reading the terminal size when the client is
+resized mid-pagination (issue #3916), so that pages rendered after a resize use
+the current dimensions rather than the ones cached at construction time.
+
+"""
+
+from unittest.mock import Mock
+
+from evennia.utils.evmore import EvMore
+from evennia.utils.test_resources import BaseEvenniaTest
+
+
+class TestEvMoreResize(BaseEvenniaTest):
+    """Terminal-resize handling for the EvMore pager."""
+
+    def setUp(self):
+        super().setUp()
+        # avoid sending real output while exercising the pager
+        self.char1.msg = Mock()
+        # deterministic starting screen size
+        self.session.protocol_flags["SCREENWIDTH"] = {0: 80}
+        self.session.protocol_flags["SCREENHEIGHT"] = {0: 20}
+
+    def _make_pager(self, nlines=50):
+        text = "\n".join(f"line {num}" for num in range(nlines))
+        return EvMore(self.char1, text, session=self.session)
+
+    def _set_screen(self, height=None, width=None):
+        if height is not None:
+            self.session.protocol_flags["SCREENHEIGHT"] = {0: height}
+        if width is not None:
+            self.session.protocol_flags["SCREENWIDTH"] = {0: width}
+
+    def test_calc_size_honors_char_cap(self):
+        """_calc_size reads current flags and caps chars-per-page at 10000."""
+        self._set_screen(height=10000, width=5)
+        pager = self._make_pager()
+        # width passes straight through; height is capped by 10000 // width
+        self.assertEqual(pager._calc_size(), (5, 10000 // 5))
+
+    def test_no_resize_uses_initial_size(self):
+        """Without a resize, the pager keeps its initial size and page count."""
+        pager = self._make_pager()
+        initial_height = pager.height
+        initial_npages = pager._npages
+        # a display with no size change must not alter pagination
+        pager.display()
+        self.assertEqual(pager.height, initial_height)
+        self.assertEqual(pager._npages, initial_npages)
+
+    def test_resize_shrink_repaginates(self):
+        """Shrinking the terminal mid-pagination adds pages (the bug case)."""
+        pager = self._make_pager()
+        initial_height = pager.height
+        initial_npages = pager._npages
+
+        # user shrinks their terminal after paging started
+        self._set_screen(height=8)
+        pager.display()
+
+        self.assertLess(pager.height, initial_height)
+        self.assertGreater(pager._npages, initial_npages)
+
+    def test_resize_grow_repaginates(self):
+        """Growing the terminal mid-pagination removes pages."""
+        # start small so there is room to grow
+        self._set_screen(height=8)
+        pager = self._make_pager()
+        initial_height = pager.height
+        initial_npages = pager._npages
+
+        self._set_screen(height=40)
+        pager.display()
+
+        self.assertGreater(pager.height, initial_height)
+        self.assertLess(pager._npages, initial_npages)
+
+    def test_resize_clamps_position(self):
+        """A resize that reduces the page count keeps the position valid."""
+        # start small -> many pages
+        self._set_screen(height=8)
+        pager = self._make_pager()
+        # jump to the last page
+        pager._npos = pager._npages - 1
+        last_pos = pager._npos
+
+        # grow the terminal so far fewer pages are needed
+        self._set_screen(height=200)
+        # this must not raise IndexError and must clamp the position
+        pager.display()
+
+        self.assertLess(pager._npages, last_pos + 1)
+        self.assertLessEqual(pager._npos, pager._npages - 1)
+        self.assertGreaterEqual(pager._npos, 0)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`EvMore` now re-reads the terminal size on every page render and re-paginates when it changes, so pages shown after a mid-pagination resize use the current dimensions instead of the ones cached at construction time.

The size computation is pulled out of `__init__` into a small `_calc_size()` helper that reads the current `SCREENHEIGHT`/`SCREENWIDTH` from `session.protocol_flags`. `__init__` now stores the original input and records the initial size. A new `_check_resize()` method runs at the top of `display()`: if the size changed, it updates `width`/`height`, re-runs `init_pages()` on the original input, and clamps `_npos` so the current position stays within the new page count.

#### Motivation for adding to Evennia

Reported in #3916: when a page is paginated, the output is sized from the terminal size at the moment the command was sent. `EvMore.__init__` reads the screen size once and `init_pages()` pre-slices the whole input into pages using those cached dimensions. If the client resizes the terminal after paging has started, NAWS updates `session.protocol_flags`, but the pager keeps using the old size, so every later page is sliced and justified to the original dimensions and the output is distorted.

Griatch confirmed the direction in the issue: "Sounds like a fix for the EvMore pager, re-reading dynamic size." Re-reading the size per page and re-paginating on change keeps the output in sync with the current terminal. The change is localized to `evmore.py` and preserves all existing input handling (str, `\f`-marked str, EvTable, QuerySet, django Paginator, and iterables), and the `ScriptEvMore`/`PrototypeEvMore` subclasses that override `init_pages()` re-paginate correctly too since the original input is retained.

#### Other info (issues closed, discussion etc)

New test module `evennia/utils/tests/test_evmore.py` (via `BaseEvenniaTest`) covers: the no-resize case keeps the initial size and page count; shrinking the terminal mid-pagination increases the page count and reduces the height (the reported bug); growing the terminal reduces the page count; a resize that shrinks the page count clamps `_npos` without an `IndexError`; and a direct `_calc_size()` check of the `10000 // width` per-page char cap. Verified with `evennia test --keepdb evennia.utils.tests.test_evmore` (5 tests pass) and `black`/`isort`.

Fixes #3916
