### PR TITLE
fix(typeclasses): evict Attributes deleted from elsewhere from the handler cache

### DIFF
--- a/evennia/typeclasses/attributes.py
+++ b/evennia/typeclasses/attributes.py
@@ -596,7 +596,7 @@ class IAttributeBackend:
         except KeyError:
             attr = None
 
-        if attr and (not hasattr(attr, "pk") and attr.pk is None):
+        if attr and (not hasattr(attr, "pk") or attr.pk is None):
             # clear out Attributes deleted from elsewhere. We must search this anew.
             attr = None
             cachefound = False

--- a/evennia/typeclasses/tests.py
+++ b/evennia/typeclasses/tests.py
@@ -47,6 +47,27 @@ class TestAttributes(BaseEvenniaTest):
         self.assertEqual(self.obj1.db.testattr, value)
         self.assertEqual(self.obj1.attributes.get("testattr"), value)
 
+    def test_attrhandler_evicts_attribute_deleted_from_elsewhere(self):
+        """An Attribute deleted elsewhere must not be served from the cache."""
+        key = "staleattr"
+        self.obj1.attributes.add(key, "value1")
+
+        backend = self.obj1.attributes.backend
+        cachekey = f"{key}-None"
+        attr = backend._cache[cachekey]
+
+        # delete the Attribute row 'from elsewhere'; the cached object survives
+        # with pk set to None.
+        attr.delete()
+        self.assertIsNone(attr.pk)
+
+        # the stale, pk-less object must not be returned ...
+        self.assertIsNone(self.obj1.attributes.get(key))
+        # ... nor reused for the next write (which would raise
+        # "Cannot force an update in save() with no primary key.")
+        self.obj1.attributes.add(key, "value2")
+        self.assertEqual(self.obj1.attributes.get(key), "value2")
+
     @override_settings(TYPECLASS_AGGRESSIVE_CACHE=False)
     @patch("evennia.typeclasses.attributes._TYPECLASS_AGGRESSIVE_CACHE", False)
     def test_attrhandler_nocache(self):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`IAttributeBackend._get_cache_key` guarded stale cache entries with
`not hasattr(attr, "pk") and attr.pk is None`. A cached `Attribute` is always a
Django model instance, so `hasattr(attr, "pk")` is always `True` and the whole
condition is a constant `False` - the eviction its comment describes never ran.
Changed the `and` to `or`.

#### Motivation for adding to Evennia

An `Attribute` deleted from elsewhere stayed in `_cache` with `pk` set to `None`,
and the next `.add()` for that key reused it via
`attr.save(update_fields=["db_value"])`, so Django raised
`ValueError: Cannot force an update in save() with no primary key.`

#### Other info (issues closed, discussion etc)

Closes #3955. Added `test_attrhandler_evicts_attribute_deleted_from_elsewhere`,
which fails with that exact `ValueError` without the one-token fix and passes
with it; `evennia test evennia.typeclasses` is green (36 tests), black and isort
clean on both files.
