### PR TITLE
fix: evict deleted Attributes from the AttributeHandler cache

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -596,7 +596,7 @@ class IAttributeBackend:
         except KeyError:
             attr = None
 
-        if attr and (not hasattr(attr, "pk") and attr.pk is None):
+        if attr and (not hasattr(attr, "pk") or attr.pk is None):
             # clear out Attributes deleted from elsewhere. We must search this anew.
             attr = None
             cachefound = False

--- a/evennia/typeclasses/tests.py
+++ b/evennia/typeclasses/tests.py
@@ -103,6 +103,26 @@ class TestAttributes(BaseEvenniaTest):
         self.assertEqual(attrobj.category, "category4")
         self.assertEqual(attrobj.locks.all(), ["attrread:id(1)"])
 
+    def test_stale_attribute_is_evicted_from_cache(self):
+        """
+        An Attribute deleted from elsewhere (pk set to None) must be dropped
+        from the handler cache, otherwise the next write reuses the pk-less
+        object and Django raises "Cannot force an update in save() with no
+        primary key".
+
+        """
+        key = "staleattr"
+        self.obj1.attributes.add(key, "value1")
+        # make sure the Attribute is in the handler cache
+        cached = self.obj1.attributes.get(key, return_obj=True)
+        # delete it "from elsewhere" - Django sets .pk to None on the instance
+        cached.delete()
+        self.assertIsNone(cached.pk)
+
+        # writing again must re-query rather than reuse the stale cached object
+        self.obj1.attributes.add(key, "value2")
+        self.assertEqual(self.obj1.attributes.get(key), "value2")
+
     def test_value_vs_strvalue(self):
         self.obj1.attributes.add("test", "one")
         self.assertEqual(self.obj1.attributes.get("test"), "one")


### PR DESCRIPTION
Closes #3955

#### Brief overview of PR changes/additions

`AttributeHandler._get_cache_key` guarded stale-Attribute eviction with `not hasattr(attr, "pk") and attr.pk is None`. A cached `attr` is always a Django model instance, so `hasattr(attr, "pk")` is always `True` and the whole condition is a constant `False` — the eviction never ran. Changed the `and` to `or`, plus a regression test.

#### Motivation for adding to Evennia

An Attribute deleted from elsewhere (`pk` set to `None`) stayed in the handler cache, so the next `.add()` reused the pk-less object with `update_fields` set and Django raised `ValueError: Cannot force an update in save() with no primary key.`

#### Other info (issues closed, discussion etc)

Closes #3955. New `TestAttributes.test_stale_attribute_is_evicted_from_cache` fails with that exact `ValueError` on `main` and passes with the fix; `evennia.typeclasses` (36) and `evennia.objects` (52) are green.
