### PR TITLE
fix(evmenu): format dict helptext per entry

### DIFF
--- a/evennia/utils/evmenu.py
+++ b/evennia/utils/evmenu.py
@@ -1165,12 +1165,17 @@ class EvMenu:
         Format the node's help text
 
         Args:
-            helptext (str): The unformatted help text for the node.
+            helptext (str or dict): The unformatted help text for the node. A dict
+                maps a tooltip command to its own help text; each entry is
+                formatted separately.
 
         Returns:
-            helptext (str): The formatted help text.
+            helptext (str or dict): The formatted help text, of the same type as
+                the input.
 
         """
+        if isinstance(helptext, dict):
+            return {key: self.helptext_formatter(entry) for key, entry in helptext.items()}
         return dedent(helptext.strip("\n"), baseline_index=0).rstrip()
 
     def options_formatter(self, optionlist):

--- a/evennia/utils/tests/test_evmenu.py
+++ b/evennia/utils/tests/test_evmenu.py
@@ -373,3 +373,24 @@ class TestEvMenuPersistentReloadRegression(BaseEvenniaTest):
         menu_cmdsets = [cmdset for cmdset in self.char1.cmdset.get() if cmdset.key == "menu_cmdset"]
         self.assertEqual(len(menu_cmdsets), 1)
         self.assertEqual(self.char1.cmdset_storage.count("evennia.utils.evmenu.EvMenuCmdSet"), 1)
+
+
+def _tooltip_menu_start(caller, raw_string, **kwargs):
+    return (
+        "start text",
+        {"foo": "help about foo", ("bar", "baz"): "help about bar"},
+    ), {"key": "next", "desc": "go next", "goto": "start"}
+
+
+class TestEvMenuDictHelptext(BaseEvenniaTest):
+    """
+    A node may return its help text as a dict in order to provide per-command
+    tooltips (issue #3755).
+    """
+
+    def test_dict_helptext_node(self):
+        menu = evmenu.EvMenu(self.char1, {"start": _tooltip_menu_start}, session=self.session)
+        self.assertEqual(
+            menu.helptext,
+            {"foo": "help about foo", "bar": "help about bar", "baz": "help about bar"},
+        )


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`EvMenu.helptext_formatter()` called `.strip()` on the help text unconditionally, but a node may return its help text as a dict to provide per-command tooltips — so any such node raised `AttributeError: 'dict' object has no attribute 'strip'`. Dict helptext is now formatted entry by entry, which keeps the tooltip lookup in `parse_input()` working.

#### Motivation for adding to Evennia

The dict form is already parsed and supported in `_execute_node`/`parse_input` (including `(key, aliases)` tuples), so it was only the formatter that made it unusable.

#### Other info (issues closed, discussion etc)

Closes #3755. Added `TestEvMenuDictHelptext`, which fails with the reported AttributeError without the fix and passes with it; `evennia.utils.tests.test_evmenu` is green (8 tests).
